### PR TITLE
refactor(zitadel): operator-supplied PAT via .env, expose via output

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,12 +38,21 @@ LETSENCRYPT_EMAIL=your-email@example.com
 # TF_VAR_ssh_user=your-linux-user
 # TF_VAR_ssh_private_key_path=/home/your-linux-user/.ssh/id_ed25519
 
-# --- Zitadel TF provider (escape hatch only) -------------------------------
-# Normal flow needs nothing here — modules/zitadel auto-bootstraps a
-# `tf-platform` machine user via FIRSTINSTANCE config + a sidecar that
-# extracts the PAT into a k8s Secret the provider reads on the next
-# apply. Set this only if the auto-bootstrap got wedged and you need
-# to inject a manually-generated PAT to unstick the provider.
+# --- Zitadel TF provider (one-time bootstrap, then it just works) ----------
+# Required ONLY when at least one `kind: app` component declares
+# `oidc.enabled: true` (so the Zitadel TF provider needs to provision
+# Project + Application + Roles). Pure-Zitadel deploys without any
+# kind:app components don't need this.
+#
+# Bootstrap once after the first `./tf apply` brings Zitadel up:
+#
+#   kubectl get secret zitadel-tf-pat -n platform \
+#     -o jsonpath='{.data.access_token}' | base64 -d
+#
+# Paste the printed token here. The PAT belongs to a `tf-platform`
+# machine user that FIRSTINSTANCE config seeds with IAM_OWNER and a
+# 100-year expiry — refresh only if you re-bootstrap (the new PAT
+# replaces the Secret, run the kubectl-get again).
 # TF_VAR_zitadel_pat=your-zitadel-personal-access-token
 
 # (Optional) Backblaze B2 for remote state

--- a/main.tf
+++ b/main.tf
@@ -135,6 +135,7 @@ module "project" {
   # Zitadel — issuer URL is null when `services.zitadel.enabled = false`,
   # which trips the project-level check on any `kind: app` component
   # that opted into oidc.
-  zitadel_org_name   = "ZITADEL"
-  zitadel_issuer_url = local.platform.services.zitadel.enabled ? "https://${local.platform.services.zitadel.external_domain}" : null
+  zitadel_org_name               = "ZITADEL"
+  zitadel_issuer_url             = local.platform.services.zitadel.enabled ? "https://${local.platform.services.zitadel.external_domain}" : null
+  zitadel_provider_authenticated = var.zitadel_pat != ""
 }

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -164,7 +164,7 @@ locals {
     name => merge(
       { kind = "deployment" },
       local.component_defaults,
-      var.components[name],
+      try(var.components[name], {}),
       try(var.project_config.components[name], {}),
     )
   }
@@ -319,12 +319,16 @@ locals {
 }
 
 # Catch typos / missing component definitions at plan time.
+# A routed component is "known" if it has either a generic template
+# at `config/components/<name>.yaml` OR an inline definition in this
+# project's `envs.<env>.components.<name>` block.
 check "routes_reference_known_components" {
   assert {
     condition = alltrue([
-      for name in local._component_names : contains(keys(var.components), name)
+      for name in local._component_names :
+      contains(keys(var.components), name) || contains(keys(try(var.project_config.components, {})), name)
     ])
-    error_message = "project '${local.namespace}' has a route to an unknown component. Referenced components: ${jsonencode(local._component_names)}. Available components: ${jsonencode(keys(var.components))}. Add the missing config/components/<name>.yaml or fix the route target."
+    error_message = "project '${local.namespace}' has a route to an unknown component. Referenced components: ${jsonencode(local._component_names)}. Available templates: ${jsonencode(keys(var.components))}. Inline overrides: ${jsonencode(keys(try(var.project_config.components, {})))}. Add `config/components/<name>.yaml` OR an inline `envs.<env>.components.<name>` block in the domain yaml."
   }
 }
 

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -106,6 +106,12 @@ variable "zitadel_issuer_url" {
   default     = null
 }
 
+variable "zitadel_provider_authenticated" {
+  description = "True when the root TF has been handed a non-empty `TF_VAR_zitadel_pat` for the Zitadel provider. False trips the precondition on any active `kind: app` + `oidc.enabled: true` component, with a pointer at the operator-side bootstrap docs."
+  type        = bool
+  default     = false
+}
+
 variable "volume_base_path" {
   description = "Parent path used verbatim by hostPath PersistentVolumes for every component in this project. Must resolve to a real writable directory from the kubelet's point of view. Forwarded unchanged to modules/component."
   type        = string
@@ -785,6 +791,13 @@ check "zitadel_issuer_set_when_app_oidc_used" {
   assert {
     condition     = length(local.app_components_with_oidc) == 0 || var.zitadel_issuer_url != null
     error_message = "project '${local.namespace}' has at least one `kind: app` component with `oidc.enabled: true` (${join(", ", keys(local.app_components_with_oidc))}) but `services.zitadel.enabled` is false. Either flip Zitadel on in `config/platform.yaml` or remove the oidc block."
+  }
+}
+
+check "zitadel_pat_set_when_app_oidc_used" {
+  assert {
+    condition     = length(local.app_components_with_oidc) == 0 || var.zitadel_provider_authenticated
+    error_message = "project '${local.namespace}' has `kind: app` components with `oidc.enabled: true` (${join(", ", keys(local.app_components_with_oidc))}) but `TF_VAR_zitadel_pat` is empty. Bootstrap the PAT once: `kubectl get secret zitadel-tf-pat -n platform -o jsonpath='{.data.access_token}' | base64 -d`, then paste it into `.env` as `TF_VAR_zitadel_pat=...`. See operating.md → 'Zitadel PAT bootstrap'."
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -104,6 +104,18 @@ output "zitadel" {
   sensitive = true
 }
 
+output "zitadel_pat" {
+  description = "PAT for the Zitadel TF provider (machine user `tf-platform`, IAM_OWNER, far-future expiry). Lifted from the in-cluster `zitadel-tf-pat` Secret that the FIRSTINSTANCE-bootstrapped pat-broker sidecar populates. Empty when Zitadel is disabled OR the sidecar hasn't run yet (pre-bootstrap clean clone); populated after the first `./tf apply` brings Zitadel up. Fetch with `terraform output -raw zitadel_pat`, then paste into `.env` as `TF_VAR_zitadel_pat=...` so subsequent applies provision kind:app components."
+  sensitive   = true
+  value = try(
+    base64decode([
+      for o in data.kubernetes_resources.zitadel_tf_pat_output["enabled"].objects :
+      o if o.metadata.name == "zitadel-tf-pat"
+    ][0].data.access_token),
+    ""
+  )
+}
+
 output "namespaces" {
   description = "All project namespaces managed by this platform."
   value       = [for _, proj in module.project : proj.namespace]

--- a/zitadel.tf
+++ b/zitadel.tf
@@ -33,33 +33,21 @@
 #   - sidecar bootstraps the PAT Secret asynchronously
 # Re-apply after that picks up the real PAT and provisions any
 # kind:app components that show up in YAML.
-# PAT lookup at root scope — NOT inside modules/zitadel — so the data
-# source has no depends_on chain to the Deployment and resolves at
-# refresh time independent of the module's apply state. Empty `objects`
-# list on first apply (Secret doesn't exist yet); populated thereafter.
-# Going through the root keeps `provider "zitadel"` from picking up an
-# `(known after apply)` value, which Terraform refuses to validate at
-# plan time.
-data "kubernetes_resources" "zitadel_tf_pat" {
+# Read-only lookup of the FIRSTINSTANCE-bootstrapped PAT for the
+# `zitadel_pat` output below. `kubernetes_resources` returns an empty
+# `objects` list when the Secret doesn't exist yet (clean clone, pre-
+# bootstrap), so the output degrades to "" instead of failing the
+# whole plan. Refreshes on every plan/apply, so a freshly-populated
+# Secret shows up on the next run.
+# `count` gates the lookup on `services.zitadel.enabled` — when
+# Zitadel is fully disabled the data source isn't fetched at all and
+# the output collapses to "".
+data "kubernetes_resources" "zitadel_tf_pat_output" {
+  for_each = local.platform.services.zitadel.enabled ? toset(["enabled"]) : toset([])
+
   api_version = "v1"
   kind        = "Secret"
   namespace   = kubernetes_namespace_v1.platform.metadata[0].name
-  # field_selector "metadata.name=..." is silently ignored by the
-  # Terraform kubernetes provider's resources data source — it does
-  # not propagate the selector to the API list call. Filter in HCL
-  # instead from the full namespace listing.
-  label_selector = ""
-}
-
-locals {
-  zitadel_tf_pat_secrets = [
-    for o in data.kubernetes_resources.zitadel_tf_pat.objects :
-    o if o.metadata.name == "zitadel-tf-pat"
-  ]
-  zitadel_tf_pat = try(
-    base64decode(local.zitadel_tf_pat_secrets[0].data.access_token),
-    ""
-  )
 }
 
 # Provider transport is operator-configurable via
@@ -96,15 +84,22 @@ locals {
 }
 
 provider "zitadel" {
-  domain       = local.zitadel_provider_host
-  insecure     = tostring(local.platform.services.zitadel.provider.insecure)
-  port         = tostring(local.platform.services.zitadel.provider.port)
-  access_token = coalesce(local.zitadel_tf_pat, var.zitadel_pat, "PLACEHOLDER_BOOTSTRAP")
+  domain   = local.zitadel_provider_host
+  insecure = tostring(local.platform.services.zitadel.provider.insecure)
+  port     = tostring(local.platform.services.zitadel.provider.port)
+  # PAT lives in the operator's `.env` as `TF_VAR_zitadel_pat` (one-
+  # time setup — see operating.md → "Zitadel PAT bootstrap"). Empty
+  # placeholder satisfies provider validation on a clean clone where
+  # Zitadel hasn't been bootstrapped yet; the precondition below
+  # catches the real misuse case (kind:app components active without
+  # a PAT in `.env`).
+  access_token = var.zitadel_pat != "" ? var.zitadel_pat : "PLACEHOLDER_BOOTSTRAP"
 
   transport_headers = {
     Host = local.platform.services.zitadel.external_domain
   }
 }
+
 
 module "zitadel" {
   source     = "./modules/zitadel"


### PR DESCRIPTION
## Summary

The previous design tried to lift the FIRSTINSTANCE-bootstrapped PAT into the provider config automatically — a `kubernetes_resources` data source + `coalesce(...)` chain. Two problems in practice:

1. **Plan-time read of a Secret that may not exist yet** (chicken-and-egg on the very first apply, before Zitadel is bootstrapped).
2. **Refresh-time staleness** — the data source observed an empty `objects` list even when the Secret was live, so the provider fell back to `PLACEHOLDER_BOOTSTRAP` and every gRPC call returned 401.

Replace with a one-time operator copy step. Net effect: simpler TF, fewer moving parts, no chicken-and-egg.

## Operator workflow (one-time)

After the first `./tf apply` brings Zitadel up:

```sh
terraform output -raw zitadel_pat
# OR equivalently:
kubectl get secret zitadel-tf-pat -n platform -o jsonpath='{.data.access_token}' | base64 -d
```

Paste the result into `.env` as `TF_VAR_zitadel_pat=...`. Subsequent applies provision `kind: app` components.

The PAT belongs to a `tf-platform` machine user that FIRSTINSTANCE seeds with `IAM_OWNER` and a 100-year expiry. Refresh only on a Zitadel re-bootstrap (the sidecar repopulates the Secret, run the lookup again).

## Changes

- **`provider "zitadel"`** reads `var.zitadel_pat` directly with a `PLACEHOLDER_BOOTSTRAP` fallback so provider config validates on a clean clone with Zitadel disabled.
- **`output "zitadel_pat"`** lifts the live PAT from the `zitadel-tf-pat` Secret via a `for_each`-gated `kubernetes_resources` data source. Empty when Zitadel is disabled or the sidecar hasn't populated the Secret yet; populated otherwise.
- **`check "zitadel_pat_set_when_app_oidc_used"`** in `modules/project` fires loud at plan time when any `kind: app` + `oidc.enabled: true` component is present without a non-empty `var.zitadel_pat`. Error message points at the bootstrap flow.
- **`.env.example`** documents the workflow inline.
- Folds in the missed-merge fix from PR #23: `try(var.components[name], {})` so inline-only `kind: app` components in the domain yaml don't trip the schema check.

## Test plan

- [x] `./tf plan` clean (only adds the new `zitadel_pat` output to state)
- [x] `terraform output -raw zitadel_pat` returns the live PAT (sensitive output)
- [x] Plan errors with the bootstrap pointer when `TF_VAR_zitadel_pat` is unset AND a kind:app component is active
- [x] `services.zitadel.enabled = false` → output is empty string, no k8s API calls (data source `for_each` collapses to empty)
- [x] terraform fmt clean

## Why drop the auto-extract

- Plan-time refresh of a freshly-created Secret is unreliable (the same data source returned 0 items on PR #22 even with the Secret present — TF refresh ordering quirk).
- One operator click per Zitadel bootstrap is genuinely cheaper than the chicken-and-egg debugging cost.
- Keeps `provider "zitadel"` config purely operator-supplied — easier to reason about and debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)