### PR TITLE
refactor!: drop dead var.pod_cidr + fix stale docs

### DIFF
--- a/BUGS.md
+++ b/BUGS.md
@@ -54,38 +54,3 @@ provisioner "local-exec" {
 
 Verify by running `terraform destroy` with `TF_LOG=INFO` — should see the
 curl's exit status streaming through instead of being suppressed.
-
-## 2. `variable "pod_cidr"` is declared but never read
-
-`variables.tf:19-28` declares `variable "pod_cidr"` with default
-`10.244.0.0/16` and a comment claiming "minikube's Flannel addon
-hardcodes `10.244.0.0/16` in its kube-flannel-cfg ConfigMap and ignores
-kubeadm.pod-network-cidr". Neither the default nor the comment reflects
-the active cluster any more:
-
-- **Not wired.** `main.tf:32-41` (Option A, the active minikube block)
-  does not pass `pod_cidr = var.pod_cidr` to `module "k8s"`, and no
-  `resource` / `local` / `output` reads it either. `grep -n var.pod_cidr
-  *.tf` returns only the declaration line. Whatever the operator sets
-  (via `TF_VAR_pod_cidr`, tfvars, or default) never reaches the cluster.
-- **Stale comment.** The cluster module (`terraform-minikube-k8s`
-  v3.1.0+) disables the built-in Flannel addon (`cni = "false"`) and
-  applies its own manifest with `replace(..., "10.244.0.0/16",
-  var.pod_cidr)`. The "addon hardcodes 10.244" story is historical.
-- **Actual cluster CIDR.** Comes from the child module's
-  `var.pod_cidr` default — currently `100.72.0.0/16` — paired with
-  `service_cidr` default `100.64.0.0/20`. Disjoint, CGNAT, avoids the
-  kicbase podman-bridge collision on `10.244.0.1`.
-
-**Proposed fix — pick one:**
-
-- **A.** Delete the variable. Nothing in this repo consumes it; removing
-  the dead surface is cleaner than maintaining an illusion of control.
-- **B.** Wire it through: change default to `100.72.0.0/16`, rewrite the
-  comment to cite the podman-bridge collision (not addon hardcoding),
-  add `pod_cidr = var.pod_cidr` to the `module "k8s"` block in
-  `main.tf`. Preserves an operator-facing override knob.
-
-Either way, `docs/architecture.md:205-206` also needs a pass — it
-still claims `pod_cidr` is "hardcoded on minikube" and service CIDR is
-`100.64.0.0/12`, both wrong post-v3.1.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,12 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 - `variable "cloudflare_zone_id"` — declared at the root but never read anywhere in `.tf` code. The tunnel resource is account-scoped; per-hostname `CNAME` records pull their zone ID from each domain's `config/domains/*.yaml` (`project_config.cloudflare_zone_id`). Operators running with `CLOUDFLARE_ZONE_ID` / `TF_VAR_cloudflare_zone_id` in `.env` can safely drop the line. Anyone passing it via `-var` or `*.tfvars` must remove the row or Terraform errors with "value for undeclared variable"
 - `variable "cloudflare_tunnel_secret"` — superseded by the Terraform-owned random_password above. Drop `CLOUDFLARE_TUNNEL_SECRET` from `.env` after the first successful apply on the new code
+- `variable "pod_cidr"` — declared at the root with default `10.244.0.0/16` but never read anywhere in `.tf` code and never passed down to `module "k8s"`. The actual Pod CIDR is whatever the active cluster module's own default is (`100.72.0.0/16` on `terraform-minikube-k8s` v4.0.0, `10.42.0.0/16` on k3s). Operators setting `TF_VAR_pod_cidr` in `.env` can drop it — the value never reached the cluster anyway. `-var` / `*.tfvars` users must remove the row. `BUGS.md #2` (which tracked this as known dead code) is also dropped in the same commit
 
 ### Docs
 - New `## First-time Cloudflare setup` section in README — step-by-step for a zero-state Cloudflare account: create account, add site, point nameservers, locate Account ID + per-domain Zone IDs, scope a custom API Token with the three exact permissions the stack needs (`Cloudflare Tunnel: Edit`, `DNS: Edit`, `Zone: Read`), verify tunnel health after bootstrap
 - Quick Start step 1 refreshed around the new `.env` layout — `CLOUDFLARE_ZONE_ID` and `CLOUDFLARE_TUNNEL_SECRET` both gone; SSH block uses the correct `TF_VAR_ssh_*` prefix (was missing — the bare `SSH_HOST`-style names the old example showed never reached Terraform)
 - `.env.example`: dropped `CLOUDFLARE_ZONE_ID` and `CLOUDFLARE_TUNNEL_SECRET`; added a comment pointing at `config/domains/*.yaml` for per-domain Zone IDs
 - Variables reference table in README: dropped the two removed variables
+- `docs/architecture.md` Networking section: rewrote the Pod / Service CIDR claims to reflect actual module defaults on both distributions (`100.72.0.0/16` + `100.64.0.0/20` on minikube, `10.42.0.0/16` + `10.43.0.0/16` on k3s). Old "`pod_cidr` hardcoded on minikube" and "Service CIDR: `100.64.0.0/12`" were both wrong post-`terraform-minikube-k8s` v4.0.0
 
 ## [0.2.0] - 2026-04-19
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -202,8 +202,9 @@ For non-root images (WordPress = UID 33, Redis = UID 999, Open WebUI = UID 1000)
 
 ## Networking
 
-- **CNI**: Flannel (both distributions; `pod_cidr` hardcoded on minikube, configurable on k3s)
-- **Service CIDR**: `100.64.0.0/12` (CGNAT range, avoids LAN collisions)
+- **CNI**: Flannel on both distributions. The cluster module owns the manifest and renders `net-conf.json` from its own `var.pod_cidr` — platform-level override is intentionally not exposed (see CHANGELOG, `var.pod_cidr` removal).
+- **Pod CIDR**: `100.72.0.0/16` on minikube (CGNAT, avoids kicbase podman-bridge collision on `10.244.0.1`), `10.42.0.0/16` on k3s (k3s default).
+- **Service CIDR**: `100.64.0.0/20` on minikube (CGNAT slice), `10.43.0.0/16` on k3s (k3s default).
 - **Traefik**: Helm chart in `ingress-controller` namespace, LoadBalancer Service
 - **Cloudflare Tunnel**: replaces any LoadBalancer IP for external access; the host never needs open ports
 

--- a/variables.tf
+++ b/variables.tf
@@ -16,17 +16,6 @@ variable "kubernetes_version" {
   default     = "v1.34.4"
 }
 
-variable "pod_cidr" {
-  # NOTE: minikube's Flannel addon hardcodes "Network": "10.244.0.0/16" in its
-  # kube-flannel-cfg ConfigMap and ignores kubeadm.pod-network-cidr. Anything
-  # outside 10.244.0.0/16 causes Flannel to crash ("subnet does not contain
-  # node PodCIDR") and leaves all pods stuck in ContainerCreating. The k3s
-  # sibling does not have this limitation.
-  description = "CIDR range to use for Pod IPs inside the Minikube cluster"
-  type        = string
-  default     = "10.244.0.0/16"
-}
-
 # ---------------------------------------------------------------------------
 # SSH connection to the k3s target host (only used when the k3s distribution
 # block is active in main.tf). Defaults cover the local loopback install;


### PR DESCRIPTION
## Why

`variable "pod_cidr"` at the root has been dead code since the start. Declared with default `10.244.0.0/16`, never read anywhere:

```
$ grep -rn 'var\.pod_cidr' *.tf modules/
variables.tf:19:variable "pod_cidr" {
```

`main.tf` never passes it down to `module "k8s"`, and no `resource` / `local` / `output` consumes it either. Whatever the operator set in `TF_VAR_pod_cidr` / tfvars / default sat in the variable table and never reached the cluster.

The actual Pod CIDR the cluster ends up on is whatever the **child module's own** `var.pod_cidr` default is — `100.72.0.0/16` on `terraform-minikube-k8s` v4.0.0 (CGNAT, escapes the kicbase podman-bridge collision), `10.42.0.0/16` on k3s (k3s default). Tracked as `BUGS.md #2` with two resolution paths — picking **A (delete)** because maintaining an override knob that no child module actually exposes is worse than no knob at all.

## BREAKING

- `-var pod_cidr=...` or a `pod_cidr = ...` row in `*.tfvars` — Terraform errors with `value for undeclared variable`. Remove the row.
- `TF_VAR_pod_cidr` in `.env` or shell — silently stops having any effect (TF ignores env vars for undeclared variables). Drop it for cleanliness.
- No runtime impact on a bootstrapped cluster — the variable never reached it anyway.

## Docs swept in the same PR

- `BUGS.md` §2 (the known-bug entry for this variable) removed.
- `docs/architecture.md` Networking section rewritten — old claims "`pod_cidr` hardcoded on minikube" and "Service CIDR: `100.64.0.0/12`" were both wrong post-v4.0.0. Now lists actual module defaults for both distributions (minikube: `100.72.0.0/16` + `100.64.0.0/20`, k3s: `10.42.0.0/16` + `10.43.0.0/16`).
- `CHANGELOG.md` [Unreleased] → Removed entry added; Docs section extended.

## Dependency on PR #4

Based on `fix/revert-pr-3-and-reapply-cf-cleanup` (PR #4). GitHub will auto-retarget the base to `main` once PR #4 merges. Merge order: **PR #4 first, then this one.**

## Test plan

- [x] `terraform fmt -recursive` — clean on touched files (unrelated historical drift in `locals.tf` / `modules/project/main.tf` not touched here).
- [x] `terraform validate` — `Success! The configuration is valid.`
- [ ] `grep -rn 'var\.pod_cidr' *.tf modules/` on merged main — returns zero results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)