### PR TITLE
feat(ollama): gpu.device_type for single-device projection

### DIFF
--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -41,21 +41,41 @@ services:
     # injected verbatim. The module bakes in nothing vendor- or
     # hardware-specific — every value below must match the actual host.
     #
-    # Worked example: Intel Arc B50 + Vulkan via the upstream Ollama
-    # image. Replace MESA_VK_DEVICE_SELECT with the PCI vendor:device
-    # of YOUR discrete GPU (`lspci -nn | grep -i vga`). For NVIDIA,
-    # device_path = "/dev/nvidia0", supplemental_groups follows the
-    # host nvidia driver's group, and env_*'s shape changes (CUDA-style
-    # variables) — the schema below stays the same.
+    # `device_type` picks the kubelet hostPath type:
+    #   - "Directory"  — project the whole tree (default; right for
+    #                    /dev/dri on a single-GPU host or for NVIDIA's
+    #                    /dev/nvidia tree)
+    #   - "CharDevice" — project a single device file (e.g.
+    #                    /dev/dri/renderD129) and hide the rest. Use
+    #                    when the host has multiple GPUs and you want
+    #                    the pod to see only one — Vulkan/CUDA inside
+    #                    then enumerate exactly one device, no
+    #                    selection-by-env-var gymnastics.
+    #
+    # Worked example A — Intel Arc B50 + Vulkan, single device file:
+    #
+    # gpu:
+    #   image: docker.io/ollama/ollama:0.21.1
+    #   device_path: /dev/dri/renderD129  # Arc render node only
+    #   device_type: CharDevice
+    #   supplemental_groups: [44, 990]    # host video (44) + render (990) GIDs
+    #   env:
+    #     OLLAMA_VULKAN: "1"
+    #     OLLAMA_NUM_GPU: "999"           # offload as many layers as fit
+    #     OLLAMA_FLASH_ATTENTION: "0"     # current Vulkan path mis-handles it
+    #     OLLAMA_DEBUG: "1"
+    #
+    # Worked example B — same Intel/AMD path but project the whole
+    # /dev/dri so the operator can pick a device by env var instead of
+    # at hostPath time:
     #
     # gpu:
     #   image: docker.io/ollama/ollama:0.21.1
     #   device_path: /dev/dri
-    #   supplemental_groups: [44, 990]   # host video (44) + render (990) GIDs
+    #   device_type: Directory             # default; can be omitted
+    #   supplemental_groups: [44, 990]
     #   env:
-    #     OLLAMA_VULKAN: "1"             # upstream backend selector
-    #     OLLAMA_NUM_GPU: "999"          # offload as many layers as fit
-    #     OLLAMA_FLASH_ATTENTION: "0"    # disabled — current Vulkan path mis-handles it
-    #     GGML_VK_VISIBLE_DEVICES: "1"   # ggml-vulkan device index (skip iGPU at 0)
-    #     MESA_VK_DEVICE_SELECT: "8086:e212"  # Mesa device picker — Arc B50 PCI ID here
-    #     OLLAMA_DEBUG: "1"              # verbose logs while the GPU stack stabilises
+    #     OLLAMA_VULKAN: "1"
+    #     OLLAMA_NUM_GPU: "999"
+    #     GGML_VK_VISIBLE_DEVICES: "1"     # pick non-iGPU index
+    #     MESA_VK_DEVICE_SELECT: "8086:e212"  # Mesa device picker (PCI vendor:device)

--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -52,12 +52,23 @@ services:
     #                    then enumerate exactly one device, no
     #                    selection-by-env-var gymnastics.
     #
-    # Worked example A — Intel Arc B50 + Vulkan, single device file:
+    # `privileged` defaults to true (sledgehammer: all caps, all device
+    # cgroups, AppArmor bypass). On modern k3s/containerd + cgroup v2,
+    # a CharDevice volume gets its per-device cgroup allow rule from
+    # kubelet automatically — try `privileged: false` first to lock
+    # the pod down. Side effect: with privileged off, `runc` stops
+    # mknod-ing every host device into the pod's tmpfs /dev, so Mesa
+    # Anv enumerates ONLY the projected device instead of probing
+    # every renderD* node on the host.
+    #
+    # Worked example A — Intel Arc B50 + Vulkan, single device file,
+    # unprivileged:
     #
     # gpu:
     #   image: docker.io/ollama/ollama:0.21.1
     #   device_path: /dev/dri/renderD129  # Arc render node only
     #   device_type: CharDevice
+    #   privileged: false
     #   supplemental_groups: [44, 990]    # host video (44) + render (990) GIDs
     #   env:
     #     OLLAMA_VULKAN: "1"

--- a/modules/ollama/main.tf
+++ b/modules/ollama/main.tf
@@ -111,20 +111,37 @@ variable "gpu" {
     privileged with the supplied supplemental groups, and injects the
     operator-supplied env vars verbatim. The module bakes in nothing
     vendor- or hardware-specific; everything that varies between
-    Intel/AMD/NVIDIA or between PCI device IDs is supplied here:
+    Intel/AMD/NVIDIA or between PCI device IDs is supplied here.
 
+    `device_type` controls the kubelet hostPath volume type — defaults
+    to `Directory`, which projects the entire host directory into the
+    container (right for `/dev/dri` on AMD/Intel, `/dev/nvidia` for
+    multi-card NVIDIA setups). Set to `CharDevice` to project a single
+    device file (e.g. `/dev/dri/renderD129`) — useful when the host
+    has multiple GPUs and you want the container to see only one.
+
+    Worked examples:
+
+      # Project all of /dev/dri (Intel/AMD multi-GPU or single-GPU host):
       gpu = {
         image               = "docker.io/ollama/ollama:0.21.1"
         device_path         = "/dev/dri"
+        device_type         = "Directory"
         supplemental_groups = [44, 990]
         env = {
-          OLLAMA_VULKAN           = "1"
-          OLLAMA_NUM_GPU          = "999"
-          OLLAMA_FLASH_ATTENTION  = "0"
-          GGML_VK_VISIBLE_DEVICES = "1"
-          MESA_VK_DEVICE_SELECT   = "8086:e212"
-          OLLAMA_DEBUG            = "1"
+          OLLAMA_VULKAN = "1"
+          OLLAMA_NUM_GPU = "999"
+          ...
         }
+      }
+
+      # Project only renderD129 (Arc B50) and hide the iGPU entirely:
+      gpu = {
+        image               = "docker.io/ollama/ollama:0.21.1"
+        device_path         = "/dev/dri/renderD129"
+        device_type         = "CharDevice"
+        supplemental_groups = [44, 990]
+        env = { OLLAMA_VULKAN = "1", OLLAMA_NUM_GPU = "999", ... }
       }
 
     Tenant components are unaffected — they keep their own restricted
@@ -133,10 +150,15 @@ variable "gpu" {
   type = object({
     image               = string
     device_path         = string
+    device_type         = optional(string, "Directory")
     supplemental_groups = list(number)
     env                 = map(string)
   })
   default = null
+  validation {
+    condition     = var.gpu == null || contains(["Directory", "CharDevice", "BlockDevice", "File"], var.gpu.device_type)
+    error_message = "ollama gpu.device_type must be one of: Directory, CharDevice, BlockDevice, File. Mirrors kubelet hostPath types."
+  }
 }
 
 locals {
@@ -363,18 +385,20 @@ resource "kubernetes_stateful_set_v1" "ollama" {
           }
         }
 
-        # Host GPU device path (e.g. /dev/dri for Intel/AMD,
-        # /dev/nvidia* for NVIDIA) projected into the pod. Matching
-        # `volume_mount` is on the container above. The pod-level
-        # `supplemental_groups` grant access to whatever GIDs own the
-        # device files at this path on the host.
+        # Host GPU device path projected into the pod. `device_type`
+        # picks the kubelet hostPath type — `Directory` for the whole
+        # /dev/dri (or /dev/nvidia) tree, `CharDevice` to expose only
+        # a single device file (e.g. /dev/dri/renderD129) and hide the
+        # rest. Matching `volume_mount` is on the container above. The
+        # pod-level `supplemental_groups` grant access to whatever GIDs
+        # own the device files on the host.
         dynamic "volume" {
           for_each = local.gpu_iter
           content {
             name = "gpu-device"
             host_path {
               path = volume.value.device_path
-              type = "Directory"
+              type = volume.value.device_type
             }
           }
         }

--- a/modules/ollama/main.tf
+++ b/modules/ollama/main.tf
@@ -151,15 +151,30 @@ variable "gpu" {
     image               = string
     device_path         = string
     device_type         = optional(string, "Directory")
+    privileged          = optional(bool, true)
     supplemental_groups = list(number)
     env                 = map(string)
   })
   default = null
   validation {
-    condition     = var.gpu == null || contains(["Directory", "CharDevice", "BlockDevice", "File"], var.gpu.device_type)
+    # HCL `||` evaluates both operands eagerly; wrap the attribute
+    # access in `try()` so the validator passes through when var.gpu
+    # is null instead of erroring on the missing attribute.
+    condition     = try(contains(["Directory", "CharDevice", "BlockDevice", "File"], var.gpu.device_type), true)
     error_message = "ollama gpu.device_type must be one of: Directory, CharDevice, BlockDevice, File. Mirrors kubelet hostPath types."
   }
 }
+
+# `privileged` defaults to true to preserve the prior shape; this is
+# a sledgehammer that grants every device cgroup, every capability
+# and bypasses AppArmor. With a CharDevice volume on a modern
+# k3s/containerd + cgroup v2 host, kubelet adds the per-device
+# cgroup allow rule by itself, so unprivileged Vulkan inference is
+# usually possible. Operators can opt out via `privileged: false`
+# to lock the platform-namespace Ollama down (and as a side effect
+# make `runc` stop mknod-ing every host device into the pod's
+# tmpfs /dev — Mesa Anv then enumerates ONLY the projected device
+# instead of probing every renderD* node it finds).
 
 locals {
   instances = var.enabled ? toset(["enabled"]) : toset([])
@@ -267,14 +282,17 @@ resource "kubernetes_stateful_set_v1" "ollama" {
           command = var.gpu == null ? null : ["ollama", "serve"]
 
           # Container-level privileged context only emitted when GPU
-          # offload is configured — needed for ioctl access to the
-          # device file under `var.gpu.device_path`. Without GPU the
-          # pod keeps the upstream restricted defaults.
+          # offload is configured. `privileged` is operator-supplied
+          # (default true). `run_as_non_root = false` always — the
+          # upstream Ollama image runs as root regardless of privileged
+          # status, and `read_only_root_filesystem = false` lets it
+          # write its scratch files. Without GPU the pod keeps the
+          # upstream restricted defaults.
           dynamic "security_context" {
             for_each = local.gpu_iter
             content {
-              privileged                 = true
-              allow_privilege_escalation = true
+              privileged                 = security_context.value.privileged
+              allow_privilege_escalation = security_context.value.privileged
               read_only_root_filesystem  = false
               run_as_non_root            = false
             }


### PR DESCRIPTION
## Summary
Optional \`device_type\` field on \`var.gpu\` lets the operator project a single device file into the Ollama pod instead of the whole \`/dev/dri\` (or equivalent) tree. Defaults to \`Directory\` so existing configs keep working unchanged.

## Why
On a host with multiple GPUs (e.g. iGPU + discrete), projecting all of \`/dev/dri\` makes Vulkan/CUDA inside the pod enumerate every device — and selection then has to happen by env var (\`GGML_VK_VISIBLE_DEVICES\`, \`MESA_VK_DEVICE_SELECT\`, \`CUDA_VISIBLE_DEVICES\`). With Mesa Anv on still-young Arc Battlemage that's been fragile (Anv silently ignores Battlemage in the 25.2.x bundled with the upstream Ollama image, so device selection becomes "iGPU regardless of env vars"). Projecting only \`/dev/dri/renderD129\` means there's nothing to select between — the iGPU is invisible to the pod.

## Test plan
- [x] \`terraform fmt -check -recursive\` clean.
- [x] \`terraform validate\` clean.
- [x] Validation block rejects bad device_type values at plan time.
- [ ] Apply against this host with \`device_type: CharDevice\` + \`device_path: /dev/dri/renderD129\` → pod sees only Arc, Vulkan enumerates one device, OLLAMA logs show Arc Pro B50 instead of UHD 630.

## Compat
Default \`device_type = "Directory"\` preserves the prior shape — the previously-merged \`var.gpu\` example in PR #17 keeps working as-is.