### PR TITLE
feat(project): per-project component overrides + chat image-tag fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,13 @@ envs:                                         # Map of env → per-env routing
     routes:
       whoami.dev: whoami                      # whoami.dev.example.com → whoami (env in key, explicit)
 
+    components:                               # (Optional) per-project component overrides
+      web:                                    #   re-use the generic `web` template…
+        replicas: 1                           #   …but with one replica in dev
+        storage:                              #   …and a hostPath PV for static content
+          - mount: /usr/share/nginx/html
+            size: 100Mi
+
 limits:                                       # (Optional) override default resource quota per project
   cpu: "4"
   memory: "8Gi"
@@ -273,6 +280,8 @@ limits:                                       # (Optional) override default reso
 **Hostname generation:** the host prefix from the route map key is used literally. Empty string = apex. No env is injected into the hostname — if two envs of the same domain need distinct URLs, spell out the subdomain in the key (`api.dev: whoami` → `api.dev.example.com`).
 
 **Decoupled routes + components:** a component is deployed iff at least one route targets it. The same component can back multiple hosts (bare + `www`); different hosts can back different components (api → `whoami2`, bare → `whoami`).
+
+**Per-project component overrides (`envs.<env>.components`):** lets a generic component template be reused across projects with per-tenant tweaks — no per-project component yaml needed. Override keys win over the matching keys in `config/components/<name>.yaml` via shallow merge. Lists and nested maps are REPLACED wholesale (terraform `merge()` is shallow); to change one entry of a list you provide the full list.
 
 ### Component configuration (`config/components/*.yaml`)
 

--- a/config/components/chat.yaml
+++ b/config/components/chat.yaml
@@ -119,14 +119,17 @@ env_static:
 # scratchpad that belongs to the chat session.
 sidecars:
   mcp-weather:
-    # Pinned to v1.1.0 — first release where MCP_ROUTER_MODE defaults
-    # to `fat_tools_lean` (PR #59 upstream), shrinking the catalog by
-    # ~79% with no hit-rate regression. We don't override
+    # Pinned to v1.2.0 — adds the `web` domain (search / news /
+    # hackernews / trends, gated by MCP_ENABLED_DOMAINS), bundles
+    # sunrise / sunset / feels_like / UV / precip_prob into every
+    # weather call, and surfaces NWS active alerts on US locations.
+    # Carries the `fat_tools_lean` router default from v1.1.0 (-79%
+    # catalog with no hit-rate regression) — we don't override
     # MCP_ROUTER_MODE in env so the upstream default is what runs.
-    # Bump this tag deliberately (not :latest) — operator visibility on
-    # what version is in front of every tenant chat matters more than
-    # auto-refresh.
-    image: ghcr.io/rromenskyi/mcp-weather-simple:v1.1.0
+    # Bump this tag deliberately (not :latest) — operator visibility
+    # on what version is in front of every tenant chat matters more
+    # than auto-refresh.
+    image: ghcr.io/rromenskyi/mcp-weather-simple:1.2.0
     port:  8000
     env_static:
       MCP_TRANSPORT: streamable-http

--- a/locals.tf
+++ b/locals.tf
@@ -70,6 +70,15 @@ locals {
           cloudflare_zone_id = try(cfg.cloudflare_zone_id, null)
           routes             = try(env_spec.routes, {})
           limits             = try(env_spec.limits, cfg.limits, null)
+          # Optional per-project component overrides. Top-level keys here
+          # win over the matching keys in `config/components/<name>.yaml`
+          # via shallow merge — provide a full replacement value for any
+          # nested structure (lists like `storage:` are replaced wholesale,
+          # not deep-merged). Lets a generic component template (e.g.
+          # `web.yaml` = `nginx:alpine`+port+replicas) be reused across
+          # projects with per-tenant tweaks (storage block, replica count,
+          # resource caps, …) without spawning a per-project component yaml.
+          components         = try(env_spec.components, {})
         }
       ]
     ]) :

--- a/locals.tf
+++ b/locals.tf
@@ -78,7 +78,7 @@ locals {
           # `web.yaml` = `nginx:alpine`+port+replicas) be reused across
           # projects with per-tenant tweaks (storage block, replica count,
           # resource caps, …) without spawning a per-project component yaml.
-          components         = try(env_spec.components, {})
+          components = try(env_spec.components, {})
         }
       ]
     ]) :

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -134,12 +134,22 @@ locals {
   #     Deployment is created; the IngressRoute cross-references the existing
   #     Service by `name`+`namespace`+`port` (or `kind: TraefikService` for
   #     Traefik-internal references like `api@internal`).
+  # Four-step shallow merge:
+  #   1. built-in default `kind`
+  #   2. project-module fallbacks (`local.component_defaults`)
+  #   3. the component yaml itself (`var.components[name]`)
+  #   4. per-project overrides from the domain yaml
+  #      (`project_config.components[name]`) — top-level keys here win
+  #      over the same keys in the component yaml. Lists/nested maps
+  #      are REPLACED wholesale (Terraform merge() is shallow), which
+  #      keeps the override semantics predictable.
   normalized_components = {
     for name in local._component_names :
     name => merge(
       { kind = "deployment" },
       local.component_defaults,
       var.components[name],
+      try(var.project_config.components[name], {}),
     )
   }
 


### PR DESCRIPTION
## Summary
- **fix(chat)**: corrects `mcp-weather-simple` image tag `v1.2.0` → `1.2.0` (the GHCR tag is published without the `v` prefix). Standalone fix; safe to merge on its own if needed.
- **feat(project)**: adds a per-project component-override layer — `envs.<env>.components: { <name>: { ...overrides } }` in any domain yaml. Top-priority shallow merge over the component yaml. Lets generic templates (e.g. `web.yaml`) be reused across tenants without spawning per-project component files.

## Test plan
- [x] `terraform validate` passes locally.
- [x] `terraform apply` deploys the `web` component for `ipsupport.us` with the override-supplied storage block (PV at `/data/vol/phost-ipsupport-us-prod/web/usr-share-nginx-html/`); pod serves the static site successfully (verified via `kubectl exec wget -qO- localhost/`).
- [x] Existing components without overrides (chat, wordpress, whoami, etc.) reconcile with no spec drift.
- [x] Chat rollout completes after the tag fix.