### PR TITLE
chore(ollama): raise pull-Job create timeout 15m → 60m

### DIFF
--- a/modules/ollama/main.tf
+++ b/modules/ollama/main.tf
@@ -314,10 +314,13 @@ resource "kubernetes_job_v1" "pull_models" {
   wait_for_completion = true
 
   timeouts {
-    # Model downloads over residential ISP can be slow — `deepseek-r1:1.5b`
-    # is ~1.1Gi, bigger models push this higher. 15 min covers most
-    # first-time pulls; increase if you preload many models.
-    create = "15m"
+    # Model downloads over residential ISP can be slow. A 9–10 GiB model
+    # like `gemma4:e4b` or `qwen2.5:14b` is ~8–10 min alone on a
+    # ~20 MB/s link; a 4–6 model list pushes the total into the tens of
+    # minutes even with layer sharing. The Job itself is idempotent
+    # (`ollama pull` is a no-op on already-cached models), so an ample
+    # terraform-side timeout is cheap — reruns are fast.
+    create = "60m"
   }
 }
 


### PR DESCRIPTION
## Summary

- A single large model (\`gemma4:e4b\`, \`qwen2.5:14b\`) takes ~8–10 min to pull on a ~20 MB/s residential link; a list of 4–6 models pushes total pull time well past the old 15-minute ceiling even with layer sharing. When terraform hits the timeout, the k8s Job keeps running in-cluster (Kubernetes doesn't inherit terraform's deadline), so the download is not lost — but the apply reports an error and the operator has to rerun just to reconcile state.
- The Job is idempotent (\`ollama pull\` is a no-op on cached models), so a 60-minute terraform-side window costs nothing on reruns — the second apply finishes in seconds.

## Test plan

- [ ] On an empty \`models_cache\` PV, add 3+ heavy models to \`services.ollama.models\` in \`config/platform.yaml\` and \`./tf apply\` — completes without timeout error.
- [ ] Rerun \`./tf apply\` immediately after — no diff (the Job's sha1 name is stable across runs with the same models list), the finished Job stays in state.
- [ ] Drop the timeout back to its previous 15m value on a throwaway branch, retest with a big models list, confirm the old behavior reliably reproduces the error. (Sanity check only — not to merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)