### PR TITLE
feat(cloudflare): manual DNS records declared per-domain in YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,9 +275,27 @@ envs:                                         # Map of env → per-env routing
 limits:                                       # (Optional) override default resource quota per project
   cpu: "4"
   memory: "8Gi"
+
+dns:                                          # (Optional) manual DNS records, domain-scoped
+  - name: "@"                                 # apex (or "" — same thing)
+    type: MX
+    content: "mail-relay.example.net"
+    priority: 10
+  - name: "@"
+    type: TXT
+    content: "v=spf1 include:mail-relay.example.net ~all"
+  - name: _sip._udp                           # SRV uses structured `data:` not `content:`
+    type: SRV
+    data:
+      priority: 10
+      weight:   100
+      port:     5060
+      target:   sip.example.com
 ```
 
 **Hostname generation:** the host prefix from the route map key is used literally. Empty string = apex. No env is injected into the hostname — if two envs of the same domain need distinct URLs, spell out the subdomain in the key (`api.dev: whoami` → `api.dev.example.com`).
+
+**DNS records (`dns:`)** — manual records added on top of the auto-generated CNAMEs that every `routes:` entry produces (each routed hostname → the Cloudflare Tunnel CNAME). Use `dns:` for MX/SPF/DKIM/DMARC, `_sip._udp` SRV records (sipmesh deploy), apex A records when a host has a public WAN IP for non-HTTP traffic, third-party verification TXT, and so on. Domain-scoped, not env-scoped — these describe the zone, not a per-env routing decision. Supported fields: `name`, `type`, `content` OR `data` (SRV/CAA/LOC use the structured `data` block), `ttl` (default 1 = "Auto" on CF Free), `proxied` (only meaningful for A/AAAA/CNAME), `priority` (for MX), `comment`. The `for_each` key is content-hashed so re-ordering the YAML list does not churn the plan; editing a record's content rotates that one key (CF requires delete+create for value changes anyway). See `config/domains/example.com.yaml.example` for worked examples covering mail, SIP SRV, apex A, and verification TXT.
 
 **Decoupled routes + components:** a component is deployed iff at least one route targets it. The same component can back multiple hosts (bare + `www`); different hosts can back different components (api → `whoami2`, bare → `whoami`).
 

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -129,3 +129,60 @@ resource "cloudflare_record" "tunnel" {
   type    = "CNAME"
   proxied = true
 }
+
+# ── Manual DNS records — declared per-domain in YAML ─────────────────────────
+#
+# The auto-generated CNAMEs above cover everything routed through the
+# Cloudflare Tunnel (= every component declared in `envs.*.routes:`).
+# Manual records here cover the rest: MX/SPF/DKIM/DMARC for mail,
+# SRV records for service discovery (e.g. `_sip._udp` for sipmesh),
+# apex A records when a host has a public WAN IP exposed for non-HTTP
+# traffic, third-party verification TXT, etc.
+#
+# Schema lives on each `config/domains/<domain>.yaml` under top-level
+# `dns:` — see config/domains/example.com.yaml.example for the worked
+# shape. Records are domain-scoped (not env-scoped) — they describe the
+# zone, not a per-env routing decision.
+resource "cloudflare_record" "manual" {
+  for_each = local.manual_dns_records
+
+  zone_id  = each.value.zone_id
+  name     = each.value.name
+  type     = each.value.type
+  ttl      = each.value.ttl
+  proxied  = each.value.proxied
+  priority = each.value.priority
+  comment  = each.value.comment
+
+  # Flat `content` for A/AAAA/CNAME/MX/TXT/NS/PTR. SRV/CAA/LOC use the
+  # structured `data` block instead — the provider rejects co-presence
+  # of both, so each record specifies exactly one in YAML.
+  content = each.value.data == null ? each.value.content : null
+
+  dynamic "data" {
+    for_each = each.value.data == null ? [] : [each.value.data]
+    content {
+      priority = try(data.value.priority, null)
+      weight   = try(data.value.weight, null)
+      port     = try(data.value.port, null)
+      target   = try(data.value.target, null)
+      service  = try(data.value.service, null)
+      proto    = try(data.value.proto, null)
+      name     = try(data.value.name, null)
+      flags    = try(data.value.flags, null)
+      tag      = try(data.value.tag, null)
+      value    = try(data.value.value, null)
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = each.value.content != null || each.value.data != null
+      error_message = "DNS record ${each.key} must declare either `content` (string) or `data` (object). See config/domains/example.com.yaml.example."
+    }
+    precondition {
+      condition     = each.value.zone_id != null
+      error_message = "DNS record ${each.key}: domain has no `cloudflare_zone_id` — set it on the domain YAML before declaring `dns:` records."
+    }
+  }
+}

--- a/config/domains/example.com.yaml.example
+++ b/config/domains/example.com.yaml.example
@@ -9,6 +9,58 @@ name: example.com                              # Domain name (used in hostnames)
 slug: example-com                              # URL-safe slug (used in namespace names)
 cloudflare_zone_id: "your-zone-id-from-cf"     # Cloudflare Zone ID for this domain
 
+# (Optional) Manual DNS records. Domain-scoped (not env-scoped) — these
+# describe the zone, not per-env routing. The platform automatically
+# emits a CNAME for every `envs.*.routes:` entry below pointing at the
+# Cloudflare Tunnel; use `dns:` here for everything else (MX/SPF/DKIM/
+# DMARC for mail, SRV for SIP/XMPP, apex A when a host has a public
+# WAN IP for non-HTTP, third-party verification TXT, etc.).
+#
+# Each entry:
+#   name     — record name. "@" or "" = apex; otherwise relative to the zone.
+#   type     — A | AAAA | CNAME | MX | TXT | SRV | NS | CAA | PTR | LOC.
+#   content  — string value (required for non-SRV/CAA/LOC types).
+#   data     — structured object (required for SRV/CAA/LOC; replaces content).
+#   ttl      — seconds. Default 1 = "Auto" on Cloudflare Free.
+#   proxied  — orange-cloud (CF proxy). Only valid for A/AAAA/CNAME. Default false.
+#   priority — for MX records. Default null.
+#   comment  — free-text shown in CF UI for context.
+#
+# dns:
+#   # Mail — external relay holds the public IP and the MX, since
+#   # residential ISPs block inbound :25 and CF Tunnel doesn't forward TCP.
+#   - name: "@"
+#     type: MX
+#     content: "mail-relay.example.net"
+#     priority: 10
+#   - name: "@"
+#     type: TXT
+#     content: "v=spf1 include:mail-relay.example.net ~all"
+#     comment: "SPF — authorise mail-relay to send as @example.com"
+#   - name: _dmarc
+#     type: TXT
+#     content: "v=DMARC1; p=none; rua=mailto:postmaster@example.com"
+#
+#   # Apex A — when home box has a public WAN IP exposed (e.g. SIP UDP).
+#   - name: "@"
+#     type: A
+#     content: "203.0.113.5"
+#     proxied: false               # CF Tunnel proxy is HTTP-only; UDP needs unproxied
+#
+#   # SIP service discovery — sipmesh sip-proxy listens on UDP 5060 at sip.example.com.
+#   - name: _sip._udp
+#     type: SRV
+#     data:
+#       priority: 10
+#       weight:   100
+#       port:     5060
+#       target:   sip.example.com
+#
+#   # Third-party verification (Bing webmaster, GitHub Pages, etc.)
+#   - name: "@"
+#     type: TXT
+#     content: "google-site-verification=AbCdEf..."
+
 # `envs` is a map of env name → per-env routing config.
 # Hostnames and components are decoupled:
 #   - the map key is the HOST PREFIX    ("" = bare apex, "www" = www.example.com)

--- a/locals.tf
+++ b/locals.tf
@@ -125,6 +125,35 @@ locals {
     trimsuffix(basename(f), ".yaml") => yamldecode(file("${path.module}/config/components/${f}"))
   }
 
+  # Manual DNS records from `config/domains/<domain>.yaml#dns:`. Domain-
+  # scoped (not env-scoped) — DNS records are facts about the zone, not
+  # about an env. Auto-generated CNAMEs for `envs.*.routes:` are emitted
+  # separately by cloudflare.tf via `local.all_hostnames`.
+  #
+  # for_each key = "{domain_key}|{type}|{name}|{md5(content|data)}". Re-
+  # ordering the YAML list does not churn the plan; editing content
+  # rotates only that record's key (replace, not in-place update — CF
+  # doesn't allow changing the value of an existing record without a
+  # delete+create, so this matches reality).
+  manual_dns_records = {
+    for entry in flatten([
+      for domain_key, cfg in local._domain_configs : [
+        for rec in try(cfg.dns, []) : {
+          domain_key = domain_key
+          zone_id    = cfg.cloudflare_zone_id
+          name       = rec.name
+          type       = rec.type
+          content    = try(rec.content, null)
+          data       = try(rec.data, null)
+          ttl        = try(rec.ttl, 1)
+          proxied    = try(rec.proxied, false)
+          priority   = try(rec.priority, null)
+          comment    = try(rec.comment, null)
+        }
+      ]
+    ]) : "${entry.domain_key}|${entry.type}|${entry.name}|${md5(coalesce(entry.content, jsonencode(entry.data)))}" => entry
+  }
+
   # Resource-quota settings per namespace. `config/limits/<namespace>.yaml`
   # overrides `config/limits/default.yaml` — e.g. `config/limits/platform.yaml`
   # bumps the root platform namespace above the tenant-default tier


### PR DESCRIPTION
## Summary

- Add top-level `dns:` array to `config/domains/<domain>.yaml` — domain-scoped manual DNS records on top of the auto-generated route → tunnel CNAMEs.
- Wire into `cloudflare_record.manual` with content-hashed `for_each` keys, supporting both flat `content` and structured `data` (SRV/CAA/LOC).
- Document schema in README, add worked examples (MX/SPF/DMARC, apex A, `_sip._udp` SRV, verification TXT) to `example.com.yaml.example`.

## Why

- **Mail** (Stalwart on the home node fronted by an external SMTP relay since residential ISPs block inbound `:25`) needs MX + SPF + DMARC records. Today the operator has to add them via Cloudflare UI — click-ops, tracked nowhere.
- **sipmesh** deployment needs `_sip._udp` SRV + apex A (proxied: false, since CF Tunnel is HTTP-only and SIP is UDP).
- Generally aligns with the no-click-ops principle — DNS records are TF, not Cloudflare UI.

## Design notes

- Domain-scoped (not env-scoped) — DNS describes the zone, not a per-env routing decision.
- `for_each` key is `{domain}|{type}|{name}|md5(content|data)` so re-ordering the YAML list does not churn the plan; editing a record rotates one key (CF requires delete+create for value changes anyway).
- Preconditions on each record: `content` OR `data` must be set; domain must have `cloudflare_zone_id`.
- Stays on `cloudflare/cloudflare ~> 4.0` to match existing `cloudflare_record.tunnel`.

## Verification

- [x] `terraform fmt -check -recursive` — clean
- [x] `terraform validate` — Success
- [x] `./tf plan -target=cloudflare_record.manual` against current state — "No changes" (empty `for_each`, no live yaml has `dns:` block yet)
- [ ] Operator: add MX/SPF/DMARC to one live domain yaml and run `./tf plan` to see the real diff

## Test plan

- [ ] Add a `dns:` entry with type=MX to a live domain yaml; `./tf plan` shows exactly one new `cloudflare_record.manual` instance with correct priority/content
- [ ] Add a SRV record using `data:` block; plan shows the structured block
- [ ] Edit content of an existing record; plan shows replace (delete + create), not in-place update
- [ ] Re-order `dns:` array in YAML; plan shows no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)