### PR TITLE
fix: revert broken PR #3 merge, reapply Cloudflare cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
-# Cloudflare
+# Cloudflare — account-scoped values only. Per-domain Zone IDs live in
+# config/domains/*.yaml (field `cloudflare_zone_id`), not here. The tunnel
+# secret is Terraform-generated (see cloudflare.tf → random_password).
 CLOUDFLARE_API_TOKEN=your-cloudflare-api-token
 CLOUDFLARE_ACCOUNT_ID=your-cloudflare-account-id
-CLOUDFLARE_ZONE_ID=your-primary-zone-id
-CLOUDFLARE_TUNNEL_SECRET=any-random-string-min-32-chars
 
 # Let's Encrypt
 LETSENCRYPT_EMAIL=your-email@example.com

--- a/BUGS.md
+++ b/BUGS.md
@@ -63,13 +63,13 @@ hardcodes `10.244.0.0/16` in its kube-flannel-cfg ConfigMap and ignores
 kubeadm.pod-network-cidr". Neither the default nor the comment reflects
 the active cluster any more:
 
-- **Not wired.** Neither `module "k8s_minikube"` nor `module "k8s_k3s"`
-  in `main.tf` passes `pod_cidr = var.pod_cidr` through, and no
+- **Not wired.** `main.tf:32-41` (Option A, the active minikube block)
+  does not pass `pod_cidr = var.pod_cidr` to `module "k8s"`, and no
   `resource` / `local` / `output` reads it either. `grep -n var.pod_cidr
   *.tf` returns only the declaration line. Whatever the operator sets
   (via `TF_VAR_pod_cidr`, tfvars, or default) never reaches the cluster.
-- **Stale comment.** The minikube cluster module (`terraform-minikube-k8s`
-  v4.0.0+) disables the built-in Flannel addon (`cni = "false"`) and
+- **Stale comment.** The cluster module (`terraform-minikube-k8s`
+  v3.1.0+) disables the built-in Flannel addon (`cni = "false"`) and
   applies its own manifest with `replace(..., "10.244.0.0/16",
   var.pod_cidr)`. The "addon hardcodes 10.244" story is historical.
 - **Actual cluster CIDR.** Comes from the child module's
@@ -83,10 +83,9 @@ the active cluster any more:
   the dead surface is cleaner than maintaining an illusion of control.
 - **B.** Wire it through: change default to `100.72.0.0/16`, rewrite the
   comment to cite the podman-bridge collision (not addon hardcoding),
-  add `pod_cidr = var.pod_cidr` to both `module "k8s_minikube"` and
-  `module "k8s_k3s"` blocks in `main.tf`. Preserves an operator-facing
-  override knob.
+  add `pod_cidr = var.pod_cidr` to the `module "k8s"` block in
+  `main.tf`. Preserves an operator-facing override knob.
 
 Either way, `docs/architecture.md:205-206` also needs a pass — it
 still claims `pod_cidr` is "hardcoded on minikube" and service CIDR is
-`100.64.0.0/12`, both wrong post-v4.0.0.
+`100.64.0.0/12`, both wrong post-v3.1.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Cloudflare Tunnel secret is now Terraform-generated via `random_password.cloudflare_tunnel_secret` (48 chars, no special) and fed into `cloudflare_zero_trust_tunnel_cloudflared.main.secret` via `base64encode`. One fewer knob in `.env`. **Migration impact on a running platform:** first `terraform apply` after merge sees the new `random_password` value and plans destroy-and-recreate of the tunnel → brief cloudflared reconnect (10-30 s Cloudflare-side blip while the new JWT propagates to the in-cluster `cloudflared` Deployment). DNS `CNAME` records update in place (target changes to the new tunnel UUID without record recreation)
+
+### Removed
+- `variable "cloudflare_zone_id"` — declared at the root but never read anywhere in `.tf` code. The tunnel resource is account-scoped; per-hostname `CNAME` records pull their zone ID from each domain's `config/domains/*.yaml` (`project_config.cloudflare_zone_id`). Operators running with `CLOUDFLARE_ZONE_ID` / `TF_VAR_cloudflare_zone_id` in `.env` can safely drop the line. Anyone passing it via `-var` or `*.tfvars` must remove the row or Terraform errors with "value for undeclared variable"
+- `variable "cloudflare_tunnel_secret"` — superseded by the Terraform-owned random_password above. Drop `CLOUDFLARE_TUNNEL_SECRET` from `.env` after the first successful apply on the new code
+
+### Docs
+- New `## First-time Cloudflare setup` section in README — step-by-step for a zero-state Cloudflare account: create account, add site, point nameservers, locate Account ID + per-domain Zone IDs, scope a custom API Token with the three exact permissions the stack needs (`Cloudflare Tunnel: Edit`, `DNS: Edit`, `Zone: Read`), verify tunnel health after bootstrap
+- Quick Start step 1 refreshed around the new `.env` layout — `CLOUDFLARE_ZONE_ID` and `CLOUDFLARE_TUNNEL_SECRET` both gone; SSH block uses the correct `TF_VAR_ssh_*` prefix (was missing — the bare `SSH_HOST`-style names the old example showed never reached Terraform)
+- `.env.example`: dropped `CLOUDFLARE_ZONE_ID` and `CLOUDFLARE_TUNNEL_SECRET`; added a comment pointing at `config/domains/*.yaml` for per-domain Zone IDs
+- Variables reference table in README: dropped the two removed variables
+
 ## [0.2.0] - 2026-04-19
 
 Shared platform services expand beyond MySQL to cover Postgres, Redis, and Ollama, with a root-owned `platform` namespace and per-namespace ResourceQuota driven from YAML. Component model gains generic `env_random` / `env_static` / `security` patterns; routes are decoupled from components.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- `var.distribution` — enum toggle (`"k3s"` default, `"minikube"`) selects which cluster-bootstrap module runs. Replaces the manual "comment out Option A, uncomment Option B" dance in `main.tf`. `for_each = toset(... ? ["enabled"] : [])` on both sibling modules instantiates exactly one; three flat locals (`local.k8s_kubeconfig_path`, `local.k8s_cluster_name`, `local.k8s_cluster_distribution`) collapse the outputs so downstream code stays distribution-agnostic
-
-### Changed
-- **BREAKING** — `module "k8s"` split into `module "k8s_minikube"` and `module "k8s_k3s"`, each guarded by `for_each` keyed by `"enabled"`. State addresses change: `module.k8s.*` → `module.k8s_k3s["enabled"].*` (k3s, default) or `module.k8s_minikube["enabled"].*` (minikube). Run ONE of the migration loops below in the root directory BEFORE `terraform apply` or the whole cluster gets destroyed and recreated:
-  ```bash
-  # k3s (default)
-  terraform state list | grep '^module\.k8s\.' | while read a; do
-    terraform state mv "$a" "${a//module.k8s./module.k8s_k3s[\"enabled\"].}"
-  done
-
-  # minikube
-  terraform state list | grep '^module\.k8s\.' | while read a; do
-    terraform state mv "$a" "${a//module.k8s./module.k8s_minikube[\"enabled\"].}"
-  done
-  ```
-- `terraform-minikube-k8s` bumped to `v4.0.0` (BREAKING upstream: `var.cni` removed, Flannel manifest owned by the module with `pod_cidr` rendered into `kube-flannel-cfg`, CGNAT defaults `pod_cidr=100.72.0.0/16` / `service_cidr=100.64.0.0/20`). No input changes on this repo's side because the new defaults are fine as-is; override via `TF_VAR_pod_cidr` is no-op here (pod_cidr is not forwarded to the child module — tracked in `BUGS.md #2`)
-
 ## [0.2.0] - 2026-04-19
 
 Shared platform services expand beyond MySQL to cover Postgres, Redis, and Ollama, with a root-owned `platform` namespace and per-namespace ResourceQuota driven from YAML. Component model gains generic `env_random` / `env_static` / `security` patterns; routes are decoupled from components.

--- a/README.md
+++ b/README.md
@@ -85,24 +85,22 @@ terraform-minikube-platform/
 
 Three sibling modules are fetched directly from GitHub at pinned releases — no sibling checkout required:
 
-- Layer 1 (cluster bootstrap, `var.distribution` picks ONE):
-  - [`terraform-minikube-k8s`](https://github.com/rromenskyi/terraform-minikube-k8s) — `distribution = "minikube"`, pinned to `v4.0.0`
-  - [`terraform-k3s-k8s`](https://github.com/rromenskyi/terraform-k3s-k8s) — `distribution = "k3s"` (active default), pinned to `v0.3.1`
+- Layer 1 (cluster bootstrap, pick ONE):
+  - [`terraform-minikube-k8s`](https://github.com/rromenskyi/terraform-minikube-k8s) — Option A (minikube), pinned to `v3.0.0`
+  - [`terraform-k3s-k8s`](https://github.com/rromenskyi/terraform-k3s-k8s) — Option B (k3s, active default), pinned to `v0.3.1`
 - Layer 2 (platform addons): [`terraform-k8s-addons`](https://github.com/rromenskyi/terraform-k8s-addons) — pinned in `main.tf`
 
 `terraform init` downloads the selected modules automatically. To upgrade, bump the `?ref=vX.Y.Z` in `main.tf` and re-run `terraform init -upgrade`.
 
 ### Alternative cluster distribution
 
-The cluster module is swappable via **`var.distribution`** (`"k3s"` default, `"minikube"` alternative). `main.tf` wires both sibling modules with `for_each = toset(… ? ["enabled"] : [])` so exactly one instantiates at any time; three flat `local.k8s_*` references collapse the outputs so downstream code stays distribution-agnostic.
+The cluster module is swappable. `main.tf` has an **Option A — minikube** (commented out) and **Option B — k3s** (active default) block. Both modules export the same output signature (`cluster_host`, `client_certificate`, `client_key`, `cluster_ca_certificate`, `kubeconfig_path`, `cluster_name`, `cluster_distribution`), so layers 2 and 3 are distribution-agnostic.
 
-To switch to minikube (local docker-driver bootstrap):
-1. In `.env` (or exported env), set `TF_VAR_distribution=minikube`.
-2. Optionally set `TF_VAR_memory` and `TF_VAR_kubernetes_version`; SSH vars are unused in minikube mode.
+To switch to k3s (native install via SSH):
+1. In `main.tf`, comment out the Option A block and uncomment Option B.
+2. In `.env`, set `TF_VAR_ssh_user`, `TF_VAR_ssh_host`, `TF_VAR_ssh_private_key_path`.
 3. `terraform init -upgrade`.
-4. `./tf bootstrap-minikube` — the root `kubernetes` / `helm` providers lazily open `local.k8s_kubeconfig_path`, so a single apply is enough.
-
-> **Migrating an existing state between distributions (or from pre-v0.3.0 platform revs that used `module "k8s"`)** — the module addresses changed from `module.k8s.*` to `module.k8s_k3s["enabled"].*` / `module.k8s_minikube["enabled"].*`. Run the `terraform state mv` loop in `CHANGELOG.md` → `[Unreleased]` → **BREAKING** note BEFORE `terraform apply`, or the whole cluster gets destroyed and recreated.
+4. `./tf bootstrap-k3s` — the root `kubernetes` / `helm` providers lazily open `module.k8s.kubeconfig_path`, so a single apply is enough.
 
 ## Prerequisites
 
@@ -155,9 +153,9 @@ cp config/domains/example.com.yaml.example config/domains/mydomain.com.yaml
 ### 4. Bootstrap
 
 ```bash
-./tf bootstrap-k3s         # native k3s over SSH (var.distribution = "k3s", default)
+./tf bootstrap-k3s         # native k3s over SSH (Option B, default)
 # or
-./tf bootstrap-minikube    # minikube (var.distribution = "minikube"; export TF_VAR_distribution=minikube first)
+./tf bootstrap-minikube    # minikube (Option A)
 ```
 
 This destroys any existing state, reinstalls the cluster from zero, purges stale Cloudflare tunnel + DNS, and runs a single `terraform apply` to converge everything.

--- a/README.md
+++ b/README.md
@@ -108,11 +108,57 @@ To switch to k3s (native install via SSH):
 - **Terraform** >= 1.5.0
 - **kubectl**
 - **jq**
-- **Cloudflare account** with at least one domain
+- **Cloudflare account** with at least one domain (see **First-time Cloudflare setup** below)
+
+## First-time Cloudflare setup
+
+If you have never used Cloudflare before, the three values the stack needs — `CLOUDFLARE_ACCOUNT_ID`, `CLOUDFLARE_API_TOKEN`, and a per-domain `cloudflare_zone_id` in each `config/domains/*.yaml` — are all produced by the steps below. Skip this section if your Cloudflare account is already set up and you know where to find IDs and tokens.
+
+### 1. Create an account and add your domain
+
+1. Sign up at <https://dash.cloudflare.com/sign-up> — the **Free** plan is enough for everything this repo uses (tunnels, DNS, proxying, TLS termination).
+2. In the dashboard: **Add a Site** → enter your apex domain (e.g. `example.com`) → pick **Free** → `Continue`.
+3. Cloudflare scans existing DNS records and offers to import them. Review and keep what you need. Bootstrap will add the per-hostname `CNAME`s the tunnel needs; pre-existing records are left alone.
+4. Cloudflare shows two nameservers (usually `<name>.ns.cloudflare.com`). At your **domain registrar** (where you bought the domain — Namecheap, GoDaddy, Porkbun, etc.), replace the current nameservers with those two.
+5. Wait for propagation — the Overview page turns green (`Active`) anywhere from a few minutes to 24 h after the NS change.
+
+### 2. Locate `CLOUDFLARE_ACCOUNT_ID` and each domain's Zone ID
+
+Open the domain's **Overview** page (`Websites` → click your domain). Scroll to the **right sidebar** → **API** block:
+
+- **Account ID** — shared across every domain in your Cloudflare account. Copy it into `CLOUDFLARE_ACCOUNT_ID` in `.env`.
+- **Zone ID** — unique to *this* domain. Copy it into `cloudflare_zone_id` inside the domain's YAML under `config/domains/` (NOT into `.env` — the stack reads zone IDs per-domain, not globally).
+
+If you host multiple domains, each gets its own `cloudflare_zone_id` in its own YAML; they all share the single `CLOUDFLARE_ACCOUNT_ID`.
+
+### 3. Create `CLOUDFLARE_API_TOKEN`
+
+The stack needs a custom API token — **not** the Global API Key.
+
+1. Click your avatar → **My Profile** → **API Tokens** → **Create Token**.
+2. Pick **Create Custom Token** → `Get started`.
+3. Name: anything memorable — `platform-terraform` works.
+4. **Permissions** — add three rows:
+   - `Account` → `Cloudflare Tunnel` → `Edit` — creates/deletes the tunnel and its cloudflared config.
+   - `Zone` → `DNS` → `Edit` — creates the per-hostname `CNAME` records.
+   - `Zone` → `Zone` → `Read` — lets the provider enumerate zones on plan.
+5. **Account Resources** → `Include` → your specific account.
+6. **Zone Resources** → `Include` → add **every** zone referenced in `config/domains/*.yaml`. (If only one domain: just that one.)
+7. Leave **Client IP Address Filtering** and **TTL** empty unless you know you need them.
+8. `Continue to summary` → `Create Token`.
+9. **Copy the token immediately** — Cloudflare shows it exactly once. Put it in `CLOUDFLARE_API_TOKEN` in `.env`. Losing it means creating a new token and retiring the old one.
+
+### 4. Do NOT pre-create the tunnel
+
+Terraform creates the tunnel itself (name `platform`, see `cloudflare.tf`). The tunnel secret is Terraform-generated too — one less thing you have to produce. If you already created a tunnel with that name by hand — from an earlier experiment, another clone of this repo, or a sibling project — `./tf bootstrap-*` aborts at preflight and tells you to either run `./tf cloudflare-purge` (wipe it) or `terraform import` (adopt it).
+
+After bootstrap finishes, verify the tunnel is live: **Zero Trust** → **Networks** → **Tunnels**. You should see `platform` with status `Healthy` once the `cloudflared` Deployment inside the cluster has rolled out.
 
 ## Quick start
 
 ### 1. Configure secrets
+
+If Cloudflare is new to you, walk through **First-time Cloudflare setup** above first — all of `CLOUDFLARE_*` comes out of those steps.
 
 ```bash
 cp .env.example .env
@@ -121,18 +167,17 @@ cp .env.example .env
 Edit `.env` and fill in:
 
 ```bash
-CLOUDFLARE_API_TOKEN=your-token           # API token (not Global API key)
+# Cloudflare (account-scoped; per-domain Zone IDs live in config/domains/*.yaml)
+CLOUDFLARE_API_TOKEN=your-custom-token            # NOT the Global API Key
 CLOUDFLARE_ACCOUNT_ID=your-account-id
-CLOUDFLARE_ZONE_ID=your-primary-zone-id   # Zone ID of the "infra" domain
-CLOUDFLARE_TUNNEL_SECRET=any-random-32-char-string
-LETSENCRYPT_EMAIL=your-email@example.com
-HOST_VOLUME_PATH=/data/vol                # See Persistent storage below
-CLUSTER_NAME=platform
 
-# Only for k3s distribution:
-SSH_HOST=127.0.0.1
-SSH_USER=your-linux-user
-SSH_PRIVATE_KEY_PATH=/home/you/.ssh/id_ed25519
+LETSENCRYPT_EMAIL=your-email@example.com
+HOST_VOLUME_PATH=/data/vol                        # See "Persistent storage" below
+
+# Only for k3s distribution (TF_VAR_ prefix is required):
+TF_VAR_ssh_host=127.0.0.1
+TF_VAR_ssh_user=your-linux-user
+TF_VAR_ssh_private_key_path=/home/you/.ssh/id_ed25519
 ```
 
 ### 2. Decide which shared services to run
@@ -514,8 +559,6 @@ Deletes the cluster, resets Terraform state, purges Cloudflare tunnel + DNS reco
 | `letsencrypt_email` | *(required)* | Email for Let's Encrypt certificates |
 | `cloudflare_api_token` | *(required)* | Cloudflare API token |
 | `cloudflare_account_id` | *(required)* | Cloudflare Account ID |
-| `cloudflare_tunnel_secret` | *(required)* | Random 32+ char secret for tunnel creation |
-| `cloudflare_zone_id` | *(required)* | Primary zone used by the tunnel |
 | `ssh_host` / `ssh_user` / `ssh_port` / `ssh_private_key_path` | *(required for k3s)* | SSH target for the k3s installer |
 
 ## Known limitations

--- a/_providers.tf
+++ b/_providers.tf
@@ -10,16 +10,16 @@ provider "cloudflare" {
 # `-target` bootstrap that inline host/cert attributes would otherwise force
 # on the k3s distribution.
 provider "kubernetes" {
-  config_path = local.k8s_kubeconfig_path
+  config_path = module.k8s.kubeconfig_path
 }
 
 provider "kubectl" {
-  config_path      = local.k8s_kubeconfig_path
+  config_path      = module.k8s.kubeconfig_path
   load_config_file = true
 }
 
 provider "helm" {
   kubernetes {
-    config_path = local.k8s_kubeconfig_path
+    config_path = module.k8s.kubeconfig_path
   }
 }

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -14,11 +14,24 @@ locals {
 
 # ── Cloudflare Zero Trust Tunnel ─────────────────────────────────────────────
 
+# Terraform-owned tunnel secret. Cloudflare uses this shared key to sign the
+# JWT (`tunnel_token`) that cloudflared pods present to the control plane —
+# cloudflared itself never sees this secret, only the derived token. Generated
+# here instead of taking a `.env` input because `./tf bootstrap-*` is a
+# destroy-and-recreate flow by design, so there is no state-loss recovery
+# story that needs a human-memorised secret. `random_password` (not
+# `random_id`) so the value is already a string that `base64encode` accepts
+# without hex→bytes rewiring.
+resource "random_password" "cloudflare_tunnel_secret" {
+  length  = 48
+  special = false
+}
+
 resource "cloudflare_zero_trust_tunnel_cloudflared" "main" {
   account_id = var.cloudflare_account_id
   name       = "platform"
   config_src = "cloudflare"
-  secret     = base64encode(var.cloudflare_tunnel_secret)
+  secret     = base64encode(random_password.cloudflare_tunnel_secret.result)
 }
 
 # Pre-destroy force-delete for the tunnel above.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -48,7 +48,7 @@ config/components/*.yaml      → local.components
 config/limits/*.yaml          → local.namespace_limits (keyed by namespace name)
 
 main.tf
-  → module.k8s_k3s["enabled"] OR module.k8s_minikube["enabled"]  (cluster; picked by var.distribution)
+  → module.k8s                (cluster — Option A minikube or Option B k3s)
   → module.addons             (Traefik + cert-manager + monitoring + namespaces)
   → module.project (for_each) (per tenant)
 
@@ -142,7 +142,7 @@ All three live in the root-owned `platform` namespace (ResourceQuota from `confi
 - Model-pull Job runs `ollama pull <model>` for every entry in `services.ollama.models` after the server is ready. Idempotent — re-applies are free for already-cached models. Name hashes the model list, so a list change rotates the Job.
 - No auth. Tenants address it via `OLLAMA_HOST` / `OLLAMA_BASE_URL` / `OLLAMA_API_BASE` env vars injected through the per-tenant `ollama-endpoint` Secret.
 
-## Bootstrap Flow (k3s — `var.distribution="k3s"`, the default)
+## Bootstrap Flow (k3s, Option B default)
 
 ```
 ./tf bootstrap-k3s
@@ -153,7 +153,7 @@ All three live in the root-owned `platform` namespace (ResourceQuota from `confi
   Step 1:    terraform apply -auto-approve (single phase — providers open kubeconfig_path lazily)
 ```
 
-`./tf bootstrap-minikube` is the same flow against a minikube profile — set `TF_VAR_distribution=minikube` before running.
+`./tf bootstrap-minikube` is the same flow against a minikube profile (Option A).
 
 ## Why IngressRoute Uses kubectl_manifest
 

--- a/main.tf
+++ b/main.tf
@@ -25,33 +25,28 @@
 #   module.addons.
 
 # -----------------------------------------------------------------------------
-# Layer 1: Cluster distribution — selected by var.distribution.
-#
-# Both sibling modules export the same output shape (cluster_host,
-# *_certificate, cluster_ca_certificate, kubeconfig_path, cluster_name,
-# cluster_distribution). The `for_each`-on-empty-set pattern (per AGENT.md
-# §Terraform rules) instantiates exactly one of the two; the `locals` block
-# collapses the pair into flat, distribution-agnostic references downstream
-# code reads via `local.k8s_*`.
+# Layer 1: Cluster distribution — pick ONE (the other stays commented out).
 # -----------------------------------------------------------------------------
 
-locals {
-  use_minikube = toset(var.distribution == "minikube" ? ["enabled"] : [])
-  use_k3s      = toset(var.distribution == "k3s" ? ["enabled"] : [])
-}
+# --- Option A: minikube ------------------------------------------------------
+# module "k8s" {
+#   source = "git::https://github.com/rromenskyi/terraform-minikube-k8s.git?ref=v3.0.0"
+#
+#   cluster_name       = var.cluster_name
+#   kubernetes_version = var.kubernetes_version
+#   memory             = var.memory
+#
+#   # Keep Pod and Service ranges in separate CGNAT slices so neither collides
+#   # with the host LAN nor with each other.
+#   pod_cidr     = var.pod_cidr
+#   service_cidr = "100.64.0.0/12"
+#   dns_ip       = "100.64.0.10"
+#   cni          = "flannel"
+# }
 
-module "k8s_minikube" {
-  for_each = local.use_minikube
-  source   = "git::https://github.com/rromenskyi/terraform-minikube-k8s.git?ref=v4.0.0"
-
-  cluster_name       = var.cluster_name
-  kubernetes_version = var.kubernetes_version
-  memory             = var.memory
-}
-
-module "k8s_k3s" {
-  for_each = local.use_k3s
-  source   = "git::https://github.com/rromenskyi/terraform-k3s-k8s.git?ref=v0.3.1"
+# --- Option B: k3s -----------------------------------------------------------
+module "k8s" {
+  source = "git::https://github.com/rromenskyi/terraform-k3s-k8s.git?ref=v0.3.1"
 
   cluster_name = var.cluster_name
 
@@ -66,22 +61,20 @@ module "k8s_k3s" {
   ssh_private_key_path = var.ssh_private_key_path
 }
 
-locals {
-  k8s_kubeconfig_path      = one(concat([for m in module.k8s_minikube : m.kubeconfig_path], [for m in module.k8s_k3s : m.kubeconfig_path]))
-  k8s_cluster_name         = one(concat([for m in module.k8s_minikube : m.cluster_name], [for m in module.k8s_k3s : m.cluster_name]))
-  k8s_cluster_distribution = one(concat([for m in module.k8s_minikube : m.cluster_distribution], [for m in module.k8s_k3s : m.cluster_distribution]))
-}
-
-# k3s-specific SSH prerequisites. The asserts are vacuously true when
-# distribution != "k3s", so this block is silent in minikube mode.
+# Fail fast at plan time if the operator forgot to set ssh_user /
+# ssh_private_key_path when the k3s distribution is active. Module blocks do
+# not accept `lifecycle { precondition }` in current Terraform, so a `check`
+# block is used. When the minikube distribution is active instead, the k3s
+# SSH vars are unused — the check still runs but is harmless informational
+# noise.
 check "k3s_ssh_vars_set" {
   assert {
-    condition     = var.distribution != "k3s" || (var.ssh_user != "" && var.ssh_private_key_path != "")
-    error_message = "distribution = \"k3s\" requires ssh_user and ssh_private_key_path (set TF_VAR_ssh_user / TF_VAR_ssh_private_key_path, see .env.example)."
+    condition     = var.ssh_user != "" && var.ssh_private_key_path != ""
+    error_message = "ssh_user and ssh_private_key_path are required when the k3s distribution is active (set TF_VAR_ssh_user and TF_VAR_ssh_private_key_path, see .env.example)."
   }
 
   assert {
-    condition     = var.distribution != "k3s" || var.ssh_private_key_path == "" || fileexists(var.ssh_private_key_path)
+    condition     = var.ssh_private_key_path == "" || fileexists(var.ssh_private_key_path)
     error_message = "ssh_private_key_path does not point to a readable file: ${var.ssh_private_key_path}"
   }
 }
@@ -92,9 +85,9 @@ check "k3s_ssh_vars_set" {
 module "addons" {
   source = "git::https://github.com/rromenskyi/terraform-k8s-addons.git?ref=v1.1.0"
 
-  kubeconfig_path      = local.k8s_kubeconfig_path
-  cluster_name         = local.k8s_cluster_name
-  cluster_distribution = local.k8s_cluster_distribution
+  kubeconfig_path      = module.k8s.kubeconfig_path
+  cluster_name         = module.k8s.cluster_name
+  cluster_distribution = module.k8s.cluster_distribution
 
   letsencrypt_email = var.letsencrypt_email
 

--- a/variables.tf
+++ b/variables.tf
@@ -73,17 +73,6 @@ variable "cloudflare_account_id" {
   type        = string
 }
 
-variable "cloudflare_tunnel_secret" {
-  description = "Arbitrary secret used when creating the Cloudflare Tunnel (base64-encoded by Terraform). Not the same as the JWT token cloudflared uses to connect."
-  type        = string
-  sensitive   = true
-}
-
-variable "cloudflare_zone_id" {
-  description = "Primary Cloudflare Zone ID used for tunnel DNS records"
-  type        = string
-}
-
 variable "namespace_prefix" {
   description = "Prefix prepended to every tenant-project namespace created from `config/domains/*.yaml` (e.g. `phost-` → `phost-example-com-prod`). Groups all project-tenant namespaces together under a common prefix in `kubectl get ns`, separate from the infra namespaces (`cert-manager`, `ingress-controller`, `monitoring`, `ops`, `platform`) that have their own fixed names. Set to `\"\"` to disable prefixing."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -16,17 +16,6 @@ variable "kubernetes_version" {
   default     = "v1.34.4"
 }
 
-variable "distribution" {
-  description = "Cluster distribution to bootstrap. `k3s` installs over SSH to `var.ssh_host` (production default). `minikube` runs locally via the docker-driver minikube (dev/experiment)."
-  type        = string
-  default     = "k3s"
-
-  validation {
-    condition     = contains(["minikube", "k3s"], var.distribution)
-    error_message = "distribution must be \"minikube\" or \"k3s\"."
-  }
-}
-
 variable "pod_cidr" {
   # NOTE: minikube's Flannel addon hardcodes "Network": "10.244.0.0/16" in its
   # kube-flannel-cfg ConfigMap and ignores kubeadm.pod-network-cidr. Anything


### PR DESCRIPTION
## Why

PR #3 was merged while the branch still contained the `var.distribution` + `for_each` cluster-bootstrap refactor. `terraform validate` against the merged main fails with:

```
Error: Module is incompatible with count, for_each, and depends_on

  on main.tf line 44, in module "k8s_minikube":
  44:   for_each = local.use_minikube

The module at module.k8s_minikube is a legacy module which contains its own
local provider configurations...
```

Root cause: the sibling `terraform-minikube-k8s` and `terraform-k3s-k8s` modules declare their own `provider` blocks, which Terraform treats as "legacy modules" — not usable with `for_each` / `count` / `depends_on`. Resolving it requires BREAKING API changes on both sibling modules (remove embedded provider blocks, add `configuration_aliases`), which is out of scope tonight. Dropping the refactor is the right call for now.

The merge also brought in `c70e655 feat: switch active distribution to minikube on this host` as an ancestor — the one we decided earlier to drop entirely in favor of keeping k3s on main.

## What this PR does

1. **Revert commit `556191a`** — undoes the entire PR #3 merge (`20e325e`). Files return to their pre-merge state: single `module "k8s"` block (k3s active), commented Option A (minikube), `var.cloudflare_zone_id` and `var.cloudflare_tunnel_secret` restored, README / .env.example back to the pre-PR-3 layout.

2. **Cherry-pick the useful bits** that were going to land anyway:
   - `5a83a67 refactor!: drop dead var.cloudflare_zone_id, TF-own the tunnel secret` — `var.cloudflare_zone_id` was never read anywhere (per-hostname CNAMEs pull zone IDs from `config/domains/*.yaml`, the tunnel is account-scoped). `var.cloudflare_tunnel_secret` replaced by `random_password.cloudflare_tunnel_secret` (48 chars) fed into `cloudflare_zero_trust_tunnel_cloudflared.main.secret` via `base64encode`.
   - `1cf97d0 docs: first-time Cloudflare walkthrough + Quick Start refresh` — new step-by-step CF setup section in README (account, add site, locate IDs, scoped API token with exact permissions), Quick Start §1 refreshed to the new `.env` layout, fixed the bare `SSH_HOST=…` example that never reached Terraform (missing `TF_VAR_` prefix).

Three commits total on the branch: revert + refactor + docs.

## BREAKING — migration on a running platform

Same as before (no change from earlier plan):

```
# expected plan diff after this merges
+ random_password.cloudflare_tunnel_secret
-/+ cloudflare_zero_trust_tunnel_cloudflared.main     # secret changed → destroy + recreate
~  cloudflare_record.tunnel["…"]                     # content updates in place to new tunnel UUID
```

`terraform apply` → ~10-30 s Cloudflare-side blip while cloudflared rolls with the new JWT. After the apply succeeds, drop `CLOUDFLARE_TUNNEL_SECRET` and `CLOUDFLARE_ZONE_ID` from `.env` (tfvars users must also drop the rows or TF errors with "value for undeclared variable").

## Test plan

- [x] `terraform fmt -recursive` — clean on touched files.
- [x] `terraform init -upgrade` — succeeds (`hashicorp/random` already pinned in `_versions.tf`).
- [x] `terraform validate` — `Success! The configuration is valid.`
- [ ] `terraform plan` on a live state — diff matches the three-line pattern above (+random_password, -/+ tunnel, ~ cloudflare_record).
- [ ] `terraform apply` — tunnel recreates, cloudflared pods roll, hostnames resume within ~30 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)