### PR TITLE
refactor!: pick cluster distribution via var.distribution + for_each

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -63,13 +63,13 @@ hardcodes `10.244.0.0/16` in its kube-flannel-cfg ConfigMap and ignores
 kubeadm.pod-network-cidr". Neither the default nor the comment reflects
 the active cluster any more:
 
-- **Not wired.** `main.tf:32-41` (Option A, the active minikube block)
-  does not pass `pod_cidr = var.pod_cidr` to `module "k8s"`, and no
+- **Not wired.** Neither `module "k8s_minikube"` nor `module "k8s_k3s"`
+  in `main.tf` passes `pod_cidr = var.pod_cidr` through, and no
   `resource` / `local` / `output` reads it either. `grep -n var.pod_cidr
   *.tf` returns only the declaration line. Whatever the operator sets
   (via `TF_VAR_pod_cidr`, tfvars, or default) never reaches the cluster.
-- **Stale comment.** The cluster module (`terraform-minikube-k8s`
-  v3.1.0+) disables the built-in Flannel addon (`cni = "false"`) and
+- **Stale comment.** The minikube cluster module (`terraform-minikube-k8s`
+  v4.0.0+) disables the built-in Flannel addon (`cni = "false"`) and
   applies its own manifest with `replace(..., "10.244.0.0/16",
   var.pod_cidr)`. The "addon hardcodes 10.244" story is historical.
 - **Actual cluster CIDR.** Comes from the child module's
@@ -83,9 +83,10 @@ the active cluster any more:
   the dead surface is cleaner than maintaining an illusion of control.
 - **B.** Wire it through: change default to `100.72.0.0/16`, rewrite the
   comment to cite the podman-bridge collision (not addon hardcoding),
-  add `pod_cidr = var.pod_cidr` to the `module "k8s"` block in
-  `main.tf`. Preserves an operator-facing override knob.
+  add `pod_cidr = var.pod_cidr` to both `module "k8s_minikube"` and
+  `module "k8s_k3s"` blocks in `main.tf`. Preserves an operator-facing
+  override knob.
 
 Either way, `docs/architecture.md:205-206` also needs a pass — it
 still claims `pod_cidr` is "hardcoded on minikube" and service CIDR is
-`100.64.0.0/12`, both wrong post-v3.1.0.
+`100.64.0.0/12`, both wrong post-v4.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `var.distribution` — enum toggle (`"k3s"` default, `"minikube"`) selects which cluster-bootstrap module runs. Replaces the manual "comment out Option A, uncomment Option B" dance in `main.tf`. `for_each = toset(... ? ["enabled"] : [])` on both sibling modules instantiates exactly one; three flat locals (`local.k8s_kubeconfig_path`, `local.k8s_cluster_name`, `local.k8s_cluster_distribution`) collapse the outputs so downstream code stays distribution-agnostic
+
+### Changed
+- **BREAKING** — `module "k8s"` split into `module "k8s_minikube"` and `module "k8s_k3s"`, each guarded by `for_each` keyed by `"enabled"`. State addresses change: `module.k8s.*` → `module.k8s_k3s["enabled"].*` (k3s, default) or `module.k8s_minikube["enabled"].*` (minikube). Run ONE of the migration loops below in the root directory BEFORE `terraform apply` or the whole cluster gets destroyed and recreated:
+  ```bash
+  # k3s (default)
+  terraform state list | grep '^module\.k8s\.' | while read a; do
+    terraform state mv "$a" "${a//module.k8s./module.k8s_k3s[\"enabled\"].}"
+  done
+
+  # minikube
+  terraform state list | grep '^module\.k8s\.' | while read a; do
+    terraform state mv "$a" "${a//module.k8s./module.k8s_minikube[\"enabled\"].}"
+  done
+  ```
+- `terraform-minikube-k8s` bumped to `v4.0.0` (BREAKING upstream: `var.cni` removed, Flannel manifest owned by the module with `pod_cidr` rendered into `kube-flannel-cfg`, CGNAT defaults `pod_cidr=100.72.0.0/16` / `service_cidr=100.64.0.0/20`). No input changes on this repo's side because the new defaults are fine as-is; override via `TF_VAR_pod_cidr` is no-op here (pod_cidr is not forwarded to the child module — tracked in `BUGS.md #2`)
+
 ## [0.2.0] - 2026-04-19
 
 Shared platform services expand beyond MySQL to cover Postgres, Redis, and Ollama, with a root-owned `platform` namespace and per-namespace ResourceQuota driven from YAML. Component model gains generic `env_random` / `env_static` / `security` patterns; routes are decoupled from components.

--- a/README.md
+++ b/README.md
@@ -85,22 +85,24 @@ terraform-minikube-platform/
 
 Three sibling modules are fetched directly from GitHub at pinned releases — no sibling checkout required:
 
-- Layer 1 (cluster bootstrap, pick ONE):
-  - [`terraform-minikube-k8s`](https://github.com/rromenskyi/terraform-minikube-k8s) — Option A (minikube), pinned to `v3.0.0`
-  - [`terraform-k3s-k8s`](https://github.com/rromenskyi/terraform-k3s-k8s) — Option B (k3s, active default), pinned to `v0.3.1`
+- Layer 1 (cluster bootstrap, `var.distribution` picks ONE):
+  - [`terraform-minikube-k8s`](https://github.com/rromenskyi/terraform-minikube-k8s) — `distribution = "minikube"`, pinned to `v4.0.0`
+  - [`terraform-k3s-k8s`](https://github.com/rromenskyi/terraform-k3s-k8s) — `distribution = "k3s"` (active default), pinned to `v0.3.1`
 - Layer 2 (platform addons): [`terraform-k8s-addons`](https://github.com/rromenskyi/terraform-k8s-addons) — pinned in `main.tf`
 
 `terraform init` downloads the selected modules automatically. To upgrade, bump the `?ref=vX.Y.Z` in `main.tf` and re-run `terraform init -upgrade`.
 
 ### Alternative cluster distribution
 
-The cluster module is swappable. `main.tf` has an **Option A — minikube** (commented out) and **Option B — k3s** (active default) block. Both modules export the same output signature (`cluster_host`, `client_certificate`, `client_key`, `cluster_ca_certificate`, `kubeconfig_path`, `cluster_name`, `cluster_distribution`), so layers 2 and 3 are distribution-agnostic.
+The cluster module is swappable via **`var.distribution`** (`"k3s"` default, `"minikube"` alternative). `main.tf` wires both sibling modules with `for_each = toset(… ? ["enabled"] : [])` so exactly one instantiates at any time; three flat `local.k8s_*` references collapse the outputs so downstream code stays distribution-agnostic.
 
-To switch to k3s (native install via SSH):
-1. In `main.tf`, comment out the Option A block and uncomment Option B.
-2. In `.env`, set `TF_VAR_ssh_user`, `TF_VAR_ssh_host`, `TF_VAR_ssh_private_key_path`.
+To switch to minikube (local docker-driver bootstrap):
+1. In `.env` (or exported env), set `TF_VAR_distribution=minikube`.
+2. Optionally set `TF_VAR_memory` and `TF_VAR_kubernetes_version`; SSH vars are unused in minikube mode.
 3. `terraform init -upgrade`.
-4. `./tf bootstrap-k3s` — the root `kubernetes` / `helm` providers lazily open `module.k8s.kubeconfig_path`, so a single apply is enough.
+4. `./tf bootstrap-minikube` — the root `kubernetes` / `helm` providers lazily open `local.k8s_kubeconfig_path`, so a single apply is enough.
+
+> **Migrating an existing state between distributions (or from pre-v0.3.0 platform revs that used `module "k8s"`)** — the module addresses changed from `module.k8s.*` to `module.k8s_k3s["enabled"].*` / `module.k8s_minikube["enabled"].*`. Run the `terraform state mv` loop in `CHANGELOG.md` → `[Unreleased]` → **BREAKING** note BEFORE `terraform apply`, or the whole cluster gets destroyed and recreated.
 
 ## Prerequisites
 
@@ -153,9 +155,9 @@ cp config/domains/example.com.yaml.example config/domains/mydomain.com.yaml
 ### 4. Bootstrap
 
 ```bash
-./tf bootstrap-k3s         # native k3s over SSH (Option B, default)
+./tf bootstrap-k3s         # native k3s over SSH (var.distribution = "k3s", default)
 # or
-./tf bootstrap-minikube    # minikube (Option A)
+./tf bootstrap-minikube    # minikube (var.distribution = "minikube"; export TF_VAR_distribution=minikube first)
 ```
 
 This destroys any existing state, reinstalls the cluster from zero, purges stale Cloudflare tunnel + DNS, and runs a single `terraform apply` to converge everything.

--- a/_providers.tf
+++ b/_providers.tf
@@ -10,16 +10,16 @@ provider "cloudflare" {
 # `-target` bootstrap that inline host/cert attributes would otherwise force
 # on the k3s distribution.
 provider "kubernetes" {
-  config_path = module.k8s.kubeconfig_path
+  config_path = local.k8s_kubeconfig_path
 }
 
 provider "kubectl" {
-  config_path      = module.k8s.kubeconfig_path
+  config_path      = local.k8s_kubeconfig_path
   load_config_file = true
 }
 
 provider "helm" {
   kubernetes {
-    config_path = module.k8s.kubeconfig_path
+    config_path = local.k8s_kubeconfig_path
   }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,7 @@ config/components/*.yaml      → local.components
 config/limits/*.yaml          → local.namespace_limits (keyed by namespace name)
 
 main.tf
-  → module.k8s                (cluster — Option A minikube or Option B k3s)
+  → module.k8s_k3s["enabled"] OR module.k8s_minikube["enabled"]  (cluster; picked by var.distribution)
   → module.addons             (Traefik + cert-manager + monitoring + namespaces)
   → module.project (for_each) (per tenant)
 
@@ -142,7 +142,7 @@ All three live in the root-owned `platform` namespace (ResourceQuota from `confi
 - Model-pull Job runs `ollama pull <model>` for every entry in `services.ollama.models` after the server is ready. Idempotent — re-applies are free for already-cached models. Name hashes the model list, so a list change rotates the Job.
 - No auth. Tenants address it via `OLLAMA_HOST` / `OLLAMA_BASE_URL` / `OLLAMA_API_BASE` env vars injected through the per-tenant `ollama-endpoint` Secret.
 
-## Bootstrap Flow (k3s, Option B default)
+## Bootstrap Flow (k3s — `var.distribution="k3s"`, the default)
 
 ```
 ./tf bootstrap-k3s
@@ -153,7 +153,7 @@ All three live in the root-owned `platform` namespace (ResourceQuota from `confi
   Step 1:    terraform apply -auto-approve (single phase — providers open kubeconfig_path lazily)
 ```
 
-`./tf bootstrap-minikube` is the same flow against a minikube profile (Option A).
+`./tf bootstrap-minikube` is the same flow against a minikube profile — set `TF_VAR_distribution=minikube` before running.
 
 ## Why IngressRoute Uses kubectl_manifest
 

--- a/main.tf
+++ b/main.tf
@@ -29,55 +29,45 @@
 # -----------------------------------------------------------------------------
 
 # --- Option A: minikube ------------------------------------------------------
-# module "k8s" {
-#   source = "git::https://github.com/rromenskyi/terraform-minikube-k8s.git?ref=v3.0.0"
-#
-#   cluster_name       = var.cluster_name
-#   kubernetes_version = var.kubernetes_version
-#   memory             = var.memory
-#
-#   # Keep Pod and Service ranges in separate CGNAT slices so neither collides
-#   # with the host LAN nor with each other.
-#   pod_cidr     = var.pod_cidr
-#   service_cidr = "100.64.0.0/12"
-#   dns_ip       = "100.64.0.10"
-#   cni          = "flannel"
-# }
+module "k8s" {
+  # Local path, NOT a git ref — we are testing unreleased module changes.
+  # Switch back to `git::https://github.com/rromenskyi/terraform-minikube-k8s.git?ref=vX.Y.Z`
+  # before pushing the platform repo.
+  source = "/home/roman220/minikube/terraform-minikube-k8s"
+
+  cluster_name       = var.cluster_name
+  kubernetes_version = var.kubernetes_version
+  memory             = var.memory
+}
 
 # --- Option B: k3s -----------------------------------------------------------
-module "k8s" {
-  source = "git::https://github.com/rromenskyi/terraform-k3s-k8s.git?ref=v0.3.1"
-
-  cluster_name = var.cluster_name
-
-  # Leave kubernetes_version unset to pull the default k3s channel ("stable"),
-  # or pin a specific build like "v1.31.4+k3s1". The minikube-style "stable"
-  # string is not a valid k3s version.
-  # kubernetes_version = "v1.31.4+k3s1"
-
-  ssh_host             = var.ssh_host
-  ssh_port             = var.ssh_port
-  ssh_user             = var.ssh_user
-  ssh_private_key_path = var.ssh_private_key_path
-}
-
-# Fail fast at plan time if the operator forgot to set ssh_user /
-# ssh_private_key_path when the k3s distribution is active. Module blocks do
-# not accept `lifecycle { precondition }` in current Terraform, so a `check`
-# block is used. When the minikube distribution is active instead, the k3s
-# SSH vars are unused — the check still runs but is harmless informational
-# noise.
-check "k3s_ssh_vars_set" {
-  assert {
-    condition     = var.ssh_user != "" && var.ssh_private_key_path != ""
-    error_message = "ssh_user and ssh_private_key_path are required when the k3s distribution is active (set TF_VAR_ssh_user and TF_VAR_ssh_private_key_path, see .env.example)."
-  }
-
-  assert {
-    condition     = var.ssh_private_key_path == "" || fileexists(var.ssh_private_key_path)
-    error_message = "ssh_private_key_path does not point to a readable file: ${var.ssh_private_key_path}"
-  }
-}
+# module "k8s" {
+#   source = "git::https://github.com/rromenskyi/terraform-k3s-k8s.git?ref=v0.3.1"
+#
+#   cluster_name = var.cluster_name
+#
+#   # Leave kubernetes_version unset to pull the default k3s channel ("stable"),
+#   # or pin a specific build like "v1.31.4+k3s1". The minikube-style "stable"
+#   # string is not a valid k3s version.
+#   # kubernetes_version = "v1.31.4+k3s1"
+#
+#   ssh_host             = var.ssh_host
+#   ssh_port             = var.ssh_port
+#   ssh_user             = var.ssh_user
+#   ssh_private_key_path = var.ssh_private_key_path
+# }
+#
+# check "k3s_ssh_vars_set" {
+#   assert {
+#     condition     = var.ssh_user != "" && var.ssh_private_key_path != ""
+#     error_message = "ssh_user and ssh_private_key_path are required when the k3s distribution is active (set TF_VAR_ssh_user and TF_VAR_ssh_private_key_path, see .env.example)."
+#   }
+#
+#   assert {
+#     condition     = var.ssh_private_key_path == "" || fileexists(var.ssh_private_key_path)
+#     error_message = "ssh_private_key_path does not point to a readable file: ${var.ssh_private_key_path}"
+#   }
+# }
 
 # -----------------------------------------------------------------------------
 # Layer 2: Platform add-ons (Traefik, cert-manager, monitoring, namespaces).

--- a/main.tf
+++ b/main.tf
@@ -25,49 +25,66 @@
 #   module.addons.
 
 # -----------------------------------------------------------------------------
-# Layer 1: Cluster distribution — pick ONE (the other stays commented out).
+# Layer 1: Cluster distribution — selected by var.distribution.
+#
+# Both sibling modules export the same output shape (cluster_host,
+# *_certificate, cluster_ca_certificate, kubeconfig_path, cluster_name,
+# cluster_distribution). The `for_each`-on-empty-set pattern (per AGENT.md
+# §Terraform rules) instantiates exactly one of the two; the `locals` block
+# collapses the pair into flat, distribution-agnostic references downstream
+# code reads via `local.k8s_*`.
 # -----------------------------------------------------------------------------
 
-# --- Option A: minikube ------------------------------------------------------
-module "k8s" {
-  # Local path, NOT a git ref — we are testing unreleased module changes.
-  # Switch back to `git::https://github.com/rromenskyi/terraform-minikube-k8s.git?ref=vX.Y.Z`
-  # before pushing the platform repo.
-  source = "/home/roman220/minikube/terraform-minikube-k8s"
+locals {
+  use_minikube = toset(var.distribution == "minikube" ? ["enabled"] : [])
+  use_k3s      = toset(var.distribution == "k3s" ? ["enabled"] : [])
+}
+
+module "k8s_minikube" {
+  for_each = local.use_minikube
+  source   = "git::https://github.com/rromenskyi/terraform-minikube-k8s.git?ref=v4.0.0"
 
   cluster_name       = var.cluster_name
   kubernetes_version = var.kubernetes_version
   memory             = var.memory
 }
 
-# --- Option B: k3s -----------------------------------------------------------
-# module "k8s" {
-#   source = "git::https://github.com/rromenskyi/terraform-k3s-k8s.git?ref=v0.3.1"
-#
-#   cluster_name = var.cluster_name
-#
-#   # Leave kubernetes_version unset to pull the default k3s channel ("stable"),
-#   # or pin a specific build like "v1.31.4+k3s1". The minikube-style "stable"
-#   # string is not a valid k3s version.
-#   # kubernetes_version = "v1.31.4+k3s1"
-#
-#   ssh_host             = var.ssh_host
-#   ssh_port             = var.ssh_port
-#   ssh_user             = var.ssh_user
-#   ssh_private_key_path = var.ssh_private_key_path
-# }
-#
-# check "k3s_ssh_vars_set" {
-#   assert {
-#     condition     = var.ssh_user != "" && var.ssh_private_key_path != ""
-#     error_message = "ssh_user and ssh_private_key_path are required when the k3s distribution is active (set TF_VAR_ssh_user and TF_VAR_ssh_private_key_path, see .env.example)."
-#   }
-#
-#   assert {
-#     condition     = var.ssh_private_key_path == "" || fileexists(var.ssh_private_key_path)
-#     error_message = "ssh_private_key_path does not point to a readable file: ${var.ssh_private_key_path}"
-#   }
-# }
+module "k8s_k3s" {
+  for_each = local.use_k3s
+  source   = "git::https://github.com/rromenskyi/terraform-k3s-k8s.git?ref=v0.3.1"
+
+  cluster_name = var.cluster_name
+
+  # Leave kubernetes_version unset to pull the default k3s channel ("stable"),
+  # or pin a specific build like "v1.31.4+k3s1". The minikube-style "stable"
+  # string is not a valid k3s version.
+  # kubernetes_version = "v1.31.4+k3s1"
+
+  ssh_host             = var.ssh_host
+  ssh_port             = var.ssh_port
+  ssh_user             = var.ssh_user
+  ssh_private_key_path = var.ssh_private_key_path
+}
+
+locals {
+  k8s_kubeconfig_path      = one(concat([for m in module.k8s_minikube : m.kubeconfig_path], [for m in module.k8s_k3s : m.kubeconfig_path]))
+  k8s_cluster_name         = one(concat([for m in module.k8s_minikube : m.cluster_name], [for m in module.k8s_k3s : m.cluster_name]))
+  k8s_cluster_distribution = one(concat([for m in module.k8s_minikube : m.cluster_distribution], [for m in module.k8s_k3s : m.cluster_distribution]))
+}
+
+# k3s-specific SSH prerequisites. The asserts are vacuously true when
+# distribution != "k3s", so this block is silent in minikube mode.
+check "k3s_ssh_vars_set" {
+  assert {
+    condition     = var.distribution != "k3s" || (var.ssh_user != "" && var.ssh_private_key_path != "")
+    error_message = "distribution = \"k3s\" requires ssh_user and ssh_private_key_path (set TF_VAR_ssh_user / TF_VAR_ssh_private_key_path, see .env.example)."
+  }
+
+  assert {
+    condition     = var.distribution != "k3s" || var.ssh_private_key_path == "" || fileexists(var.ssh_private_key_path)
+    error_message = "ssh_private_key_path does not point to a readable file: ${var.ssh_private_key_path}"
+  }
+}
 
 # -----------------------------------------------------------------------------
 # Layer 2: Platform add-ons (Traefik, cert-manager, monitoring, namespaces).
@@ -75,9 +92,9 @@ module "k8s" {
 module "addons" {
   source = "git::https://github.com/rromenskyi/terraform-k8s-addons.git?ref=v1.1.0"
 
-  kubeconfig_path      = module.k8s.kubeconfig_path
-  cluster_name         = module.k8s.cluster_name
-  cluster_distribution = module.k8s.cluster_distribution
+  kubeconfig_path      = local.k8s_kubeconfig_path
+  cluster_name         = local.k8s_cluster_name
+  cluster_distribution = local.k8s_cluster_distribution
 
   letsencrypt_email = var.letsencrypt_email
 

--- a/variables.tf
+++ b/variables.tf
@@ -16,6 +16,17 @@ variable "kubernetes_version" {
   default     = "v1.34.4"
 }
 
+variable "distribution" {
+  description = "Cluster distribution to bootstrap. `k3s` installs over SSH to `var.ssh_host` (production default). `minikube` runs locally via the docker-driver minikube (dev/experiment)."
+  type        = string
+  default     = "k3s"
+
+  validation {
+    condition     = contains(["minikube", "k3s"], var.distribution)
+    error_message = "distribution must be \"minikube\" or \"k3s\"."
+  }
+}
+
 variable "pod_cidr" {
   # NOTE: minikube's Flannel addon hardcodes "Network": "10.244.0.0/16" in its
   # kube-flannel-cfg ConfigMap and ignores kubeadm.pod-network-cidr. Anything


### PR DESCRIPTION
## Summary

- Replace the "comment out Option A, uncomment Option B" toggle in `main.tf` with a single enum `var.distribution` (default `"k3s"`, alternative `"minikube"`).
- Wire both sibling modules with `for_each = toset(… ? ["enabled"] : [])` so exactly ONE instantiates. Three flat `local.k8s_*` references (`one(concat(…))` over both module outputs) collapse the pair so `_providers.tf` and `module "addons"` stay distribution-agnostic.
- Bump `terraform-minikube-k8s` reference to `v4.0.0` (just tagged — CGNAT CIDR defaults + own Flannel manifest + BREAKING drop of `var.cni`).
- Rewrite README "Alternative cluster distribution" around the variable. Fix stale "Option A/B" labels in `docs/architecture.md` assembly/bootstrap sections.
- Update `BUGS.md #2` (dead `var.pod_cidr`) so the block-reference matches the new two-module layout.

Matches AGENT.md §Terraform rules ("`count = 0` is not a toggle, prefer `for_each` + `one()`").

## BREAKING — run `terraform state mv` before `terraform apply`

Module addresses change: `module.k8s.*` → `module.k8s_k3s["enabled"].*` (default) or `module.k8s_minikube["enabled"].*`. `moved` blocks are intentionally NOT used — operator-driven state migration is the explicit path (there is exactly one environment per distribution).

```bash
# default k3s upgrade
terraform state list | grep '^module\.k8s\.' | while read a; do
  terraform state mv "$a" "${a//module.k8s./module.k8s_k3s[\"enabled\"].}"
done
```

(minikube variant in `CHANGELOG.md` → `[Unreleased]` → BREAKING note)

Skip the mv loop and Terraform will plan destroy+recreate of the entire cluster. Do it first, then `terraform plan` should be a no-op.

## Test plan

- [ ] `terraform fmt -check -recursive` — clean.
- [ ] `terraform init -upgrade` — fetches `terraform-minikube-k8s` v4.0.0 + `terraform-k3s-k8s` v0.3.1 without errors.
- [ ] `terraform validate` — config parses.
- [ ] `terraform plan` under default `TF_VAR_distribution=k3s` (without running the state-mv loop) — shows destroy of `module.k8s.*` + create of `module.k8s_k3s["enabled"].*`. Expected; demonstrates the migration is needed.
- [ ] `terraform plan` under default `TF_VAR_distribution=k3s` AFTER running the state-mv loop — no diff on cluster resources (may show small side-effects from the addons provider re-reading kubeconfig path, which is cosmetic).
- [ ] Ad-hoc: `TF_VAR_distribution=minikube terraform plan` on a clean state shows only the minikube module wiring (no k3s resources planned).

🤖 Generated with [Claude Code](https://claude.com/claude-code)