### PR TITLE
feat(kind-app): kind: app + auto-provision Zitadel OIDC per component

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,14 @@ LETSENCRYPT_EMAIL=your-email@example.com
 # TF_VAR_ssh_user=your-linux-user
 # TF_VAR_ssh_private_key_path=/home/your-linux-user/.ssh/id_ed25519
 
+# --- Zitadel TF provider (escape hatch only) -------------------------------
+# Normal flow needs nothing here — modules/zitadel auto-bootstraps a
+# `tf-platform` machine user via FIRSTINSTANCE config + a sidecar that
+# extracts the PAT into a k8s Secret the provider reads on the next
+# apply. Set this only if the auto-bootstrap got wedged and you need
+# to inject a manually-generated PAT to unstick the provider.
+# TF_VAR_zitadel_pat=your-zitadel-personal-access-token
+
 # (Optional) Backblaze B2 for remote state
 # AWS_ACCESS_KEY_ID=your-backblaze-key-id
 # AWS_SECRET_ACCESS_KEY=your-backblaze-application-key

--- a/_versions.tf
+++ b/_versions.tf
@@ -22,6 +22,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.0"
     }
+    zitadel = {
+      source  = "zitadel/zitadel"
+      version = "~> 2.9"
+    }
     # minikube and k3s provider requirements are declared by the child modules
     # (`terraform-minikube-k8s` / `terraform-k3s-k8s`). The root stack does not
     # reference either provider directly.

--- a/config/components/sipmesh-frontend.yaml
+++ b/config/components/sipmesh-frontend.yaml
@@ -1,0 +1,64 @@
+# First-party SvelteKit operator console for sipmesh.
+# Source: https://github.com/rromenskyi/sipmesh-frontend
+#
+# Demonstrates the `kind: app` shape — same Deployment/Service
+# machinery as `kind: deployment`, plus auto-provisioning of a
+# Zitadel Project + OIDC Application + Roles via the platform's
+# Zitadel TF provider. The resulting client_id/client_secret/issuer
+# land in a per-component k8s Secret (`sipmesh-frontend-oidc`)
+# wired into the pod as env_from — so the SvelteKit Auth.js Zitadel
+# provider boots with zero in-app config.
+
+kind: app
+
+# Pre-built image — once PR2 (build-from-git) lands, swap this for a
+# `build:` block pointing at the upstream repo + ref.
+image: ghcr.io/rromenskyi/sipmesh-frontend:latest
+port:  3000
+
+# adapter-node serves SSR — single replica is fine while we're
+# small; bump when traffic warrants and/or when session storage
+# moves to Redis (cookie-only sessions don't need sticky routing).
+replicas: 1
+
+resources:
+  requests: { cpu: 100m,  memory: 128Mi }
+  limits:   { cpu: 500m,  memory: 512Mi }
+
+# Auth.js's /auth/* routes answer on every path under /auth/, and the
+# server also wants to know it's healthy without going through the
+# session middleware — `/` returns 200 OK rendered by SvelteKit, which
+# is good enough for a liveness probe.
+health_path: /
+
+oidc:
+  enabled: true
+
+  # Project the Application lives under. Multiple sipmesh components
+  # (frontend, future admin app, mobile) can share `project: sipmesh`
+  # once project sharing lands — for v1 it's one project per app, so
+  # the project ends up named after this component.
+  project: sipmesh
+
+  # Paths Auth.js's @auth/sveltekit handler answers on. The platform
+  # expands these into full URLs against every host this component is
+  # routed at, e.g. `https://app.example.com/auth/callback/zitadel`.
+  redirect_paths:
+    - /auth/callback/zitadel
+  post_logout_paths:
+    - /
+
+  # Project roles created up front. Drop into the user's OIDC token
+  # under `urn:zitadel:iam:org:project:roles` — gate features in the
+  # frontend on `session.user.roles?.includes('platform_admin')`.
+  roles:
+    - { key: platform_admin, display_name: "Platform Admin" }
+    - { key: tenant_admin,   display_name: "Tenant Admin" }
+    - { key: user,           display_name: "User" }
+
+  # `OIDC_APP_TYPE_WEB` + `OIDC_AUTH_METHOD_TYPE_BASIC` = standard
+  # SSR webapp with client_secret. Defaults; left commented for
+  # discoverability.
+  # app_type:    OIDC_APP_TYPE_WEB
+  # auth_method: OIDC_AUTH_METHOD_TYPE_BASIC
+  # dev_mode:    false

--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -112,3 +112,14 @@ services:
     first_admin_email: you@example.com
     # Optional: override the default username `zitadel-admin`.
     # first_admin_username: ops
+
+    # Default Login Policy at FIRSTINSTANCE bootstrap. Defaults are
+    # secure: no public registration; Google/SAML federation on;
+    # username/password login on (needed for the bootstrap admin).
+    # Tweaks here only land on a FRESH instance — change on an
+    # existing one needs a DB drop or the (deferred) TF-managed
+    # `zitadel_default_login_policy` resource.
+    # login_policy:
+    #   allow_register:          false
+    #   allow_external_idp:      true
+    #   allow_username_password: true

--- a/locals.tf
+++ b/locals.tf
@@ -33,6 +33,11 @@ locals {
         external_domain      = ""
         first_admin_email    = ""
         first_admin_username = "zitadel-admin"
+        login_policy = {
+          allow_register          = false
+          allow_external_idp      = true
+          allow_username_password = true
+        }
       }
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -131,4 +131,10 @@ module "project" {
   redis_host                = module.redis.host
   redis_default_secret      = module.redis.default_secret_name
   ollama_url                = module.ollama.url
+
+  # Zitadel — issuer URL is null when `services.zitadel.enabled = false`,
+  # which trips the project-level check on any `kind: app` component
+  # that opted into oidc.
+  zitadel_org_name   = "ZITADEL"
+  zitadel_issuer_url = local.platform.services.zitadel.enabled ? "https://${local.platform.services.zitadel.external_domain}" : null
 }

--- a/modules/component/main.tf
+++ b/modules/component/main.tf
@@ -110,6 +110,12 @@ variable "ollama_secret_name" {
   default     = null
 }
 
+variable "oidc_secret_name" {
+  description = "Name of the oidc-credentials Secret to expose as env_from. Null = no Zitadel client wired (kind: app components without `oidc.enabled: true`, or any non-app component). Injects AUTH_ZITADEL_ISSUER/AUTH_ZITADEL_ID/AUTH_ZITADEL_SECRET/AUTH_SECRET so a stock @auth/sveltekit Zitadel provider boots with zero in-app config."
+  type        = string
+  default     = null
+}
+
 variable "static_env" {
   description = "Additional static env vars (name → literal value) mounted directly on the container. Use when a component needs a plain env knob that isn't a secret and doesn't come from a shared service."
   type        = map(string)
@@ -494,6 +500,18 @@ resource "kubernetes_deployment_v1" "this" {
           # Ollama endpoint (OLLAMA_HOST)
           dynamic "env_from" {
             for_each = var.ollama_secret_name != null ? [var.ollama_secret_name] : []
+            content {
+              secret_ref {
+                name = env_from.value
+              }
+            }
+          }
+
+          # OIDC client credentials (AUTH_ZITADEL_*, AUTH_SECRET) —
+          # populated by modules/zitadel-app for `kind: app` components
+          # whose YAML opted into `oidc.enabled: true`.
+          dynamic "env_from" {
+            for_each = var.oidc_secret_name != null ? [var.oidc_secret_name] : []
             content {
               secret_ref {
                 name = env_from.value

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -12,6 +12,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.0"
     }
+    zitadel = {
+      source  = "zitadel/zitadel"
+      version = "~> 2.9"
+    }
   }
 }
 
@@ -90,6 +94,18 @@ variable "ollama_url" {
   default     = null
 }
 
+variable "zitadel_org_name" {
+  description = "Zitadel org name where `kind: app` components auto-provision projects + applications. Defaults to the bootstrap `ZITADEL` org. Per-org tenancy lands in a follow-up PR."
+  type        = string
+  default     = "ZITADEL"
+}
+
+variable "zitadel_issuer_url" {
+  description = "Zitadel public issuer URL (https://id.<your-domain>) — embedded into AUTH_ZITADEL_ISSUER inside the per-app OIDC Secret. Null disables OIDC provisioning entirely (any kind: app component with `oidc.enabled: true` will fail with a clear error from the check below)."
+  type        = string
+  default     = null
+}
+
 variable "volume_base_path" {
   description = "Parent path used verbatim by hostPath PersistentVolumes for every component in this project. Must resolve to a real writable directory from the kubelet's point of view. Forwarded unchanged to modules/component."
   type        = string
@@ -153,14 +169,30 @@ locals {
     )
   }
 
+  # `kind: deployment` (legacy/general containers) and `kind: app`
+  # (first-party apps with optional Zitadel auto-provisioning) both
+  # produce a Deployment + Service through `module.component`. The
+  # difference is purely whether the project module also stands up
+  # an OIDC client for them — see `app_components_with_oidc` below.
   deployable_components = {
     for name, c in local.normalized_components :
-    name => c if c.kind == "deployment"
+    name => c if c.kind == "deployment" || c.kind == "app"
   }
 
   external_components = {
     for name, c in local.normalized_components :
     name => c if c.kind == "external"
+  }
+
+  # Components that opted into Zitadel auto-provisioning (kind: app +
+  # oidc.enabled: true). One Project + Application + Roles get
+  # provisioned per entry, and the resulting client_id/secret/issuer
+  # land in a per-component k8s Secret that the workload mounts as
+  # env_from.
+  app_components_with_oidc = {
+    for name, c in local.normalized_components :
+    name => c
+    if c.kind == "app" && try(c.oidc.enabled, false)
   }
 
   # Per-component list of fully-qualified hostnames. The host prefix from
@@ -731,6 +763,68 @@ resource "kubernetes_secret_v1" "ollama_endpoint" {
   }
 }
 
+# ── Zitadel auto-provisioning for `kind: app` components ─────────────────────
+#
+# One Project + Application + Roles + k8s Secret per opted-in app.
+# Project name defaults to the component name (v1: one project per
+# app); roles default to `[platform_admin, tenant_admin, user]` so a
+# bare `oidc.enabled: true` already buys a usable role tree. Override
+# both via the component yaml — see config/components/sipmesh-frontend.yaml
+# for the worked shape.
+
+check "zitadel_issuer_set_when_app_oidc_used" {
+  assert {
+    condition     = length(local.app_components_with_oidc) == 0 || var.zitadel_issuer_url != null
+    error_message = "project '${local.namespace}' has at least one `kind: app` component with `oidc.enabled: true` (${join(", ", keys(local.app_components_with_oidc))}) but `services.zitadel.enabled` is false. Either flip Zitadel on in `config/platform.yaml` or remove the oidc block."
+  }
+}
+
+module "zitadel_app" {
+  for_each = local.app_components_with_oidc
+
+  source = "../zitadel-app"
+
+  org_name     = try(each.value.oidc.org, var.zitadel_org_name)
+  project_name = try(each.value.oidc.project, each.key)
+  app_name     = each.key
+
+  issuer_url = var.zitadel_issuer_url
+
+  # Build prod-style redirect URIs from the hostnames Traefik routes
+  # to this component crossed with the operator-supplied paths. Local
+  # `http://localhost:5173/...` URIs are intentionally NOT auto-added
+  # — wire those by hand on a separate dev-mode application in the
+  # Zitadel UI when iterating locally.
+  redirect_uris = flatten([
+    for host in local.routes_by_component[each.key] : [
+      for path in try(each.value.oidc.redirect_paths, ["/auth/callback/zitadel"]) :
+      "https://${host}${path}"
+    ]
+  ])
+
+  post_logout_uris = flatten([
+    for host in local.routes_by_component[each.key] : [
+      for path in try(each.value.oidc.post_logout_paths, ["/"]) :
+      "https://${host}${path}"
+    ]
+  ])
+
+  grant_types    = try(each.value.oidc.grant_types, ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE", "OIDC_GRANT_TYPE_REFRESH_TOKEN"])
+  response_types = try(each.value.oidc.response_types, ["OIDC_RESPONSE_TYPE_CODE"])
+  app_type       = try(each.value.oidc.app_type, "OIDC_APP_TYPE_WEB")
+  auth_method    = try(each.value.oidc.auth_method, "OIDC_AUTH_METHOD_TYPE_BASIC")
+  dev_mode       = try(each.value.oidc.dev_mode, false)
+
+  roles = try(each.value.oidc.roles, [
+    { key = "platform_admin", display_name = "Platform Admin", group = "" },
+    { key = "tenant_admin", display_name = "Tenant Admin", group = "" },
+    { key = "user", display_name = "User", group = "" },
+  ])
+
+  secret_namespace = kubernetes_namespace_v1.this.metadata[0].name
+  secret_name      = "${each.key}-oidc"
+}
+
 # ── Components ────────────────────────────────────────────────────────────────
 
 module "component" {
@@ -765,6 +859,10 @@ module "component" {
 
   ollama_secret_name = try(each.value.ollama, false) && local.needs_ollama ? (
     kubernetes_secret_v1.ollama_endpoint[0].metadata[0].name
+  ) : null
+
+  oidc_secret_name = contains(keys(local.app_components_with_oidc), each.key) ? (
+    module.zitadel_app[each.key].secret_name
   ) : null
 
   static_env = try(each.value.env_static, {})

--- a/modules/zitadel-app/main.tf
+++ b/modules/zitadel-app/main.tf
@@ -1,0 +1,216 @@
+terraform {
+  required_providers {
+    zitadel = {
+      source  = "zitadel/zitadel"
+      version = "~> 2.9"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+# ── Inputs ────────────────────────────────────────────────────────────────────
+
+variable "org_name" {
+  description = "Zitadel org the project + app live under. Defaults to the bootstrap `ZITADEL` org which the platform-zitadel module creates as the master org. Override per app once multi-tenant orgs land."
+  type        = string
+  default     = "ZITADEL"
+}
+
+variable "project_name" {
+  description = "Zitadel Project name. v1 limitation: one project per app (every `kind: app` component gets its own project, named after the app). Sharing a project across apps is a follow-up — would need project creation hoisted out of this per-app module."
+  type        = string
+}
+
+variable "app_name" {
+  description = "Zitadel Application name. Component name is the natural pick."
+  type        = string
+}
+
+variable "issuer_url" {
+  description = "Zitadel public issuer URL (e.g. https://id.example.com). Embedded into the AUTH_ZITADEL_ISSUER env var so client apps don't have to repeat it."
+  type        = string
+}
+
+variable "redirect_uris" {
+  description = "Full URLs Zitadel will allow as auth-code callback destinations. Built upstream from component hostnames + `oidc.redirect_paths` (e.g. `[\"https://app.example.com/auth/callback/zitadel\"]`)."
+  type        = list(string)
+  default     = []
+}
+
+variable "post_logout_uris" {
+  description = "URLs Zitadel will allow as post-logout redirect destinations. Built upstream from component hostnames + `oidc.post_logout_paths`."
+  type        = list(string)
+  default     = []
+}
+
+variable "grant_types" {
+  description = "OIDC grant types. Default = Authorization Code + Refresh Token, the standard combo for SSR web apps."
+  type        = list(string)
+  default     = ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE", "OIDC_GRANT_TYPE_REFRESH_TOKEN"]
+}
+
+variable "response_types" {
+  description = "OIDC response types. Default = Authorization Code flow only."
+  type        = list(string)
+  default     = ["OIDC_RESPONSE_TYPE_CODE"]
+}
+
+variable "app_type" {
+  description = "Zitadel app type — WEB (server-side, has client_secret), USER_AGENT (SPA, PKCE), NATIVE (mobile, PKCE)."
+  type        = string
+  default     = "OIDC_APP_TYPE_WEB"
+}
+
+variable "auth_method" {
+  description = "Client auth method when redeeming auth codes. BASIC = client_id:client_secret in Authorization header. NONE = PKCE only (use for SPA/native)."
+  type        = string
+  default     = "OIDC_AUTH_METHOD_TYPE_BASIC"
+}
+
+variable "dev_mode" {
+  description = "Allow `http://` and `localhost` redirect URIs. Off by default (production-style strict). Flip on while iterating locally."
+  type        = bool
+  default     = false
+}
+
+variable "roles" {
+  description = "Project roles to create — each becomes a Zitadel role grantable to users (platform_admin, tenant_admin, user, etc). The role keys land in the user's OIDC token under `urn:zitadel:iam:org:project:roles` and downstream apps gate features on them."
+  type = list(object({
+    key          = string
+    display_name = string
+    group        = optional(string, "")
+  }))
+  default = []
+}
+
+variable "secret_namespace" {
+  description = "K8s namespace where the Secret holding AUTH_ZITADEL_* + AUTH_SECRET lands."
+  type        = string
+}
+
+variable "secret_name" {
+  description = "Name of the Secret to create."
+  type        = string
+}
+
+# ── Lookups + resources ───────────────────────────────────────────────────────
+
+# Look up the org by name. The bootstrap `ZITADEL` org is created by
+# the platform-zitadel module as part of FIRSTINSTANCE; subsequent
+# tenant orgs would be created out-of-band (UI today, dedicated module
+# in a future PR) and referenced by name here.
+#
+# `zitadel_org` data source requires id (which we don't know up front),
+# so we go through `zitadel_orgs` plural with an EQUALS filter and pull
+# the first match.
+data "zitadel_orgs" "this" {
+  name        = var.org_name
+  name_method = "TEXT_QUERY_METHOD_EQUALS"
+}
+
+locals {
+  org_id = data.zitadel_orgs.this.ids[0]
+}
+
+resource "zitadel_project" "this" {
+  org_id = local.org_id
+  name   = var.project_name
+
+  # Standard production defaults. project_role_assertion = put roles
+  # into the ID token (Auth.js reads from there). project_role_check
+  # off because a role is an authorization signal, not an authn gate
+  # — let the app decide what unroled users can see.
+  project_role_assertion = true
+  project_role_check     = false
+  has_project_check      = false
+}
+
+resource "zitadel_project_role" "roles" {
+  for_each = { for r in var.roles : r.key => r }
+
+  org_id       = local.org_id
+  project_id   = zitadel_project.this.id
+  role_key     = each.value.key
+  display_name = each.value.display_name
+  group        = each.value.group
+}
+
+resource "zitadel_application_oidc" "this" {
+  org_id     = local.org_id
+  project_id = zitadel_project.this.id
+  name       = var.app_name
+
+  redirect_uris             = var.redirect_uris
+  post_logout_redirect_uris = var.post_logout_uris
+  response_types            = var.response_types
+  grant_types               = var.grant_types
+  app_type                  = var.app_type
+  auth_method_type          = var.auth_method
+  dev_mode                  = var.dev_mode
+
+  # ID-token enrichment so Auth.js / similar can decode roles from
+  # the JWT without a follow-up /userinfo call.
+  id_token_role_assertion        = true
+  id_token_userinfo_assertion    = true
+  access_token_role_assertion    = true
+  access_token_type              = "OIDC_TOKEN_TYPE_BEARER"
+  additional_origins             = []
+  clock_skew                     = "0s"
+  version                        = "OIDC_VERSION_1_0"
+  skip_native_app_success_page   = false
+  back_channel_logout_uri        = ""
+}
+
+# Cookie / session encryption key for downstream Auth.js (or similar).
+# Generated once per app, lives in TF state, mounted into the pod via
+# the Secret below. Replace via `terraform taint` if you ever need to
+# rotate (will invalidate every existing user session).
+resource "random_password" "auth_secret" {
+  length  = 64
+  special = false
+}
+
+resource "kubernetes_secret_v1" "oidc" {
+  metadata {
+    name      = var.secret_name
+    namespace = var.secret_namespace
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/component"  = "oidc-credentials"
+    }
+  }
+
+  data = {
+    AUTH_ZITADEL_ISSUER = var.issuer_url
+    AUTH_ZITADEL_ID     = zitadel_application_oidc.this.client_id
+    AUTH_ZITADEL_SECRET = zitadel_application_oidc.this.client_secret
+    AUTH_SECRET         = random_password.auth_secret.result
+  }
+}
+
+# ── Outputs ───────────────────────────────────────────────────────────────────
+
+output "secret_name" {
+  value       = kubernetes_secret_v1.oidc.metadata[0].name
+  description = "Name of the Secret holding AUTH_ZITADEL_ISSUER, AUTH_ZITADEL_ID, AUTH_ZITADEL_SECRET, AUTH_SECRET — feed into the component as `oidc_secret_name`."
+}
+
+output "project_id" {
+  value = zitadel_project.this.id
+}
+
+output "app_id" {
+  value = zitadel_application_oidc.this.id
+}
+
+output "client_id" {
+  value     = zitadel_application_oidc.this.client_id
+  sensitive = true
+}

--- a/modules/zitadel-app/main.tf
+++ b/modules/zitadel-app/main.tf
@@ -157,15 +157,15 @@ resource "zitadel_application_oidc" "this" {
 
   # ID-token enrichment so Auth.js / similar can decode roles from
   # the JWT without a follow-up /userinfo call.
-  id_token_role_assertion        = true
-  id_token_userinfo_assertion    = true
-  access_token_role_assertion    = true
-  access_token_type              = "OIDC_TOKEN_TYPE_BEARER"
-  additional_origins             = []
-  clock_skew                     = "0s"
-  version                        = "OIDC_VERSION_1_0"
-  skip_native_app_success_page   = false
-  back_channel_logout_uri        = ""
+  id_token_role_assertion      = true
+  id_token_userinfo_assertion  = true
+  access_token_role_assertion  = true
+  access_token_type            = "OIDC_TOKEN_TYPE_BEARER"
+  additional_origins           = []
+  clock_skew                   = "0s"
+  version                      = "OIDC_VERSION_1_0"
+  skip_native_app_success_page = false
+  back_channel_logout_uri      = ""
 }
 
 # Cookie / session encryption key for downstream Auth.js (or similar).

--- a/modules/zitadel/main.tf
+++ b/modules/zitadel/main.tf
@@ -57,6 +57,28 @@ variable "first_admin_username" {
   default     = "zitadel-admin"
 }
 
+variable "login_policy" {
+  description = <<-EOT
+    Default Login Policy applied at FIRSTINSTANCE bootstrap. Sets the
+    instance-wide gate for self-service registration, external IDP
+    federation, and username/password login. Secure default: registration
+    OFF (operator decides who joins; nobody self-onboards), Google/SAML
+    federation ON (so wired IDPs work), username/password ON (so the
+    bootstrap admin can log in).
+
+    NOTE: FIRSTINSTANCE config takes effect only on the very first boot
+    against an empty database. Tweaking these values on an existing
+    instance won't propagate without a DB drop OR the (deferred)
+    TF-driven `zitadel_default_login_policy` resource.
+  EOT
+  type = object({
+    allow_register          = optional(bool, false)
+    allow_external_idp      = optional(bool, true)
+    allow_username_password = optional(bool, true)
+  })
+  default = {}
+}
+
 # ── Locals ────────────────────────────────────────────────────────────────────
 
 locals {
@@ -377,6 +399,52 @@ resource "kubernetes_deployment_v1" "zitadel" {
             value = "false"
           }
 
+          # Machine user + Personal Access Token, generated at first
+          # boot and written to PatPath inside the container. The
+          # `pat-broker` sidecar below picks the file up and pushes
+          # the token into a k8s Secret (`zitadel-tf-pat`) so the TF
+          # Zitadel provider can authenticate without an operator
+          # ever touching the UI. Far-future expiry — the PAT is
+          # platform infrastructure, not a user credential.
+          # Default Login Policy — set at FIRSTINSTANCE so a fresh
+          # bootstrap lands secure (no public registration). Tweaks
+          # via these envs against an existing instance don't take —
+          # FIRSTINSTANCE config is consulted exactly once.
+          env {
+            name  = "ZITADEL_FIRSTINSTANCE_LOGINPOLICY_ALLOWREGISTER"
+            value = tostring(var.login_policy.allow_register)
+          }
+          env {
+            name  = "ZITADEL_FIRSTINSTANCE_LOGINPOLICY_ALLOWEXTERNALIDP"
+            value = tostring(var.login_policy.allow_external_idp)
+          }
+          env {
+            name  = "ZITADEL_FIRSTINSTANCE_LOGINPOLICY_ALLOWUSERNAMEPASSWORD"
+            value = tostring(var.login_policy.allow_username_password)
+          }
+
+          env {
+            name  = "ZITADEL_FIRSTINSTANCE_PATPATH"
+            value = "/var/zitadel/secrets/pat"
+          }
+          env {
+            name  = "ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_USERNAME"
+            value = "tf-platform"
+          }
+          env {
+            name  = "ZITADEL_FIRSTINSTANCE_ORG_MACHINE_MACHINE_NAME"
+            value = "tf-platform"
+          }
+          env {
+            name  = "ZITADEL_FIRSTINSTANCE_ORG_MACHINE_PAT_EXPIRATIONDATE"
+            value = "2099-12-31T00:00:00Z"
+          }
+
+          volume_mount {
+            name       = "pat-output"
+            mount_path = "/var/zitadel/secrets"
+          }
+
           # Go binary, idle ~50-100m CPU. 1 CPU limit covers a
           # spike of concurrent OIDC token exchanges without
           # CPU-throttling. Fits the platform-budget ResourceQuota
@@ -419,8 +487,107 @@ resource "kubernetes_deployment_v1" "zitadel" {
             timeout_seconds   = 3
           }
         }
+
+        # PAT broker. Watches the PatPath for the FIRSTINSTANCE-
+        # generated machine-user token, then creates/updates the
+        # `zitadel-tf-pat` Secret so the TF Zitadel provider can pick
+        # it up via `data "kubernetes_resources"` on the next apply.
+        # Uses the dedicated `zitadel-pat-broker` ServiceAccount which
+        # only has Secret create/patch in this namespace.
+        container {
+          name  = "pat-broker"
+          image = "bitnami/kubectl:latest"
+
+          command = ["/bin/bash", "-c"]
+          args = [
+            <<-EOT
+            set -euo pipefail
+            echo "pat-broker: waiting for PAT file..."
+            until [ -s /var/zitadel/secrets/pat ]; do sleep 2; done
+            TOKEN=$(cat /var/zitadel/secrets/pat)
+            echo "pat-broker: PAT captured ($${#TOKEN} chars), syncing Secret..."
+            kubectl create secret generic zitadel-tf-pat \
+              --namespace="${var.namespace}" \
+              --from-literal=access_token="$TOKEN" \
+              --dry-run=client -o yaml \
+              | kubectl apply -f -
+            echo "pat-broker: Secret synced, idling."
+            sleep infinity
+            EOT
+          ]
+
+          resources {
+            requests = { cpu = "10m", memory = "32Mi" }
+            limits   = { cpu = "100m", memory = "64Mi" }
+          }
+
+          volume_mount {
+            name       = "pat-output"
+            mount_path = "/var/zitadel/secrets"
+          }
+        }
+
+        service_account_name = kubernetes_service_account_v1.pat_broker["enabled"].metadata[0].name
+
+        volume {
+          name = "pat-output"
+          empty_dir {}
+        }
       }
     }
+  }
+}
+
+# ── PAT broker RBAC ───────────────────────────────────────────────────────────
+#
+# Minimal scope: the sidecar can only create/patch Secrets in its own
+# namespace. Targeted further to the single Secret name with a
+# resource_names limiter would be cleaner but RBAC's resourceNames
+# blocks `create` (only post-creation verbs honour it), so namespace
+# scope is the floor.
+
+resource "kubernetes_service_account_v1" "pat_broker" {
+  for_each = local.instances
+
+  metadata {
+    name      = "zitadel-pat-broker"
+    namespace = var.namespace
+  }
+}
+
+resource "kubernetes_role_v1" "pat_broker" {
+  for_each = local.instances
+
+  metadata {
+    name      = "zitadel-pat-broker"
+    namespace = var.namespace
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["secrets"]
+    verbs      = ["create", "get", "patch", "update"]
+  }
+}
+
+resource "kubernetes_role_binding_v1" "pat_broker" {
+  for_each = local.instances
+
+  metadata {
+    name      = "zitadel-pat-broker"
+    namespace = var.namespace
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role_v1.pat_broker["enabled"].metadata[0].name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account_v1.pat_broker["enabled"].metadata[0].name
+    namespace = var.namespace
   }
 }
 
@@ -487,3 +654,4 @@ output "admin_password" {
   sensitive   = true
   description = "Bootstrap human admin password. Change in the UI on first login. Only re-emitted if the random_password resource is replaced."
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -73,3 +73,17 @@ variable "host_volume_path" {
   type        = string
   default     = "/data/vol"
 }
+
+variable "zitadel_pat" {
+  description = <<-EOT
+    Personal Access Token for the Zitadel TF provider. One-time
+    bootstrap: log into the Zitadel console, Settings → Service
+    Users → New, name it `tf-platform`, grant role `IAM_OWNER`,
+    generate a PAT, paste here as `TF_VAR_zitadel_pat`. Empty when
+    `services.zitadel.enabled = false` — the provider config in
+    `zitadel.tf` no-ops in that case.
+  EOT
+  type        = string
+  default     = ""
+  sensitive   = true
+}

--- a/zitadel.tf
+++ b/zitadel.tf
@@ -7,6 +7,60 @@
 # the module's bootstrap Job). Public ingress is registered the same
 # way as Grafana / Traefik dashboard: a `kind: external` component
 # in `config/components/zitadel.yaml` routed by a domain entry.
+# Zitadel TF provider — used by `kind: app` components to
+# auto-provision Project + OIDC Application + Roles + a k8s Secret
+# with AUTH_ZITADEL_* envs ready for Auth.js / similar OIDC clients.
+#
+# Bootstrap is fully automated — no operator click anywhere:
+#   1. modules/zitadel sets ZITADEL_FIRSTINSTANCE_ORG_MACHINE_* +
+#      ZITADEL_FIRSTINSTANCE_PATPATH on the Zitadel pod, so on the
+#      very first boot Zitadel creates a `tf-platform` machine user
+#      and writes its Personal Access Token to a file inside an
+#      emptyDir volume.
+#   2. A `pat-broker` sidecar in the same Pod watches the file, then
+#      kubectl-applies a `zitadel-tf-pat` Secret with the token.
+#   3. modules/zitadel exposes the Secret value via the `tf_pat`
+#      output (empty string during the first-apply window when the
+#      sidecar hasn't run yet, real PAT on every apply after that).
+#   4. This provider's `access_token` coalesces module output → the
+#      legacy `var.zitadel_pat` (escape hatch for emergencies) → a
+#      placeholder so provider config stays valid even on a clean
+#      clone before Zitadel has ever booted.
+#
+# On a fresh cluster the very first apply will:
+#   - create Zitadel + sidecar (provider gets PLACEHOLDER token, but
+#     no kind:app components exist yet so no provider call is made)
+#   - sidecar bootstraps the PAT Secret asynchronously
+# Re-apply after that picks up the real PAT and provisions any
+# kind:app components that show up in YAML.
+# PAT lookup at root scope — NOT inside modules/zitadel — so the data
+# source has no depends_on chain to the Deployment and resolves at
+# refresh time independent of the module's apply state. Empty `objects`
+# list on first apply (Secret doesn't exist yet); populated thereafter.
+# Going through the root keeps `provider "zitadel"` from picking up an
+# `(known after apply)` value, which Terraform refuses to validate at
+# plan time.
+data "kubernetes_resources" "zitadel_tf_pat" {
+  api_version    = "v1"
+  kind           = "Secret"
+  namespace      = kubernetes_namespace_v1.platform.metadata[0].name
+  field_selector = "metadata.name=zitadel-tf-pat"
+}
+
+locals {
+  zitadel_tf_pat = try(
+    base64decode(data.kubernetes_resources.zitadel_tf_pat.objects[0].data.access_token),
+    ""
+  )
+}
+
+provider "zitadel" {
+  domain       = local.platform.services.zitadel.external_domain
+  insecure     = "false"
+  port         = "443"
+  access_token = coalesce(local.zitadel_tf_pat, var.zitadel_pat, "PLACEHOLDER_BOOTSTRAP")
+}
+
 module "zitadel" {
   source     = "./modules/zitadel"
   depends_on = [module.addons, module.postgres]
@@ -18,4 +72,5 @@ module "zitadel" {
   external_domain           = local.platform.services.zitadel.external_domain
   first_admin_email         = local.platform.services.zitadel.first_admin_email
   first_admin_username      = local.platform.services.zitadel.first_admin_username
+  login_policy              = local.platform.services.zitadel.login_policy
 }


### PR DESCRIPTION
## Summary

Adds `kind: app` to the platform — a component flavour that, on top of the existing `kind: deployment` workload, auto-provisions a Zitadel **Project + OIDC Application + Roles** and a k8s Secret (`AUTH_ZITADEL_*` + `AUTH_SECRET`) wired into the pod via env_from. Zero clicks in the Zitadel UI to deploy a new app.

## What ships

- **`modules/zitadel-app/`** — new module: project + OIDC application + project_role per declared role + random AUTH_SECRET + k8s Secret with the four envs Auth.js (or any OIDC client) expects
- **`modules/component`** — new `oidc_secret_name` env_from input (mirrors postgres/redis/ollama pattern)
- **`modules/project`** — `deployable_components` filter widened to include `kind: app`; new `app_components_with_oidc` filter; `module.zitadel_app` for_each per opted-in app; secret name piped to `module.component`
- **`modules/zitadel`** — FIRSTINSTANCE machine-user + PAT bootstrap, emptyDir + `pat-broker` sidecar that lifts the token into a `zitadel-tf-pat` Secret, RBAC for the sidecar
- **`zitadel.tf`** — `data "kubernetes_resources"` lookup of the PAT Secret + `provider "zitadel"` config feeding `coalesce(local.zitadel_tf_pat, var.zitadel_pat, "PLACEHOLDER_BOOTSTRAP")`
- **Schema additions** — `services.zitadel.login_policy.{allow_register,allow_external_idp,allow_username_password}` (secure defaults: registration off, IDP on, username/password on); `oidc:` sub-block on a component spec
- **Sample** — `config/components/sipmesh-frontend.yaml` showing the full kind:app + oidc shape

## Bootstrap automation

| Old | New |
|---|---|
| Operator opens Zitadel UI, creates service user, generates PAT, pastes into `.env` | Zitadel creates `tf-platform` machine user + PAT at FIRSTINSTANCE, sidecar puts it in a Secret, TF reads it on next refresh |

Fresh-cluster ergonomics: first apply stands up Zitadel + sidecar (provider sees placeholder, no kind:app components active so no provider call); sidecar populates Secret; second apply uses the real PAT.

`TF_VAR_zitadel_pat` stays in `.env.example` as an escape hatch for stuck-bootstrap recovery only.

## Caveats

- **One project per app** in v1 — `oidc.project: <name>` defaults to component name. Sharing a project across multiple apps is a follow-up (would need project creation hoisted out of the per-app module).
- **FIRSTINSTANCE config is one-shot**. Tweaking `login_policy.*` on a live instance via these envs won't propagate; requires a DB drop OR the (deferred) TF-managed `zitadel_default_login_policy` resource. New deployments get the new defaults automatically.
- **Localhost dev URIs intentionally NOT auto-added** to redirect URIs — `npm run dev` against `localhost:5173` should use a separate dev-mode application provisioned by hand in the Zitadel UI.

## Test plan

- [x] `./tf init` pulls Zitadel TF provider 2.9
- [x] `./tf plan` is clean (3 to add: SA + Role + RoleBinding for sidecar; 1 to change: Zitadel deployment with new envs + sidecar)
- [ ] `./tf apply` succeeds; sidecar reaches the `idling` log line; `zitadel-tf-pat` Secret exists in `platform` namespace
- [ ] Add a route to `config/domains/<domain>.yaml` pointing at sipmesh-frontend, build+push the actual image, re-apply: Zitadel project + app + roles + secret materialise; pod boots with AUTH_ZITADEL_* envs visible

## Follow-ups (deferred)

- Build-from-git pipeline — already filed as #20
- TF-managed `zitadel_default_login_policy` (so login_policy survives a Zitadel restart on existing instances)
- Project sharing across apps (multiple kind:app components → same Project)
- Per-org provisioning (today everything lands in the bootstrap `ZITADEL` org)

🤖 Generated with [Claude Code](https://claude.com/claude-code)