### PR TITLE
feat(mail): Stalwart 0.16 + Roundcube + cluster-wide forward-auth

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,0 +1,342 @@
+# Backlog
+
+Open work, in rough priority order. Sized for a single operator —
+each item is a sit-down session, not a sprint.
+
+## Hot — needed for mail to be production-correct
+
+### Reconsider Stalwart vs a traditional Postfix + Dovecot + Roundcube pod
+
+Stalwart was picked for "all-in-one Rust + native OIDC + declarative
+JMAP config". Reality has been bumpier: Stalwart's bundled WebUI does
+not include a mailbox view, so a separate webmail (Roundcube) is
+bolted on top anyway; the OIDC integration cost roughly three days
+of debugging (Zitadel JWT access tokens carry no `scope` claim, so
+Stalwart's hardcoded `openid` scope check fails until `requireScopes`
+is explicitly empty; Stalwart caches `OidcDirectory` at startup, so a
+schema change applied by the applier sidecar after Stalwart is up
+needs a second pod rollout to take effect; the JMAP `apply` engine
+groups all destroys before all updates, which silently breaks any
+plan that relies on a pre-destroy detach).
+
+The traditional Postfix + Dovecot + Roundcube stack — plain SASL auth,
+no SSO — is older but solves the same operational goal in a fraction
+of the time, fits in a few hundred lines of yaml, and has decades of
+operational muscle memory behind it.
+
+When Stalwart's next rough edge surfaces, evaluate ripping it out:
+drop `mail.tf`, `modules/stalwart`, `modules/roundcube`, the Zitadel
+app + project for Stalwart, and the `mail.yaml` external component;
+replace with a `kind: deployment` component wrapping Postfix +
+Dovecot + Roundcube, or a maintained `mailcow` / `docker-mailserver`
+helm chart. The trade-off lost is OIDC SSO into Stalwart's admin
+panel (which only the operator ever sees) — small in exchange for
+reliability.
+
+Alternative: wait for Stalwart upstream to release a mailbox UI in
+their `webui` bundle (on their public roadmap as of writing) and
+revisit then.
+
+### Make Cloudflare Tunnel optional for public-IP deploys
+
+Today the platform is hard-wired to Cloudflare Tunnel: every tenant
+hostname is a CNAME to `<tunnel-id>.cfargotunnel.com`, cloudflared
+runs as a Deployment in `ops`, and `cloudflare.tf` is unconditionally
+loaded. This is the right shape for a residential ISP behind a NAT
+and ISP-blocked :25 / :80 / :443 — that's where this cluster runs
+today. It's the wrong shape for a public-IP VPS deploy: there the
+provider already gives you working :80 / :443 / :25, cloudflared is
+extra latency and an extra moving part, and the simpler Traefik +
+cert-manager LetsEncrypt direct path works fine.
+
+Plan: gate the whole CF Tunnel chain behind a `var.public_ingress`
+flag (default `cloudflare_tunnel` for backwards-compatibility on the
+home box; `direct` for VPS deployments). When `direct`:
+
+- Skip `cloudflare_zero_trust_tunnel_cloudflared.main` and the
+  cloudflared Deployment.
+- DNS records become A/AAAA at the VPS public IP rather than CNAME
+  at `*.cfargotunnel.com`.
+- `cert-manager` switches from cluster-internal HTTP-01 (which
+  currently tunnels through cloudflared, fragile) to either HTTP-01
+  on the publicly reachable :80 or DNS-01 via the Cloudflare API
+  (which we already have a token for).
+- Traefik exposes :80 and :443 via a hostNetwork or NodePort
+  Service rather than only `ClusterIP` reachable through cloudflared.
+- The `force-https-proto` middleware that currently rewrites
+  `X-Forwarded-Proto` for cloudflared origin requests becomes a no-op
+  (Traefik terminates TLS itself).
+
+Trade-off: on `direct` you lose Cloudflare's DDoS shield + WAF +
+per-zone rate limits. Acceptable for a small VPS where the threat
+model is "drive-by scans, not nation-state".
+
+Order of operations when this lands: a fresh `direct` deployment
+should bring up the cluster, route mail.example.com / id.example.com
+/ chat.example.com / etc. on the VPS public IP, validate certs from
+LetsEncrypt over the standard public path, and never fetch a single
+byte through cloudflared. Existing `cloudflare_tunnel` deploys
+should require zero change.
+
+### Infisical as the platform secrets store (Zitadel-OIDC-gated)
+
+All sensitive material currently lives in two places: `terraform output
+-raw <name>` for things that originate in TF (recovery admin password,
+DB superuser passwords, smart-host credentials, basic auth pairs) and
+`kubectl get secret … -o jsonpath` for per-namespace per-component
+credentials. Both rotate on `./tf bootstrap-k3s` but otherwise sit in
+state and on disk indefinitely. Every operator look-up (cheatsheet,
+"give me the redis password") is a CLI ritual.
+
+Plan: deploy Infisical as a platform service in the `platform`
+namespace, OIDC-gated through Zitadel (a `mail-user`-style project
+role on a new Infisical Zitadel app gates access), and migrate every
+TF-managed secret into it. Components that need a credential read it
+out of Infisical at runtime via the in-cluster API rather than out of
+a hand-rolled `kubernetes_secret_v1`. Operator look-up shifts from
+`terraform output -raw` to a single Infisical UI/CLI gated by the
+same SSO that fronts the cluster.
+
+Open questions:
+
+1. **TF integration shape** — `infisical/infisical` provider exists
+   for declarative project + folder + secret-key creation, but the
+   write path conflicts with the bootstrap chicken-and-egg (the
+   provider needs Infisical reachable to plan; first apply has to
+   bring Infisical up before any other component can resolve its
+   secrets). Either: phased apply (Infisical comes up empty, then a
+   second pass populates secrets and rewires consumers) or write all
+   secrets via a `null_resource + local-exec` after Infisical is
+   ready and pre-mark them in TF state as imports.
+
+2. **Consumer pattern** — components currently read TF-managed
+   `kubernetes_secret_v1` via env-var. Two integration options:
+   `infisical-agent` sidecar that watches Infisical and rewrites a
+   local Secret on change, or the operator-flavour Infisical
+   ServiceAccount + CSI driver (CSI = colder, more native, more
+   moving parts). Lean towards sidecar for the small number of
+   components on this cluster.
+
+3. **Bootstrap admin** — Infisical itself needs an initial admin
+   account before OIDC is wired in. Mirror the Stalwart pattern:
+   `INFISICAL_RECOVERY_ADMIN` env-pinned plus a `random_password`
+   resource and a `terraform output -raw infisical_recovery_admin_password`.
+
+4. **What gets migrated first** — start with the things the
+   operator actually looks up from the cheatsheet (mail recovery
+   admin, BasicAuth pairs, MySQL/Postgres/Redis root passwords).
+   Per-tenant DB credentials probably stay as-is for now since they
+   get composed into per-component env-vars at TF-render time.
+
+When this lands, drop the secret-bearing rows from
+`outputs.tf::cheatsheet` and replace with a single line pointing at
+the Infisical URL.
+
+### ~~PTR for `relay.ipsupport.us`~~ — done 2026-04-30
+
+VPS provider rDNS now resolves `130.51.23.250` → `relay.ipsupport.us`.
+No further action; leaves SPF/DKIM/DMARC alignment as the remaining
+deliverability gate.
+
+### Stalwart wizard + DNS records (DKIM / SPF / DMARC)
+
+Mail server is up but unconfigured. Walk the wizard at
+`https://mail.ipsupport.us`:
+
+1. Set the admin password.
+2. Add domain `ipsupport.us`.
+3. Generate DKIM key (Domains → ipsupport.us → DKIM → Create).
+4. Optionally create accounts (`roman@ipsupport.us`, etc.).
+
+Then add the mail-related DNS records to the `dns:` block in
+`config/domains/ipsupport.us.yaml` (the static A/AAAA records are
+already there; this is just the TXT/MX additions):
+
+- MX `ipsupport.us` → `relay.ipsupport.us` (currently set by hand
+  on Cloudflare — move into the YAML and import into state, OR let
+  TF recreate it).
+- SPF TXT on `ipsupport.us`: `v=spf1 ip4:130.51.23.250 -all`.
+- DKIM TXT (key emitted by Stalwart): `<selector>._domainkey...`.
+- DMARC TXT on `_dmarc.ipsupport.us`:
+  `v=DMARC1; p=quarantine; rua=mailto:postmaster@ipsupport.us`.
+
+The DNS-as-YAML schema supports MX (`type: MX, content: "10 relay.ipsupport.us"`)
+and TXT (`type: TXT, content: "v=spf1 ..."`) directly via the flat
+`content:` form; SRV/CAA/LOC use the structured `data:` form.
+
+### Outbound mail relay covers more than `ipsupport.us`
+
+`gh/ansible-relay.ipsupport.us` Postfix `relay_domains` list is
+currently single-domain. When other tenant domains
+(`jagdterrier.club`, `paseka.co`, `priroda.kharkov.ua`) need mail,
+add them to `relay_mail_domains` in
+`inventories/prod/group_vars/mail_relay_vps.yml` and re-apply.
+Document this in the repo's README so it's a one-grep ops note.
+
+## Medium — quality of life
+
+### Consolidate Zitadel projects: per-domain, not per-app
+
+Today every Zitadel-integrated app — `kind: app` components
+(platform-dash, sipmesh-frontend) plus cluster-wide infra clients
+(forward-auth, future Grafana SSO, Traefik SSO) — gets its own
+Zitadel project. With N apps, the operator stares at N nearly-empty
+projects in the Zitadel console.
+
+Proper layout: **one project per tenant domain** (`ipsupport.us`,
+`jagdterrier.club`, `paseka.co`, `priroda.kharkov.ua`) holding all
+that domain's kind:app components, plus **one `platform-services`
+project** for cluster-wide infra OIDC clients. ~5 projects total
+forever, vs growing 1-per-app indefinitely.
+
+Refactor: hoist project creation out of `modules/zitadel-app` and
+`modules/oauth2-proxy` into the layer that owns the scope —
+`modules/project` for tenant domains, root TF for platform — and
+pass `project_id` down to the per-app module. Roles still belong to
+the per-app module (they're application-scoped within the project).
+
+### Auto-recovery for `login-client.pat` after pod restart
+
+Today the operator has to extract the FIRSTINSTANCE-generated PAT
+once and paste it into `.env` as `TF_VAR_zitadel_login_client_pat`,
+otherwise the next pod restart hangs forever at "waiting for
+login-client.pat...". Mild chicken-and-egg — fresh installs are
+fine, restarts after first install are operator-blocking.
+
+Proper fix: extend the `pat-broker` sidecar in
+`modules/zitadel/main.tf` to ALSO save `login-client.pat` (alongside
+the tf-platform PAT) to a Secret on first observation, and add an
+initContainer that, when the Secret exists but the emptyDir is
+empty, copies `login-client.pat` from Secret back to the emptyDir
+before the main containers start. After this lands:
+
+1. Drop `var.login_client_pat` from `modules/zitadel/main.tf`.
+2. Drop `TF_VAR_zitadel_login_client_pat` from `.env`.
+3. Drop the operator-bootstrap step from the variable's docstring.
+
+### Diagnostic recipes — how to look at cluster state
+
+Worth pulling out into `docs/diagnostics.md` as a quick-reference for
+the operator (and for future-me staring at a stuck cluster). The
+recipes that came up in this session:
+
+**Where's free CPU/memory on the node?**
+```bash
+kubectl describe node | grep -E '^Name:|Allocatable:|Allocated|cpu '
+kubectl top node
+```
+First gives the static Allocatable + the requests/limits tally that
+the scheduler actually uses (your "77% of limits at 1.8 CPU
+requests" view). Second gives live usage from metrics-server. Bump
+namespace quotas only after checking the requests/limits column —
+that's the gate, not real CPU.
+
+**Why is a pod Pending / FailedCreate?**
+```bash
+kubectl describe rs -n <ns> <rs-name> | grep -A6 Events:
+```
+Catches ResourceQuota denials with the exact `requested:` vs
+`used:` vs `limited:` numbers, plus PVC binding waits, image-pull
+backoffs.
+
+**What's actually on host port X?**
+```bash
+sudo ss -lntp 2>&1 | grep ':<port>'
+```
+Catches stale `kubectl port-forward` holdovers, or whether a
+hostNetwork pod actually grabbed the port. `pgrep -af 'port-forward'`
+correlates back to which `./tf` invocation owns the listener.
+
+**Is Traefik forwarding what I think it is?**
+```bash
+kubectl get deploy -n ingress-controller traefik \
+  -o jsonpath='{.spec.template.spec.containers[0].args[*]}' | tr ' ' '\n'
+```
+Dumps the runtime CLI args after the helm chart settles — the only
+truth about which entryPoints are configured and what
+forwardedHeaders trust looks like in production.
+
+**What's the actual response chain through CF Tunnel?**
+```bash
+curl -sIv 'https://<host>/' 2>&1 | grep -iE '< http|< location'
+```
+Quick way to see if Traefik is returning 307/302 (auth flow firing)
+or 500 (Traefik failing to proxy auth response). Cheaper than
+F12-Network-tab walkthrough for the operator.
+
+**Why is a TF-managed pod running with a stale spec?**
+- TF state may have lost the Deployment (e.g. after a `state rm`).
+  `terraform state list | grep <name>` catches that case.
+- The cluster has a zombie Deployment — `kubectl delete deploy/<name>`
+  + `terraform apply` recreates it cleanly.
+
+
+
+### Ansible-relay → Ansible-mail rename
+
+The repo `gh/ansible-relay.ipsupport.us` covers the VPS relay
+**and** will soon cover the home backend's WireGuard config (which
+is currently a manual `wg-quick@wg0` install). Rename to
+`ansible-mail`, add a `mail_home_backend` group + `wireguard_client`
+role for the home host so the WG bring-up is reproducible. Inventory
+gains a second host.
+
+### LAN-side firewall for the SMTP forwarder pod
+
+`stalwart-smtp-relay` is `hostNetwork=true` and binds explicitly to
+`10.23.0.2:25` (WG IP), so it's NOT exposed on the LAN. But the
+choice was a property of the bind address. Belt-and-suspenders: add
+a host-level ufw rule (managed via `ansible-mail`) that explicitly
+denies `:25` from the LAN interfaces, only allowing from the WG peer.
+
+### Stalwart admin still uses internal user/password
+
+We layered Zitadel forward-auth in front of the admin UI for the
+network-level gate, but Stalwart itself doesn't speak OIDC for its
+admin login. Two-factor in practice. Sufficient for v1. If it
+annoys: bridge Zitadel to Stalwart's userdb via SCIM, or enable
+Stalwart's IMAP+OIDC if a future version supports admin OIDC.
+
+### platform-dash CRD viewer
+
+`kubectl get` for IngressRoute + Middleware + IngressRouteTCP +
+ServersTransport is verbose enough that hand-pasting YAML into
+`yq` is the actual debugging workflow. Add a generic CRD lister
+to `platform-dash` (uses `KubernetesObjectApi` from
+`@kubernetes/client-node`, RBAC already covers `traefik.io/*`).
+Detailed scope in `~/.claude/projects/-home-roman220/memory/project_platform_dash_backlog.md`.
+
+## Cosmetic — fix opportunistically
+
+### `./tf` wrapper port-forward wait timeout
+
+Wrapper prints `tf: port-forward never became ready, continuing
+anyway` on most invocations because `kubectl port-forward` takes
+longer than its sleep-based wait. Apply works (port-forward IS up
+by the time the Zitadel provider hits it), but the message is
+alarming-looking for no reason. Bump the wait or switch to a TCP
+probe loop.
+
+### `tf-summarize` on the operator box
+
+Plan output from this stack is dense (especially when CF tunnel
+ingress_rule indices shift). Install `tf-summarize` (Go binary) and
+pipe `./tf plan -out=tfplan && terraform show -json tfplan |
+tf-summarize` for a human-readable summary.
+
+### Cloudflare provider v5 upgrade for keyed ingress_rules
+
+v4's `cloudflare_zero_trust_tunnel_cloudflared_config` stores
+`ingress_rule` blocks as a positional list — adding a hostname
+shifts every subsequent index, and TF shows full block diffs for
+each shift. v5 might use a keyed map. Big upgrade (other resources
+rename: `cloudflare_record` → `cloudflare_dns_record`, etc.) so
+not worth a session of its own; bundle with the next reason to
+touch the provider.
+
+### CRD viewer is the load-bearing dash item
+
+(See platform-dash backlog above.) Other dash work (sparkline
+metrics, real Nodes/Monitoring pages, light theme) is deferred —
+Grafana covers metrics and the operator hasn't asked for the
+others yet.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -132,60 +132,35 @@ When this lands, drop the secret-bearing rows from
 `outputs.tf::cheatsheet` and replace with a single line pointing at
 the Infisical URL.
 
-### ~~PTR for `relay.ipsupport.us`~~ — done 2026-04-30
+### Multi-domain support for the mail stack
 
-VPS provider rDNS now resolves `130.51.23.250` → `relay.ipsupport.us`.
-No further action; leaves SPF/DKIM/DMARC alignment as the remaining
-deliverability gate.
+Today the mail stack is single-domain: exactly one entry under
+`config/domains/<x>.yaml#mail.primary: true` drives `local.mail`,
+and `modules/stalwart` emits SPF/DKIM/DMARC for that one domain
+only. Stalwart itself happily hosts mailboxes for many domains; the
+gap is on the TF side (DNS records + Zitadel role + DKIM key
+generation).
 
-### Stalwart wizard + DNS records (DKIM / SPF / DMARC)
-
-Mail server is up but unconfigured. Walk the wizard at
-`https://mail.ipsupport.us`:
-
-1. Set the admin password.
-2. Add domain `ipsupport.us`.
-3. Generate DKIM key (Domains → ipsupport.us → DKIM → Create).
-4. Optionally create accounts (`roman@ipsupport.us`, etc.).
-
-Then add the mail-related DNS records to the `dns:` block in
-`config/domains/ipsupport.us.yaml` (the static A/AAAA records are
-already there; this is just the TXT/MX additions):
-
-- MX `ipsupport.us` → `relay.ipsupport.us` (currently set by hand
-  on Cloudflare — move into the YAML and import into state, OR let
-  TF recreate it).
-- SPF TXT on `ipsupport.us`: `v=spf1 ip4:130.51.23.250 -all`.
-- DKIM TXT (key emitted by Stalwart): `<selector>._domainkey...`.
-- DMARC TXT on `_dmarc.ipsupport.us`:
-  `v=DMARC1; p=quarantine; rua=mailto:postmaster@ipsupport.us`.
-
-The DNS-as-YAML schema supports MX (`type: MX, content: "10 relay.ipsupport.us"`)
-and TXT (`type: TXT, content: "v=spf1 ..."`) directly via the flat
-`content:` form; SRV/CAA/LOC use the structured `data:` form.
-
-### Outbound mail relay covers more than `ipsupport.us`
-
-`gh/ansible-relay.ipsupport.us` Postfix `relay_domains` list is
-currently single-domain. When other tenant domains
-(`jagdterrier.club`, `paseka.co`, `priroda.kharkov.ua`) need mail,
-add them to `relay_mail_domains` in
-`inventories/prod/group_vars/mail_relay_vps.yml` and re-apply.
-Document this in the repo's README so it's a one-grep ops note.
+Plan: shift `local.mail` from a single-domain object to a map keyed
+by domain, with `mail.enabled: true` (no `primary` flag — the
+single-domain case is just a one-entry map). `modules/stalwart`'s
+DKIM/SPF/DMARC `cloudflare_record` resources gain a `for_each` over
+that map; one DKIM key per domain (`tls_private_key.dkim` becomes
+keyed). The relay (smarthost) typically stays one-and-the-same;
+extend its `relay_domains` (Postfix) to accept all configured
+domains.
 
 ## Medium — quality of life
 
 ### Consolidate Zitadel projects: per-domain, not per-app
 
-Today every Zitadel-integrated app — `kind: app` components
-(platform-dash, sipmesh-frontend) plus cluster-wide infra clients
-(forward-auth, future Grafana SSO, Traefik SSO) — gets its own
-Zitadel project. With N apps, the operator stares at N nearly-empty
-projects in the Zitadel console.
+Today every Zitadel-integrated app — `kind: app` components plus
+cluster-wide infra clients (forward-auth, future Grafana SSO,
+Traefik SSO) — gets its own Zitadel project. With N apps, the
+operator stares at N nearly-empty projects in the Zitadel console.
 
-Proper layout: **one project per tenant domain** (`ipsupport.us`,
-`jagdterrier.club`, `paseka.co`, `priroda.kharkov.ua`) holding all
-that domain's kind:app components, plus **one `platform-services`
+Proper layout: **one project per tenant domain** holding all that
+domain's kind:app components, plus **one `platform-services`
 project** for cluster-wide infra OIDC clients. ~5 projects total
 forever, vs growing 1-per-app indefinitely.
 
@@ -218,7 +193,7 @@ before the main containers start. After this lands:
 
 Worth pulling out into `docs/diagnostics.md` as a quick-reference for
 the operator (and for future-me staring at a stuck cluster). The
-recipes that came up in this session:
+recipes that came up while building the mail stack:
 
 **Where's free CPU/memory on the node?**
 ```bash
@@ -226,7 +201,7 @@ kubectl describe node | grep -E '^Name:|Allocatable:|Allocated|cpu '
 kubectl top node
 ```
 First gives the static Allocatable + the requests/limits tally that
-the scheduler actually uses (your "77% of limits at 1.8 CPU
+the scheduler actually uses (the "77% of limits at 1.8 CPU
 requests" view). Second gives live usage from metrics-server. Bump
 namespace quotas only after checking the requests/limits column —
 that's the gate, not real CPU.
@@ -270,32 +245,15 @@ F12-Network-tab walkthrough for the operator.
 - The cluster has a zombie Deployment — `kubectl delete deploy/<name>`
   + `terraform apply` recreates it cleanly.
 
-
-
-### Ansible-relay → Ansible-mail rename
-
-The repo `gh/ansible-relay.ipsupport.us` covers the VPS relay
-**and** will soon cover the home backend's WireGuard config (which
-is currently a manual `wg-quick@wg0` install). Rename to
-`ansible-mail`, add a `mail_home_backend` group + `wireguard_client`
-role for the home host so the WG bring-up is reproducible. Inventory
-gains a second host.
-
-### LAN-side firewall for the SMTP forwarder pod
-
-`stalwart-smtp-relay` is `hostNetwork=true` and binds explicitly to
-`10.23.0.2:25` (WG IP), so it's NOT exposed on the LAN. But the
-choice was a property of the bind address. Belt-and-suspenders: add
-a host-level ufw rule (managed via `ansible-mail`) that explicitly
-denies `:25` from the LAN interfaces, only allowing from the WG peer.
-
 ### Stalwart admin still uses internal user/password
 
-We layered Zitadel forward-auth in front of the admin UI for the
-network-level gate, but Stalwart itself doesn't speak OIDC for its
-admin login. Two-factor in practice. Sufficient for v1. If it
-annoys: bridge Zitadel to Stalwart's userdb via SCIM, or enable
-Stalwart's IMAP+OIDC if a future version supports admin OIDC.
+`modules/oauth2-proxy` puts the cluster-wide forward-auth gate in
+front of the admin UI for the network-level gate, but Stalwart
+itself doesn't speak OIDC for its admin login. Two-factor in
+practice (Zitadel forward-auth + Stalwart's own admin password).
+Sufficient for v1. If it annoys: bridge Zitadel to Stalwart's
+userdb via SCIM, or enable Stalwart's IMAP+OIDC if a future version
+supports admin OIDC.
 
 ### platform-dash CRD viewer
 
@@ -304,7 +262,6 @@ ServersTransport is verbose enough that hand-pasting YAML into
 `yq` is the actual debugging workflow. Add a generic CRD lister
 to `platform-dash` (uses `KubernetesObjectApi` from
 `@kubernetes/client-node`, RBAC already covers `traefik.io/*`).
-Detailed scope in `~/.claude/projects/-home-roman220/memory/project_platform_dash_backlog.md`.
 
 ## Cosmetic — fix opportunistically
 
@@ -333,10 +290,3 @@ each shift. v5 might use a keyed map. Big upgrade (other resources
 rename: `cloudflare_record` → `cloudflare_dns_record`, etc.) so
 not worth a session of its own; bundle with the next reason to
 touch the provider.
-
-### CRD viewer is the load-bearing dash item
-
-(See platform-dash backlog above.) Other dash work (sparkline
-metrics, real Nodes/Monitoring pages, light theme) is deferred —
-Grafana covers metrics and the operator hasn't asked for the
-others yet.

--- a/_versions.tf
+++ b/_versions.tf
@@ -22,6 +22,10 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
     zitadel = {
       source  = "zitadel/zitadel"
       version = "~> 2.9"

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -92,18 +92,24 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "main" {
         hostname = ingress_rule.key
         service  = ingress_rule.value.service
 
-        # cloudflared talks HTTP/1.1 to origin by default. Components
-        # that need end-to-end gRPC (Zitadel today, anything kind:app
-        # backed by gRPC tomorrow) flip `http2_origin: true` in their
-        # YAML — that propagates through modules/project's hostnames
-        # output and lands here. Cloudflared then negotiates HTTP/2
-        # cleartext upstream against Traefik, which has its own
-        # `scheme: h2c` knob to pass the framing through to the pod.
-        dynamic "origin_request" {
-          for_each = try(ingress_rule.value.http2_origin, false) ? [1] : []
-          content {
-            http2_origin = true
-          }
+        # End-to-end TLS to Traefik. `origin_server_name` sets the SNI
+        # cloudflared presents on the upstream TLS handshake — without
+        # it cloudflared would SNI as the service-URL host
+        # (`traefik.ingress-controller.svc.cluster.local`), Traefik
+        # would fall back to its self-signed default cert, and
+        # cloudflared would reject it. Setting SNI to the public
+        # hostname lets Traefik serve the correct Let's Encrypt cert,
+        # which cloudflared validates cleanly.
+        #
+        # `http2_origin` is opt-in via the component yaml — flips
+        # cloudflared from HTTP/1.1 to HTTP/2 cleartext upstream;
+        # required end-to-end for any service that exposes gRPC
+        # alongside HTTP (Zitadel today, anything kind:app backed by
+        # gRPC tomorrow). Traefik's own `scheme: h2c` knob passes the
+        # HTTP/2 framing through to the pod.
+        origin_request {
+          origin_server_name = ingress_rule.key
+          http2_origin       = try(ingress_rule.value.http2_origin, false)
         }
       }
     }

--- a/config/components/mail.yaml
+++ b/config/components/mail.yaml
@@ -1,0 +1,24 @@
+# mail.<domain> root — routes to Roundcube webmail.
+#
+# Stalwart's bundled WebUI covers `/admin` (admin panel) and `/account`
+# (self-service account settings) — there is NO inbox view, so a
+# separate webmail (Roundcube) sits at the root of the domain. Two
+# extra IngressRoutes are emitted directly by `modules/stalwart` to
+# claim `/admin` and `/account` and forward those to the Stalwart
+# Service with priority above this generic route.
+#
+# Auth flow (browser-only, OIDC end-to-end, no app passwords):
+#   1. user opens https://mail.<domain>/
+#   2. Roundcube oauth2 plugin redirects to Zitadel /authorize (PKCE)
+#   3. Zitadel returns a code → Roundcube exchanges it for a JWT
+#      access_token at /token
+#   4. Roundcube opens IMAP+SMTP to Stalwart with SASL XOAUTH2 +
+#      that access_token
+#   5. Stalwart's Oidc directory validates the token and auto-
+#      provisions the UserAccount on first login (claim_email).
+kind: external
+
+service:
+  name:      roundcube
+  namespace: mail
+  port:      80

--- a/config/components/oauth2-proxy.yaml
+++ b/config/components/oauth2-proxy.yaml
@@ -1,0 +1,26 @@
+# Auth gate (traefik-forward-auth) — routing only, no Deployment.
+# Points at the Service the root `oauth2_proxy.tf` module emits.
+# Map the `auth` route in any domain yaml (e.g. `auth: oauth2-proxy`)
+# so `auth.<domain>` answers on this Service: traefik-forward-auth's
+# `/_oauth` callback handler lives here, plus the OIDC start endpoint
+# any protected host forwards to.
+#
+# Self-attached to the cluster-wide ForwardAuth middleware (`auth:
+# zitadel`) on purpose: thomseddon/traefik-forward-auth's `RootHandler`
+# rewrites `r.Method`/`r.Host`/`r.URL` from X-Forwarded-* headers
+# before mux dispatch — those headers are only set when the request
+# arrives via a ForwardAuth middleware. Without the middleware here,
+# the `/_oauth` callback request from Zitadel lands in the default
+# AuthHandler instead of AuthCallbackHandler, which redirects the
+# browser straight back to the provider — infinite loop. /_oauth is
+# routed in forward-auth's mux ABOVE the default auth-required path,
+# so self-protection doesn't deadlock; the callback bypasses the
+# auth gate even though everything else on this host wouldn't.
+auth: zitadel
+
+kind: external
+
+service:
+  name:      forward-auth
+  namespace: ingress-controller
+  port:      4181

--- a/config/domains/example.com.yaml.example
+++ b/config/domains/example.com.yaml.example
@@ -9,6 +9,39 @@ name: example.com                              # Domain name (used in hostnames)
 slug: example-com                              # URL-safe slug (used in namespace names)
 cloudflare_zone_id: "your-zone-id-from-cf"     # Cloudflare Zone ID for this domain
 
+# (Optional) Mail-stack opt-in. Exactly ONE domain across all
+# `config/domains/*.yaml` files should set `mail.primary: true` —
+# that domain becomes the home of the platform mail stack
+# (`mail.tf` reads `local.mail`, which is derived from the
+# primary-mail domain's yaml). When zero domains opt in, the mail
+# stack stays uncreated. The mail UI hostname defaults to
+# `mail.<name>`; override `hostname` if you want a different
+# subdomain.
+#
+# Smarthost: typically the WG IP of a public Postfix relay VPS
+# (residential ISPs and Cloudflare Tunnel both block outbound :25,
+# so a relay is required). Empty `address` falls back to direct MX
+# — fine on a public-IP VPS where :25 is reachable.
+#
+# `spf_authorized_ip` is the public IP that mail leaves through
+# (the relay's WAN IP) — drives the `v=spf1 ip4:<this> -all`
+# record `modules/stalwart` emits. Empty omits SPF entirely.
+#
+# mail:
+#   primary: true
+#   hostname: mail.example.com                 # default: mail.<name>
+#   smtp_relay_listen_ip: "10.10.0.2"          # WG iface on this node
+#   spf_authorized_ip: "203.0.113.5"           # relay's public IP
+#   dkim_selector: "stalwart"
+#   dmarc_policy: "quarantine"                 # tighten to "reject" later
+#   smarthost:
+#     address: "10.10.0.1"                     # WG IP of the relay
+#     port: 25
+#     implicit_tls: false
+#     allow_invalid_certs: false
+#     username: ""                             # empty = no SMTP AUTH
+#     # password — set TF_VAR_smarthost_password in `.env` if AUTH is needed
+
 # (Optional) Manual DNS records. Domain-scoped (not env-scoped) — these
 # describe the zone, not per-env routing. The platform automatically
 # emits a CNAME for every `envs.*.routes:` entry below pointing at the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -142,6 +142,30 @@ All three live in the root-owned `platform` namespace (ResourceQuota from `confi
 - Model-pull Job runs `ollama pull <model>` for every entry in `services.ollama.models` after the server is ready. Idempotent — re-applies are free for already-cached models. Name hashes the model list, so a list change rotates the Job.
 - No auth. Tenants address it via `OLLAMA_HOST` / `OLLAMA_BASE_URL` / `OLLAMA_API_BASE` env vars injected through the per-tenant `ollama-endpoint` Secret.
 
+## Mail Stack (mail namespace)
+
+A separate top-level stack for `mail.<primary_mail_domain>`, wired in `mail.tf`. Lives in its own `mail` namespace with a 2 GiB / 2 CPU / 6-pod ResourceQuota.
+
+**Stalwart** (`modules/stalwart`, v0.16.x):
+- All-in-one mail server: SMTP submission/delivery + IMAP + JMAP + WebUI, Rust, declarative config via `stalwart-cli apply <plan.ndjson>`.
+- StatefulSet, 1 replica, hostPath PV (`<host_volume_path>/mail/stalwart/`) — internal RocksDB store, no Postgres/MySQL needed.
+- Bootstraps on first apply: an `applier` sidecar runs `stalwart-cli` against the JMAP API to push `plan.ndjson` (Authentication directory swap → Zitadel `OidcDirectory`, MtaRoute `Relay` to the smart-host, `DkimSignature` from a TF-generated RSA key, mail UI `defaultDomainId`). The plan engine groups all destroys before all updates, so the directory swap is split into a pre-step `update Authentication singleton --field directoryId=null` to avoid a "still-referenced" abort.
+- OIDC: a Zitadel app (BASIC client) + project + two roles (`admin`, `mail-user`) provisioned by the module. Stalwart auto-provisions accounts on first OIDC login but only when the user carries the `mail-user` role; the role check is the membership gate. **`OidcDirectory` is cached in RAM at Stalwart startup**, so any schema change applied by the applier sidecar after Stalwart is up needs a second pod rollout to take effect (see BACKLOG).
+- DNS records (DKIM TXT at `<dkim_selector>._domainkey`, SPF, DMARC) emitted directly as `cloudflare_record` resources from the module — values derived from the in-state RSA pubkey, never hand-pasted.
+- Admin/account WebUI hidden behind a random per-deploy URL prefix (`random_password.admin_path`) — operator-only, no public discovery surface.
+- SMTP outbound goes through `MtaRoute Relay smarthost` to the public Postfix relay VPS (`var.smarthost_*`). SMTP inbound :25 lands at a sibling `socat` Deployment (`stalwart-smtp-relay`) bound to the WireGuard interface and forwarded back to the public relay's chain — Cloudflare Tunnel does not forward TCP/25.
+
+**Roundcube** (`modules/roundcube`, 1.6.x):
+- The actual mailbox UI (Stalwart's built-in webui has admin/account but no inbox view).
+- Deployment, 1 replica, hostPath SQLite at `<host_volume_path>/mail/roundcube/db/` (init container `fix-db-perms` chowns to apache uid 33).
+- OIDC-only auth — no password login. Roundcube's built-in OAuth2 flow (core feature in 1.5+, NOT a plugin) issues a Zitadel `OIDC_AUTH_METHOD_TYPE_BASIC` confidential client; the client secret rides into the pod via a k8s Secret (config.inc.php reads `getenv('ROUNDCUBE_OAUTH_CLIENT_SECRET')`) because TF doesn't detect drift on sensitive ConfigMap data.
+- IMAP/SMTP to Stalwart use SASL XOAUTH2 with the same Zitadel access token Roundcube minted at login.
+
+**oauth2-proxy** (`modules/oauth2-proxy`, thomseddon/traefik-forward-auth):
+- Cluster-wide ForwardAuth handler for any component that opts into `auth: zitadel` in its yaml. Fronts non-OIDC-aware apps (e.g. the Stalwart admin UI's path obscurity is belt-and-braces; other components can route through forward-auth alone).
+- Service in `ingress-controller`; tenant projects attach the middleware on demand via the `oauth2_proxy_middleware` var passed into `modules/project`. Component yamls flag `auth: zitadel: true` to pull it in on a route.
+- Self-protection: the `oauth2-proxy` component has `auth: zitadel` on itself so `auth.<domain>` request lands with the X-Forwarded-* headers thomseddon's mux requires (see Known Limitations).
+
 ## Bootstrap Flow (k3s, Option B default)
 
 ```
@@ -213,3 +237,4 @@ For non-root images (WordPress = UID 33, Redis = UID 999, Open WebUI = UID 1000)
 - Single-node only (minikube or a single k3s server). For multi-node k3s, the hostPath model has to be replaced with a network-backed StorageClass (longhorn, nfs-subdir, etc.).
 - Re-bootstrap regenerates every credential in state (MySQL root, Redis default, component BasicAuth) but persistent hostPath data retains the old credentials. Wipe the relevant `<host_volume_path>/<namespace>/<component>/` dir to reset.
 - `host_volume_path` is distribution-coupled: the value must match how the kubelet sees the FS (native-Linux k3s and `--driver=none` minikube use a regular host dir; macOS Docker-driver minikube uses `/minikube-host/...` because it auto-mounts `/Users`; Linux Docker-driver minikube needs an explicit `minikube mount`).
+- **traefik-forward-auth requires the ForwardAuth middleware on its own host.** thomseddon/traefik-forward-auth's internal mux dispatches `/_oauth` (the OIDC callback) and other paths based on `r.URL` AFTER `RootHandler` rewrites the request from `X-Forwarded-Method`/`-Host`/`-Uri` headers — those headers are only set when the request arrives via Traefik's ForwardAuth middleware. If `auth.<domain>` is routed straight to the forward-auth Service without the middleware, the Zitadel-issued `/_oauth?code=…` callback comes in with empty X-Forwarded-* values, RootHandler rewrites `r.URL` to empty, the mux falls through to the default AuthHandler, and the browser gets 307'd back to the provider — infinite loop. The `oauth2-proxy` component has `auth: zitadel` set on itself for exactly this reason; the comment in `config/components/oauth2-proxy.yaml` calls out why self-protection isn't a deadlock (`/_oauth` is routed above the auth-required default in forward-auth's mux).

--- a/locals.tf
+++ b/locals.tf
@@ -163,4 +163,45 @@ locals {
     trimsuffix(basename(f), ".yaml") => yamldecode(file("${path.module}/config/limits/${f}"))
   }
   default_limits = local.namespace_limits.default
+
+  # Mail-stack settings. Sourced from the domain yaml carrying
+  # `mail.primary: true` — exactly one tenant domain owns the
+  # platform's mail stack at a time, the others are routed elsewhere.
+  # `null` when no domain opts in (mail stack stays uncreated).
+  _mail_domain_keys = [
+    for k, cfg in local._domain_configs : k if try(cfg.mail.primary, false)
+  ]
+  _mail_domain_key = length(local._mail_domain_keys) > 0 ? local._mail_domain_keys[0] : null
+  _mail_raw        = local._mail_domain_key == null ? null : local._domain_configs[local._mail_domain_key]
+  mail = local._mail_domain_key == null ? null : merge(
+    {
+      hostname             = "mail.${local._mail_raw.name}"
+      smtp_relay_listen_ip = ""
+      spf_authorized_ip    = ""
+      dkim_selector        = "stalwart"
+      dmarc_policy         = "quarantine"
+      smarthost = {
+        address             = ""
+        port                = 25
+        implicit_tls        = false
+        allow_invalid_certs = false
+        username            = ""
+      }
+    },
+    try(local._mail_raw.mail, {}),
+    {
+      primary_domain     = local._mail_raw.name
+      cloudflare_zone_id = try(local._mail_raw.cloudflare_zone_id, "")
+      smarthost = merge(
+        {
+          address             = ""
+          port                = 25
+          implicit_tls        = false
+          allow_invalid_certs = false
+          username            = ""
+        },
+        try(local._mail_raw.mail.smarthost, {}),
+      )
+    },
+  )
 }

--- a/mail.tf
+++ b/mail.tf
@@ -1,0 +1,122 @@
+# Mail stack — Stalwart 0.16 in the `mail` namespace, SQLite + blob
+# storage on hostPath. WebUI (admin + webmail) routes through the
+# Cloudflare Tunnel as a kind:external component (config/components/
+# mail.yaml) and gets SSO via the Zitadel OIDC directory wired in by
+# the module's plan.ndjson. SMTP inbound arrives on host port 25 via
+# a tiny socat forwarder (also in `mail`) bound to the WireGuard
+# address — Cloudflare Tunnel does not forward TCP/25, the public
+# relay forwards there. SMTP outbound is wired to the same relay
+# through Stalwart's MtaRoute Relay variant; smarthost vars
+# (var.smarthost_*) plumb in at the module call below. An empty
+# smarthost_address falls back to direct MX, which residential ISPs
+# silently swallow.
+
+resource "kubernetes_namespace_v1" "mail" {
+  metadata {
+    name = "mail"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/part-of"    = "platform"
+    }
+  }
+}
+
+# Mail namespace resource budget. Sized to fit Stalwart + Roundcube +
+# the SMTP relay forwarder + applier sidecar with a small headroom
+# for future webmail accounts.
+#
+# Stalwart's main container is 500m/768Mi limits, applier 200m/128Mi,
+# Roundcube 200m/256Mi, smtp-relay 100m/32Mi — a hair under 1.1Gi
+# memory limits with all four pods running, plus the operator's
+# expected mailbox count is one digit. 2Gi memory + 2 CPU leaves
+# enough room without blowing past the 32Gi / 12-CPU node.
+resource "kubernetes_resource_quota_v1" "mail" {
+  metadata {
+    name      = "mail-budget"
+    namespace = kubernetes_namespace_v1.mail.metadata[0].name
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+
+  spec {
+    hard = {
+      "requests.cpu"    = "1"
+      "requests.memory" = "1Gi"
+      "limits.cpu"      = "2"
+      "limits.memory"   = "2Gi"
+      "pods"            = "6"
+    }
+  }
+}
+
+module "stalwart" {
+  source     = "./modules/stalwart"
+  depends_on = [module.addons, module.zitadel, kubernetes_resource_quota_v1.mail]
+
+  enabled          = true
+  namespace        = kubernetes_namespace_v1.mail.metadata[0].name
+  volume_base_path = var.host_volume_path
+
+  # Primary domain + matching Cloudflare zone come from the same
+  # entry in `_domain_configs`. `primary_mail_domain` is the variable
+  # operators flip when the home of mail moves to a different tenant
+  # — everything else (DKIM/SPF/DMARC TXT records, the mail UI's
+  # `defaultDomainId`, OIDC auto-provisioning) follows from it.
+  primary_domain     = var.primary_mail_domain
+  hostname           = "mail.${var.primary_mail_domain}"
+  cloudflare_zone_id = try(local._domain_configs[var.primary_mail_domain].cloudflare_zone_id, "")
+
+  # Zitadel wiring — when zitadel is on at platform root, the module
+  # creates an OIDC app + role + the bootstrap plan attaches Zitadel
+  # as the authentication directory. When off, Stalwart still comes
+  # up with internal directory + recovery admin only.
+  zitadel_org_id                 = local.platform.services.zitadel.enabled ? data.zitadel_orgs.platform_org[0].ids[0] : ""
+  zitadel_issuer_url             = local.platform.services.zitadel.enabled ? "https://${local.platform.services.zitadel.external_domain}" : ""
+  zitadel_provider_authenticated = var.zitadel_pat != ""
+
+  # Outbound smart-host — set TF_VAR_smarthost_address (and the
+  # adjacent _port / _username / _password if the relay needs auth)
+  # in `.env` to push every non-local message through the public
+  # Postfix relay VPS. Empty leaves Stalwart on direct-MX which the
+  # network silently swallows.
+  smarthost_address             = var.smarthost_address
+  smarthost_port                = var.smarthost_port
+  smarthost_implicit_tls        = var.smarthost_implicit_tls
+  smarthost_allow_invalid_certs = var.smarthost_allow_invalid_certs
+  smarthost_username            = var.smarthost_username
+  smarthost_password            = var.smarthost_password
+}
+
+# Roundcube webmail — fronts the actual mailbox UI at the root of
+# mail.<domain>, OIDC-only auth via Zitadel + XOAUTH2 to Stalwart's
+# IMAP/SMTP. Stalwart's bundled webui covers admin/account but has
+# no inbox view, so a separate webmail component is required for any
+# browser-based mail reading.
+module "roundcube" {
+  source     = "./modules/roundcube"
+  depends_on = [module.stalwart]
+
+  enabled          = local.platform.services.zitadel.enabled
+  namespace        = kubernetes_namespace_v1.mail.metadata[0].name
+  hostname         = "mail.${var.primary_mail_domain}"
+  volume_base_path = var.host_volume_path
+
+  zitadel_org_id                 = local.platform.services.zitadel.enabled ? data.zitadel_orgs.platform_org[0].ids[0] : ""
+  zitadel_issuer_url             = local.platform.services.zitadel.enabled ? "https://${local.platform.services.zitadel.external_domain}" : ""
+  zitadel_provider_authenticated = var.zitadel_pat != ""
+  zitadel_project_id             = local.platform.services.zitadel.enabled ? module.stalwart.zitadel_project_id : ""
+}
+
+# Zitadel org lookup — Stalwart's OIDC app + role need an org_id and
+# the existing per-domain `forward-auth` project lives under it. One
+# extra round-trip per plan when Zitadel is disabled is the price of
+# keeping the data source unconditionally referenced; gating it on
+# `enabled` would pull org_id resolution into the apply phase and
+# every dependent resource would re-plan as "must replace".
+data "zitadel_orgs" "platform_org" {
+  count = local.platform.services.zitadel.enabled ? 1 : 0
+
+  name        = "ZITADEL"
+  name_method = "TEXT_QUERY_METHOD_EQUALS"
+}

--- a/mail.tf
+++ b/mail.tf
@@ -6,12 +6,21 @@
 # a tiny socat forwarder (also in `mail`) bound to the WireGuard
 # address — Cloudflare Tunnel does not forward TCP/25, the public
 # relay forwards there. SMTP outbound is wired to the same relay
-# through Stalwart's MtaRoute Relay variant; smarthost vars
-# (var.smarthost_*) plumb in at the module call below. An empty
-# smarthost_address falls back to direct MX, which residential ISPs
-# silently swallow.
+# through Stalwart's MtaRoute Relay variant; smarthost values come
+# from `local.mail.smarthost.*` (sourced from the domain yaml that
+# carries `mail.primary: true`). An empty `smarthost.address` falls
+# back to direct MX, which residential ISPs silently swallow.
+#
+# Tenant-specific values (smarthost target, WG bind IP, public IP for
+# SPF, DKIM selector, DMARC policy) live under `mail:` in the primary
+# domain's yaml — those files are gitignored. Only the SMTP-AUTH
+# password (when used) stays out of yaml: pass via TF_VAR_smarthost_password
+# in `.env`. The mail stack is created iff exactly one domain yaml
+# sets `mail.primary: true`.
 
 resource "kubernetes_namespace_v1" "mail" {
+  count = local.mail == null ? 0 : 1
+
   metadata {
     name = "mail"
     labels = {
@@ -29,11 +38,13 @@ resource "kubernetes_namespace_v1" "mail" {
 # Roundcube 200m/256Mi, smtp-relay 100m/32Mi — a hair under 1.1Gi
 # memory limits with all four pods running, plus the operator's
 # expected mailbox count is one digit. 2Gi memory + 2 CPU leaves
-# enough room without blowing past the 32Gi / 12-CPU node.
+# enough room without blowing past a typical home-lab node.
 resource "kubernetes_resource_quota_v1" "mail" {
+  count = local.mail == null ? 0 : 1
+
   metadata {
     name      = "mail-budget"
-    namespace = kubernetes_namespace_v1.mail.metadata[0].name
+    namespace = kubernetes_namespace_v1.mail[0].metadata[0].name
     labels = {
       "app.kubernetes.io/managed-by" = "terraform"
     }
@@ -54,18 +65,26 @@ module "stalwart" {
   source     = "./modules/stalwart"
   depends_on = [module.addons, module.zitadel, kubernetes_resource_quota_v1.mail]
 
-  enabled          = true
-  namespace        = kubernetes_namespace_v1.mail.metadata[0].name
+  enabled          = local.mail != null
+  namespace        = local.mail == null ? "" : kubernetes_namespace_v1.mail[0].metadata[0].name
   volume_base_path = var.host_volume_path
 
-  # Primary domain + matching Cloudflare zone come from the same
-  # entry in `_domain_configs`. `primary_mail_domain` is the variable
-  # operators flip when the home of mail moves to a different tenant
-  # — everything else (DKIM/SPF/DMARC TXT records, the mail UI's
-  # `defaultDomainId`, OIDC auto-provisioning) follows from it.
-  primary_domain     = var.primary_mail_domain
-  hostname           = "mail.${var.primary_mail_domain}"
-  cloudflare_zone_id = try(local._domain_configs[var.primary_mail_domain].cloudflare_zone_id, "")
+  # Primary domain + matching Cloudflare zone come from the domain
+  # yaml that opts in via `mail.primary: true`. Hostname defaults to
+  # `mail.<domain>` but can be overridden in yaml.
+  primary_domain     = try(local.mail.primary_domain, "")
+  hostname           = try(local.mail.hostname, "")
+  cloudflare_zone_id = try(local.mail.cloudflare_zone_id, "")
+
+  # DNS / DKIM knobs from yaml.
+  dkim_selector     = try(local.mail.dkim_selector, "stalwart")
+  spf_authorized_ip = try(local.mail.spf_authorized_ip, "")
+  dmarc_policy      = try(local.mail.dmarc_policy, "quarantine")
+
+  # SMTP inbound forwarder bind IP — typically the WireGuard interface
+  # address on the home node so the public relay's outbound tunnel can
+  # reach it without exposing :25 on the LAN.
+  smtp_relay_listen_ip = try(local.mail.smtp_relay_listen_ip, "")
 
   # Zitadel wiring — when zitadel is on at platform root, the module
   # creates an OIDC app + role + the bootstrap plan attaches Zitadel
@@ -75,17 +94,18 @@ module "stalwart" {
   zitadel_issuer_url             = local.platform.services.zitadel.enabled ? "https://${local.platform.services.zitadel.external_domain}" : ""
   zitadel_provider_authenticated = var.zitadel_pat != ""
 
-  # Outbound smart-host — set TF_VAR_smarthost_address (and the
-  # adjacent _port / _username / _password if the relay needs auth)
-  # in `.env` to push every non-local message through the public
-  # Postfix relay VPS. Empty leaves Stalwart on direct-MX which the
-  # network silently swallows.
-  smarthost_address             = var.smarthost_address
-  smarthost_port                = var.smarthost_port
-  smarthost_implicit_tls        = var.smarthost_implicit_tls
-  smarthost_allow_invalid_certs = var.smarthost_allow_invalid_certs
-  smarthost_username            = var.smarthost_username
-  smarthost_password            = var.smarthost_password
+  # Outbound smart-host. yaml provides target/port/TLS shape. The home
+  # cluster's relay accepts mail by source-IP / WG peer-ACL, so SMTP
+  # AUTH is unused — `smarthost_username` stays empty and the module's
+  # `smarthost_password` defaults to empty too. Operators relaying
+  # through an AUTH-required SaaS (Mailgun, SendGrid, etc.) would need
+  # to add a `var.smarthost_password` (sensitive, .env-only) and pipe
+  # it through here.
+  smarthost_address             = try(local.mail.smarthost.address, "")
+  smarthost_port                = try(local.mail.smarthost.port, 25)
+  smarthost_implicit_tls        = try(local.mail.smarthost.implicit_tls, false)
+  smarthost_allow_invalid_certs = try(local.mail.smarthost.allow_invalid_certs, false)
+  smarthost_username            = try(local.mail.smarthost.username, "")
 }
 
 # Roundcube webmail — fronts the actual mailbox UI at the root of
@@ -97,9 +117,9 @@ module "roundcube" {
   source     = "./modules/roundcube"
   depends_on = [module.stalwart]
 
-  enabled          = local.platform.services.zitadel.enabled
-  namespace        = kubernetes_namespace_v1.mail.metadata[0].name
-  hostname         = "mail.${var.primary_mail_domain}"
+  enabled          = local.mail != null && local.platform.services.zitadel.enabled
+  namespace        = local.mail == null ? "" : kubernetes_namespace_v1.mail[0].metadata[0].name
+  hostname         = try(local.mail.hostname, "")
   volume_base_path = var.host_volume_path
 
   zitadel_org_id                 = local.platform.services.zitadel.enabled ? data.zitadel_orgs.platform_org[0].ids[0] : ""

--- a/main.tf
+++ b/main.tf
@@ -138,4 +138,9 @@ module "project" {
   zitadel_org_name               = "ZITADEL"
   zitadel_issuer_url             = local.platform.services.zitadel.enabled ? "https://${local.platform.services.zitadel.external_domain}" : null
   zitadel_provider_authenticated = var.zitadel_pat != ""
+
+  # Cross-namespace ForwardAuth middleware ref. Null when Zitadel is
+  # off — the project-level check rejects `auth: zitadel` on any
+  # component before the IngressRoute generation is reached.
+  oauth2_proxy_middlewares = module.oauth2_proxy.middleware_refs
 }

--- a/modules/oauth2-proxy/main.tf
+++ b/modules/oauth2-proxy/main.tf
@@ -1,0 +1,411 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.14"
+    }
+    zitadel = {
+      source  = "zitadel/zitadel"
+      version = "~> 2.9"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+# Cluster-wide auth gate built on `traefik-forward-auth` (thomseddon).
+# Picked over oauth2-proxy because it returns 307 + Location directly
+# from its auth endpoint — Traefik's ForwardAuth middleware proxies
+# the response unchanged and the browser auto-follows. oauth2-proxy
+# returns 401 with a redirect-HTML body which Errors middleware can't
+# salvage (status is preserved, body alone won't navigate).
+#
+# Module-internal naming kept as `oauth2_proxy` for state continuity
+# from the earlier iteration — the *behavior* is forward-auth, the
+# state path is what it is.
+
+variable "enabled" {
+  description = "Deploy the auth gate. Should be tied to `services.zitadel.enabled` at the root — this module needs Zitadel as the OIDC provider."
+  type        = bool
+  default     = false
+}
+
+variable "namespace" {
+  description = "Namespace the Deployment lives in. Expected to exist already (typically `ingress-controller`)."
+  type        = string
+  default     = null
+}
+
+variable "image" {
+  description = "Container image. Pinned tag so the OIDC config schema doesn't shift between restarts."
+  type        = string
+  default     = "thomseddon/traefik-forward-auth:2.2.0"
+}
+
+variable "issuer_url" {
+  description = "Zitadel public issuer URL (e.g. https://id.example.com)."
+  type        = string
+}
+
+variable "auth_hostname" {
+  description = "Public hostname this proxy answers on (e.g. auth.example.com). Used as the OIDC redirect URI host and as the auth-host (`/_oauth` callback lands here for every protected subdomain)."
+  type        = string
+}
+
+variable "cookie_domain" {
+  description = "Cookie scope. Set to the parent domain WITHOUT a leading dot (e.g. `example.com`) — traefik-forward-auth canonicalises this and emits cookies that cover every subdomain."
+  type        = string
+}
+
+variable "zitadel_org_name" {
+  description = "Zitadel org the project + app live under. Default matches the bootstrap ZITADEL org."
+  type        = string
+  default     = "ZITADEL"
+}
+
+variable "zitadel_provider_authenticated" {
+  description = "True when the root TF has been handed a non-empty `TF_VAR_zitadel_pat` for the Zitadel provider. False trips the precondition so the operator gets a clear error instead of an opaque provider 'unauthenticated' on apply."
+  type        = bool
+  default     = false
+}
+
+variable "memory_request" {
+  type    = string
+  default = "16Mi"
+}
+
+variable "memory_limit" {
+  type    = string
+  default = "64Mi"
+}
+
+variable "cpu_request" {
+  type    = string
+  default = "10m"
+}
+
+variable "cpu_limit" {
+  type    = string
+  default = "100m"
+}
+
+locals {
+  instances = var.enabled ? toset(["enabled"]) : toset([])
+
+  # Stable resource name; used for Service, Deployment, Secret, Middleware.
+  app_name = "forward-auth"
+}
+
+# ── Zitadel project + application ─────────────────────────────────────────────
+
+# Always read — counting on `var.enabled` would make `org_id` resolve
+# only at apply time and TF would mark every dependent resource as
+# "must replace" on every plan. Querying Zitadel with no resources to
+# create costs one round-trip on plan, that's the smaller evil.
+data "zitadel_orgs" "this" {
+  name        = var.zitadel_org_name
+  name_method = "TEXT_QUERY_METHOD_EQUALS"
+}
+
+resource "zitadel_project" "this" {
+  for_each = local.instances
+
+  org_id                   = data.zitadel_orgs.this.ids[0]
+  name                     = local.app_name
+  project_role_assertion   = false
+  project_role_check       = false
+  has_project_check        = false
+  private_labeling_setting = "PRIVATE_LABELING_SETTING_UNSPECIFIED"
+
+  lifecycle {
+    precondition {
+      condition     = var.zitadel_provider_authenticated
+      error_message = "forward-auth needs a Zitadel PAT. Bootstrap once: `kubectl get secret zitadel-tf-pat -n platform -o jsonpath='{.data.access_token}' | base64 -d`, paste it into `.env` as `TF_VAR_zitadel_pat=...`. See operating.md → 'Zitadel PAT bootstrap'."
+    }
+  }
+}
+
+resource "zitadel_application_oidc" "this" {
+  for_each = local.instances
+
+  org_id     = data.zitadel_orgs.this.ids[0]
+  project_id = zitadel_project.this["enabled"].id
+
+  name = local.app_name
+
+  # `/_oauth` is traefik-forward-auth's hard-coded callback path on the
+  # auth host (not `/oauth2/callback` like oauth2-proxy uses).
+  redirect_uris             = ["https://${var.auth_hostname}/_oauth"]
+  post_logout_redirect_uris = ["https://${var.auth_hostname}/"]
+
+  response_types   = ["OIDC_RESPONSE_TYPE_CODE"]
+  grant_types      = ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE", "OIDC_GRANT_TYPE_REFRESH_TOKEN"]
+  app_type         = "OIDC_APP_TYPE_WEB"
+  auth_method_type = "OIDC_AUTH_METHOD_TYPE_BASIC"
+  version          = "OIDC_VERSION_1_0"
+
+  dev_mode                    = false
+  access_token_type           = "OIDC_TOKEN_TYPE_BEARER"
+  access_token_role_assertion = false
+  id_token_role_assertion     = false
+  id_token_userinfo_assertion = false
+  clock_skew                  = "0s"
+}
+
+# ── Cookie + Secret ───────────────────────────────────────────────────────────
+
+# Cookie-signing key. traefik-forward-auth uses HMAC-SHA256, so any
+# 32+ char random is fine — pin to 32 deliberately.
+resource "random_password" "cookie_secret" {
+  for_each = local.instances
+
+  length  = 32
+  special = false
+}
+
+resource "kubernetes_secret_v1" "oauth2_proxy" {
+  for_each = local.instances
+
+  metadata {
+    name      = local.app_name
+    namespace = var.namespace
+  }
+
+  data = {
+    PROVIDERS_OIDC_CLIENT_ID     = zitadel_application_oidc.this["enabled"].client_id
+    PROVIDERS_OIDC_CLIENT_SECRET = zitadel_application_oidc.this["enabled"].client_secret
+    SECRET                       = random_password.cookie_secret["enabled"].result
+  }
+}
+
+# ── Deployment ────────────────────────────────────────────────────────────────
+
+resource "kubernetes_deployment_v1" "oauth2_proxy" {
+  for_each = local.instances
+
+  metadata {
+    name      = local.app_name
+    namespace = var.namespace
+    labels    = { app = local.app_name }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = { app = local.app_name }
+    }
+
+    template {
+      metadata {
+        labels = { app = local.app_name }
+      }
+
+      spec {
+        container {
+          name  = "forward-auth"
+          image = var.image
+
+          # All non-secret config via env. Secret env (CLIENT_ID, CLIENT_SECRET,
+          # SECRET) come from the Secret via env_from below.
+          env {
+            name  = "DEFAULT_PROVIDER"
+            value = "oidc"
+          }
+          env {
+            name  = "PROVIDERS_OIDC_ISSUER_URL"
+            value = var.issuer_url
+          }
+          env {
+            name  = "AUTH_HOST"
+            value = var.auth_hostname
+          }
+          env {
+            name  = "COOKIE_DOMAIN"
+            value = var.cookie_domain
+          }
+          env {
+            name  = "INSECURE_COOKIE"
+            value = "false"
+          }
+          env {
+            name  = "LOG_LEVEL"
+            value = "debug"
+          }
+          # Allow any email — auth controlled by Zitadel-side roles
+          # (operator can layer that in later via Zitadel's user mgmt).
+          env {
+            name  = "DEFAULT_ACTION"
+            value = "auth"
+          }
+
+          env_from {
+            secret_ref {
+              name = kubernetes_secret_v1.oauth2_proxy["enabled"].metadata[0].name
+            }
+          }
+
+          port {
+            container_port = 4181
+            name           = "http"
+            protocol       = "TCP"
+          }
+
+          resources {
+            requests = {
+              cpu    = var.cpu_request
+              memory = var.memory_request
+            }
+            limits = {
+              cpu    = var.cpu_limit
+              memory = var.memory_limit
+            }
+          }
+
+          # No HTTP probe — traefik-forward-auth doesn't expose a /healthz
+          # endpoint. Use TCP probe on the listener port.
+          startup_probe {
+            tcp_socket {
+              port = 4181
+            }
+            period_seconds    = 5
+            failure_threshold = 12
+          }
+
+          liveness_probe {
+            tcp_socket {
+              port = 4181
+            }
+            period_seconds    = 30
+            failure_threshold = 3
+          }
+
+          readiness_probe {
+            tcp_socket {
+              port = 4181
+            }
+            period_seconds    = 10
+            failure_threshold = 3
+          }
+        }
+      }
+    }
+  }
+}
+
+# ── Service ───────────────────────────────────────────────────────────────────
+
+resource "kubernetes_service_v1" "oauth2_proxy" {
+  for_each = local.instances
+
+  metadata {
+    name      = local.app_name
+    namespace = var.namespace
+    labels    = { app = local.app_name }
+  }
+
+  spec {
+    selector = { app = local.app_name }
+
+    port {
+      name        = "http"
+      port        = 4181
+      target_port = 4181
+      protocol    = "TCP"
+    }
+  }
+}
+
+# ── Traefik Middlewares ──────────────────────────────────────────────────────
+#
+# Two middlewares emitted in `ingress-controller`. Components with
+# `auth: zitadel` chain BOTH on their IngressRoute — the headers
+# middleware first, then the ForwardAuth.
+#
+# 1) `force-https-proto` — sets `X-Forwarded-Proto: https` on the
+#    request before the ForwardAuth sub-request fires. Required
+#    because Cloudflare Tunnel terminates TLS at the edge and
+#    cloudflared forwards plain HTTP into the cluster; Traefik
+#    doesn't trust the source for X-Forwarded-* headers, so it
+#    overwrites whatever cloudflared sent with its own derived
+#    `http` (the in-cluster connection scheme). Without the
+#    override, traefik-forward-auth's `redirectUri()` builds
+#    `redirect_uri=http://auth.<domain>/_oauth`, Zitadel rejects
+#    with "redirect_uri is missing in the client config" because
+#    the registered URI is HTTPS-only. The alternative was either
+#    to migrate every IR to the `websecure` entrypoint (breaks the
+#    HTTP-01 challenge path through the tunnel) or to enable
+#    `forwardedHeaders.insecure=true` on Traefik (touches shared
+#    addons-chart values). Surgical header injection is the local
+#    fix; the original-source-IP loss is acceptable inside a
+#    single-tenant home cluster.
+#
+# 2) `zitadel-auth` — the ForwardAuth middleware itself.
+#    traefik-forward-auth handles unauthenticated requests with a
+#    307 + Location response, which Traefik's ForwardAuth proxies
+#    untouched to the client; the browser follows to Zitadel.
+resource "kubectl_manifest" "middleware_proto" {
+  for_each = local.instances
+
+  yaml_body = yamlencode({
+    apiVersion = "traefik.io/v1alpha1"
+    kind       = "Middleware"
+    metadata = {
+      name      = "force-https-proto"
+      namespace = var.namespace
+    }
+    spec = {
+      headers = {
+        customRequestHeaders = {
+          "X-Forwarded-Proto" = "https"
+        }
+      }
+    }
+  })
+}
+
+resource "kubectl_manifest" "middleware_forward" {
+  for_each = local.instances
+
+  yaml_body = yamlencode({
+    apiVersion = "traefik.io/v1alpha1"
+    kind       = "Middleware"
+    metadata = {
+      name      = "zitadel-auth"
+      namespace = var.namespace
+    }
+    spec = {
+      forwardAuth = {
+        address            = "http://${kubernetes_service_v1.oauth2_proxy["enabled"].metadata[0].name}.${var.namespace}.svc.cluster.local:4181"
+        trustForwardHeader = true
+        authResponseHeaders = [
+          "X-Forwarded-User",
+        ]
+      }
+    }
+  })
+}
+
+# ── Outputs ───────────────────────────────────────────────────────────────────
+
+output "middleware_refs" {
+  description = "Ordered list of cross-namespace middleware refs an IngressRoute attaches under `spec.routes[].middlewares[]` for `auth: zitadel`. The order matters — `force-https-proto` rewrites `X-Forwarded-Proto: https` before the ForwardAuth sub-request fires, so traefik-forward-auth builds the correct `redirect_uri=https://auth...`. Null when the proxy is disabled (Zitadel off)."
+  value = var.enabled ? [
+    { name = "force-https-proto", namespace = var.namespace },
+    { name = "zitadel-auth", namespace = var.namespace },
+  ] : null
+}
+
+output "namespace" {
+  value = var.namespace
+}
+
+output "service_name" {
+  value = var.enabled ? kubernetes_service_v1.oauth2_proxy["enabled"].metadata[0].name : null
+}

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -112,6 +112,15 @@ variable "zitadel_provider_authenticated" {
   default     = false
 }
 
+variable "oauth2_proxy_middlewares" {
+  description = "Ordered list of cross-namespace Traefik Middleware refs (each `{name, namespace}`) the IngressRoute attaches under `spec.routes[].middlewares[]` for components with `auth: zitadel`. Order matters — the chain is applied head-first, so the `force-https-proto` headers middleware comes BEFORE the ForwardAuth so the latter sees the corrected `X-Forwarded-Proto`. Null when oauth2-proxy is disabled (Zitadel off)."
+  type = list(object({
+    name      = string
+    namespace = string
+  }))
+  default = null
+}
+
 variable "volume_base_path" {
   description = "Parent path used verbatim by hostPath PersistentVolumes for every component in this project. Must resolve to a real writable directory from the kubelet's point of view. Forwarded unchanged to modules/component."
   type        = string
@@ -279,6 +288,17 @@ locals {
     name => c if try(c.basic_auth, false)
   }
 
+  # Components that opt into the cluster-wide oauth2-proxy auth gate
+  # (`auth: zitadel` in the component yaml). The IngressRoute attaches
+  # the cross-namespace ForwardAuth middleware emitted by the
+  # `oauth2-proxy` root module. Empty when no component asks for it,
+  # OR when the operator left Zitadel off — the precondition below
+  # rejects `auth: zitadel` on a Zitadel-less platform up front.
+  zitadel_auth_components = {
+    for name, c in local.normalized_components :
+    name => c if try(c.auth, "") == "zitadel"
+  }
+
   # Components that declare `env_random: [VAR_1, VAR_2, ...]` in their
   # yaml. Every listed env name gets a random 32-char value terraform
   # owns and persists in state, injected into the container via a
@@ -369,6 +389,13 @@ check "ollama_enabled_when_needed" {
   assert {
     condition     = !local.needs_ollama || var.ollama_url != null
     error_message = "project '${local.namespace}' has a component with `ollama: true` but `services.ollama` is disabled in config/platform.yaml. Either enable Ollama or drop `ollama: true` from the component spec."
+  }
+}
+
+check "oauth2_proxy_available_when_zitadel_auth_used" {
+  assert {
+    condition     = length(local.zitadel_auth_components) == 0 || (var.oauth2_proxy_middlewares != null && length(var.oauth2_proxy_middlewares) > 0)
+    error_message = "project '${local.namespace}' has at least one component with `auth: zitadel` (${join(", ", keys(local.zitadel_auth_components))}) but the cluster-wide oauth2-proxy is not deployed — that gate is gated on `services.zitadel.enabled`. Either turn Zitadel on, or drop the `auth: zitadel` knob."
   }
 }
 
@@ -1026,8 +1053,21 @@ resource "kubectl_manifest" "ingressroute" {
             kind     = "Rule"
             services = [local.ir_service_refs[each.key]]
           },
-          contains(keys(local.basic_auth_components), each.key)
-          ? { middlewares = [{ name = "${each.key}-basic-auth" }] }
+          # Compose the middleware list from two opt-in sources:
+          # `basic_auth: true` (per-component, in-namespace middleware)
+          # and `auth: zitadel` (cross-namespace forward-auth → oauth2-
+          # proxy in `ingress-controller`). They can stack in principle,
+          # though the typical case is one or the other.
+          length(concat(
+            contains(keys(local.basic_auth_components), each.key) ? [{ name = "${each.key}-basic-auth" }] : [],
+            contains(keys(local.zitadel_auth_components), each.key) ? var.oauth2_proxy_middlewares : [],
+          )) > 0
+          ? {
+            middlewares = concat(
+              contains(keys(local.basic_auth_components), each.key) ? [{ name = "${each.key}-basic-auth" }] : [],
+              contains(keys(local.zitadel_auth_components), each.key) ? var.oauth2_proxy_middlewares : [],
+            )
+          }
           : {}
         )]
       },

--- a/modules/roundcube/main.tf
+++ b/modules/roundcube/main.tf
@@ -1,0 +1,547 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.14"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    zitadel = {
+      source  = "zitadel/zitadel"
+      version = "~> 2.9"
+    }
+  }
+}
+
+# =============================================================================
+# Roundcube webmail — Zitadel-OIDC-only auth via XOAUTH2
+# =============================================================================
+#
+# Roundcube fronts the actual mailbox UI at the root of mail.<domain>.
+# Authentication is exclusively OIDC (Zitadel): the user clicks "Sign
+# in with Zitadel", PKCE auth-code flow runs, Roundcube receives an
+# access_token, then opens IMAP/SMTP to Stalwart with SASL XOAUTH2 +
+# the same access_token. Stalwart's Oidc directory validates the
+# token (issuer/aud + claim_email) and auto-provisions the
+# UserAccount on first login. No app passwords, no internal
+# directory, no manual provisioning.
+
+variable "enabled" {
+  type    = bool
+  default = true
+}
+
+variable "namespace" {
+  type = string
+}
+
+variable "hostname" {
+  description = "Public hostname Roundcube is reachable at (the same one Stalwart uses; Roundcube serves root, Stalwart admin lives at /admin and /account)."
+  type        = string
+}
+
+variable "volume_base_path" {
+  description = "Root directory on the host node for Roundcube's preferences SQLite DB."
+  type        = string
+}
+
+variable "image" {
+  description = "Roundcube container image. The Apache flavour is used because the upstream image bakes a working PHP+Apache config; the alpine-fpm flavour needs an extra fpm/nginx pair."
+  type        = string
+  default     = "roundcube/roundcubemail:1.6.10-apache"
+}
+
+variable "imap_host" {
+  description = "In-cluster Stalwart IMAP service host. TLS on port 993 (`tls://...`)."
+  type        = string
+  default     = "stalwart.mail.svc.cluster.local"
+}
+
+variable "imap_port" {
+  type    = number
+  default = 993
+}
+
+variable "smtp_host" {
+  description = "In-cluster Stalwart submission service host. TLS on port 465 (`ssl://...`)."
+  type        = string
+  default     = "stalwart.mail.svc.cluster.local"
+}
+
+variable "smtp_port" {
+  type    = number
+  default = 465
+}
+
+variable "zitadel_org_id" {
+  type    = string
+  default = ""
+}
+
+variable "zitadel_issuer_url" {
+  type    = string
+  default = ""
+}
+
+variable "zitadel_provider_authenticated" {
+  type    = bool
+  default = false
+}
+
+variable "zitadel_project_id" {
+  description = "Existing Zitadel project this Roundcube OIDC app lands under. Reusing the Stalwart-tenant project keeps role grants in one place."
+  type        = string
+  default     = ""
+}
+
+variable "memory_request" {
+  type    = string
+  default = "128Mi"
+}
+
+variable "memory_limit" {
+  type    = string
+  default = "512Mi"
+}
+
+variable "cpu_request" {
+  type    = string
+  default = "20m"
+}
+
+variable "cpu_limit" {
+  type    = string
+  default = "500m"
+}
+
+locals {
+  enabled         = var.enabled
+  oidc_enabled    = var.enabled && var.zitadel_issuer_url != "" && var.zitadel_org_id != "" && var.zitadel_project_id != ""
+  instance_set    = local.enabled ? toset(["enabled"]) : toset([])
+  oidc_set        = local.oidc_enabled ? toset(["enabled"]) : toset([])
+  client_id       = local.oidc_enabled ? zitadel_application_oidc.roundcube["enabled"].client_id : ""
+  client_secret   = local.oidc_enabled ? zitadel_application_oidc.roundcube["enabled"].client_secret : ""
+  config_inc_hash = sha256(local.config_inc_php)
+
+  # Roundcube `config.inc.php` rendered from TF. Three concerns:
+  # 1. IMAP/SMTP point at Stalwart in-cluster (TLS, self-signed
+  #    cert ignored — the cluster boundary is the trust boundary).
+  # 2. oauth2 plugin enabled with the Zitadel issuer URL — Roundcube
+  #    uses OIDC discovery to find authorize/token/userinfo.
+  # 3. `oauth_scope` includes `offline_access` so Roundcube can
+  #    refresh the token without bouncing the user back to Zitadel
+  #    every hour.
+  config_inc_php = <<-EOT
+    <?php
+    // Managed by terraform — modules/roundcube/main.tf. Edits here are
+    // overwritten on every `./tf apply`.
+
+    $config = [];
+
+    $config['db_dsnw']  = 'sqlite:////var/roundcube/db/sqlite.db?mode=0640';
+
+    $config['imap_host']     = 'ssl://${var.imap_host}:${var.imap_port}';
+    $config['smtp_host']     = 'ssl://${var.smtp_host}:${var.smtp_port}';
+    $config['smtp_user']     = '%u';
+    $config['smtp_pass']     = '%p';
+
+    // Cluster-internal TLS — Stalwart listener uses k8s-issued cert
+    // (or self-signed); peer verification disabled because cluster
+    // is the trust boundary.
+    $config['imap_conn_options'] = ['ssl' => ['verify_peer' => false, 'verify_peer_name' => false]];
+    $config['smtp_conn_options'] = ['ssl' => ['verify_peer' => false, 'verify_peer_name' => false]];
+
+    $config['support_url'] = '';
+    $config['product_name'] = 'Mail';
+    $config['skin'] = 'elastic';
+    $config['language'] = 'en_US';
+
+    $config['session_lifetime'] = 30;
+    $config['ip_check'] = false;
+    $config['enable_installer'] = false;
+
+    // Encrypts session-stored OAuth tokens at rest. Random per-deploy
+    // — see `random_password.des_key` in the module.
+    $config['des_key'] = getenv('ROUNDCUBE_DES_KEY');
+
+    // OAuth2 / OIDC support is a CORE feature in Roundcube 1.5+ —
+    // not a plugin. The `oauth_*` directives below activate it; no
+    // entry in $config['plugins'] is needed.
+    $config['plugins'] = [];
+
+    // OIDC client config — Zitadel-managed confidential application
+    // with a client secret. Roundcube 1.6 oauth2 hard-requires the
+    // secret in the token-exchange request; PKCE-only public clients
+    // (auth_method_type=NONE) trigger an infinite redirect loop. The
+    // secret is rendered into the ConfigMap directly here for
+    // simplicity — fine while it's the only consumer in the namespace
+    // and the cluster boundary is the trust boundary; long-term move
+    // to an env-var sourced from a Secret.
+    $config['oauth_provider']        = 'generic';
+    $config['oauth_provider_name']   = 'Zitadel';
+    $config['oauth_client_id']       = '${local.client_id}';
+    // Sourced from the `roundcube-secrets` k8s Secret via env var so
+    // the live secret value never lands inside the ConfigMap. This
+    // also avoids a sensitive-data drift issue where Terraform stops
+    // rendering ConfigMap updates when the embedded sensitive string
+    // changes — env-var injection picks up the latest Secret on
+    // every pod start without ConfigMap re-render.
+    $config['oauth_client_secret']   = getenv('ROUNDCUBE_OAUTH_CLIENT_SECRET');
+    $config['oauth_auth_uri']        = '${var.zitadel_issuer_url}/oauth/v2/authorize';
+    $config['oauth_token_uri']       = '${var.zitadel_issuer_url}/oauth/v2/token';
+    $config['oauth_identity_uri']    = '${var.zitadel_issuer_url}/oidc/v1/userinfo';
+    $config['oauth_logout_uri']      = '${var.zitadel_issuer_url}/oidc/v1/end_session';
+    $config['oauth_scope']           = 'openid email profile offline_access';
+    $config['oauth_identity_fields'] = ['email'];
+    $config['oauth_login_redirect']  = true;
+
+    // Behind Cloudflare Tunnel + Traefik. cloudflared sends HTTP to
+    // Traefik on port 80; Traefik forwards to Roundcube as HTTP.
+    // Roundcube needs to know the *external* scheme to build correct
+    // redirect URIs back to Zitadel.
+    $config['use_https']    = true;
+    $config['force_https']  = false; // upstream already terminated TLS
+    $config['proxy_whitelist'] = ['*'];
+    $config['trusted_host_patterns'] = ['${replace(var.hostname, ".", "\\\\.")}'];
+
+  EOT
+}
+
+# ── Zitadel project + application — Roundcube as PKCE OIDC client ─────────────
+resource "zitadel_application_oidc" "roundcube" {
+  for_each = local.oidc_set
+
+  org_id     = var.zitadel_org_id
+  project_id = var.zitadel_project_id
+
+  name = "roundcube-webmail"
+
+  redirect_uris = [
+    "https://${var.hostname}/index.php/login/oauth",
+  ]
+  post_logout_redirect_uris = [
+    "https://${var.hostname}/?_task=logout",
+  ]
+
+  response_types = ["OIDC_RESPONSE_TYPE_CODE"]
+  grant_types    = ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE", "OIDC_GRANT_TYPE_REFRESH_TOKEN"]
+  app_type       = "OIDC_APP_TYPE_WEB"
+  # BASIC, despite Roundcube wire-shape being `client_secret_post`.
+  # Reason: Zitadel's TF provider only exports a populated
+  # `client_secret` attribute when this is BASIC; POST and NONE come
+  # back empty (provider issue or design — verified empirically by
+  # comparing the four OIDC apps in this state). Most OIDC servers
+  # (Zitadel included) accept BOTH client_secret_basic and
+  # client_secret_post for confidential clients regardless of the
+  # registered method, so a Roundcube-style form-body submission
+  # against a BASIC-registered Zitadel app validates fine.
+  auth_method_type = "OIDC_AUTH_METHOD_TYPE_BASIC"
+  version          = "OIDC_VERSION_1_0"
+
+  dev_mode                    = false
+  access_token_type           = "OIDC_TOKEN_TYPE_JWT"
+  access_token_role_assertion = true
+  id_token_role_assertion     = true
+  id_token_userinfo_assertion = true
+  clock_skew                  = "0s"
+
+  lifecycle {
+    precondition {
+      condition     = var.zitadel_provider_authenticated
+      error_message = "Roundcube OIDC needs the Zitadel TF provider authenticated. See operating.md → 'Zitadel PAT bootstrap'."
+    }
+  }
+}
+
+# ── Per-deploy DES key for Roundcube session token encryption ─────────────────
+resource "random_password" "des_key" {
+  for_each = local.instance_set
+  length   = 32
+  special  = false
+}
+
+resource "kubernetes_secret_v1" "roundcube_secrets" {
+  for_each = local.instance_set
+
+  metadata {
+    name      = "roundcube-secrets"
+    namespace = var.namespace
+    labels    = { app = "roundcube" }
+  }
+
+  data = {
+    des_key             = random_password.des_key["enabled"].result
+    oauth_client_secret = local.client_secret
+  }
+}
+
+# ── ConfigMap with config.inc.php ─────────────────────────────────────────────
+resource "kubernetes_config_map_v1" "roundcube_config" {
+  for_each = local.instance_set
+
+  metadata {
+    name      = "roundcube-config"
+    namespace = var.namespace
+    labels    = { app = "roundcube" }
+  }
+
+  data = {
+    "config.inc.php" = local.config_inc_php
+  }
+}
+
+# ── Persistent volume for the SQLite preferences DB ───────────────────────────
+resource "kubernetes_persistent_volume_v1" "roundcube" {
+  for_each = local.instance_set
+
+  metadata {
+    name = "roundcube-db"
+    labels = {
+      "app.kubernetes.io/name"    = "roundcube"
+      "app.kubernetes.io/part-of" = "platform"
+    }
+  }
+
+  spec {
+    capacity = { storage = "1Gi" }
+
+    access_modes = ["ReadWriteOnce"]
+    # `standard` matches what the Stalwart PV uses on this k3s cluster
+    # — k3s ships `local-path` as the cluster-default StorageClass and
+    # any PVC without an explicit class gets it stamped on by the
+    # admission plugin. An empty class on the PV then mismatches the
+    # `local-path` PVC and binding fails with `storageClassName does
+    # not match`. Naming a non-default class on both sides ("standard"
+    # is conventional and unused) opts out of the default-class
+    # injection so the static binding works.
+    storage_class_name               = "standard"
+    persistent_volume_reclaim_policy = "Retain"
+    volume_mode                      = "Filesystem"
+
+    persistent_volume_source {
+      host_path {
+        path = "${var.volume_base_path}/${var.namespace}/roundcube"
+        type = "DirectoryOrCreate"
+      }
+    }
+  }
+}
+
+resource "kubernetes_persistent_volume_claim_v1" "roundcube" {
+  for_each = local.instance_set
+
+  metadata {
+    name      = "roundcube-db"
+    namespace = var.namespace
+    labels    = { app = "roundcube" }
+  }
+
+  spec {
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = "standard"
+    volume_name        = kubernetes_persistent_volume_v1.roundcube["enabled"].metadata[0].name
+
+    resources {
+      requests = { storage = "1Gi" }
+    }
+  }
+}
+
+# ── Service ───────────────────────────────────────────────────────────────────
+resource "kubernetes_service_v1" "roundcube" {
+  for_each = local.instance_set
+
+  metadata {
+    name      = "roundcube"
+    namespace = var.namespace
+    labels    = { app = "roundcube" }
+  }
+
+  spec {
+    selector = { app = "roundcube" }
+
+    port {
+      name        = "http"
+      port        = 80
+      target_port = 80
+      protocol    = "TCP"
+    }
+  }
+}
+
+# ── Deployment ────────────────────────────────────────────────────────────────
+resource "kubernetes_deployment_v1" "roundcube" {
+  for_each = local.instance_set
+
+  metadata {
+    name      = "roundcube"
+    namespace = var.namespace
+    labels    = { app = "roundcube" }
+
+    annotations = {
+      "platform.local/config-hash" = local.config_inc_hash
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    strategy { type = "Recreate" }
+
+    selector {
+      match_labels = { app = "roundcube" }
+    }
+
+    template {
+      metadata {
+        labels = { app = "roundcube" }
+        annotations = {
+          "platform.local/config-hash" = local.config_inc_hash
+        }
+      }
+
+      spec {
+        # hostPath volumes mount with the host directory's existing
+        # ownership (root:root in our case). Roundcube's apache process
+        # runs as www-data (uid 33) and the SQLite file lives in
+        # /var/roundcube/db; without an explicit chown the main container
+        # cannot create sqlite.db and every page fails with
+        # `SQLSTATE[HY000] [14] unable to open database file`. The init
+        # container fixes ownership once at pod start.
+        init_container {
+          name    = "fix-db-perms"
+          image   = "busybox:1.36"
+          command = ["sh", "-c", "chown -R 33:33 /var/roundcube/db"]
+
+          volume_mount {
+            name       = "db"
+            mount_path = "/var/roundcube/db"
+          }
+
+          security_context {
+            run_as_user = 0
+          }
+
+          resources {
+            requests = { cpu = "10m", memory = "8Mi" }
+            limits   = { cpu = "100m", memory = "32Mi" }
+          }
+        }
+
+        container {
+          name  = "roundcube"
+          image = var.image
+
+          # Upstream image reads /var/roundcube/config/*.inc.php as
+          # additional config (merged after defaults). Mounting our
+          # config.inc.php there lets us drive everything declaratively
+          # without any image rebuild or env-var translation layer.
+          volume_mount {
+            name       = "config"
+            mount_path = "/var/roundcube/config/config.inc.php"
+            sub_path   = "config.inc.php"
+            read_only  = true
+          }
+
+          # SQLite DB lives in a persistent volume so user prefs,
+          # contacts, and the cached IMAP folder list survive pod
+          # restarts.
+          volume_mount {
+            name       = "db"
+            mount_path = "/var/roundcube/db"
+          }
+
+          env {
+            name = "ROUNDCUBE_DES_KEY"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret_v1.roundcube_secrets["enabled"].metadata[0].name
+                key  = "des_key"
+              }
+            }
+          }
+
+          env {
+            name = "ROUNDCUBE_OAUTH_CLIENT_SECRET"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret_v1.roundcube_secrets["enabled"].metadata[0].name
+                key  = "oauth_client_secret"
+              }
+            }
+          }
+
+          # Defaults so the upstream image's bootstrap script doesn't
+          # try to rewrite our config (it skips its own template when
+          # these are unset and a user-supplied config.inc.php exists).
+          env {
+            name  = "ROUNDCUBEMAIL_DB_TYPE"
+            value = "sqlite"
+          }
+
+          port {
+            container_port = 80
+            protocol       = "TCP"
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/"
+              port = 80
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 5
+          }
+
+          resources {
+            requests = {
+              cpu    = var.cpu_request
+              memory = var.memory_request
+            }
+            limits = {
+              cpu    = var.cpu_limit
+              memory = var.memory_limit
+            }
+          }
+        }
+
+        volume {
+          name = "config"
+          config_map {
+            name = kubernetes_config_map_v1.roundcube_config["enabled"].metadata[0].name
+            items {
+              key  = "config.inc.php"
+              path = "config.inc.php"
+            }
+          }
+        }
+
+        volume {
+          name = "db"
+          persistent_volume_claim {
+            claim_name = kubernetes_persistent_volume_claim_v1.roundcube["enabled"].metadata[0].name
+          }
+        }
+      }
+    }
+  }
+}
+
+# ── Outputs ───────────────────────────────────────────────────────────────────
+output "service_name" {
+  value = var.enabled ? kubernetes_service_v1.roundcube["enabled"].metadata[0].name : null
+}
+
+output "namespace" {
+  value = var.namespace
+}
+
+output "zitadel_application_oidc_id" {
+  value = local.oidc_enabled ? zitadel_application_oidc.roundcube["enabled"].id : null
+}

--- a/modules/stalwart/main.tf
+++ b/modules/stalwart/main.tf
@@ -1,0 +1,1549 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.14"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = "~> 4.0"
+    }
+    cloudflare = {
+      source  = "cloudflare/cloudflare"
+      version = "~> 4.0"
+    }
+    zitadel = {
+      source  = "zitadel/zitadel"
+      version = "~> 2.9"
+    }
+  }
+}
+
+# =============================================================================
+# Stalwart 0.16 — declarative deployment via stalwart-cli apply
+# =============================================================================
+#
+# 0.16 dropped TOML config. On disk lives only `config.json` (datastore
+# definition); everything else (listeners, directories, accounts, OIDC)
+# lives in the database and is loaded via `stalwart-cli apply` against
+# the running server's JMAP API. Workflow:
+#
+#   1. ConfigMap renders config.json + plan.ndjson from TF templates.
+#   2. Init container `bootstrap` writes config.json into the data PV
+#      (idempotent), downloads stalwart-cli + the WebUI bundle, patches
+#      the bundle's hard-coded `stalwart-webui` OAuth client_id with
+#      our Zitadel application's client_id, places the patched zip on
+#      a shared emptyDir.
+#   3. Main container starts stalwart with STALWART_RECOVERY_ADMIN
+#      pinned (env-var, doubles as fallback admin).
+#   4. Sidecar `applier` (init container with restartPolicy: Always)
+#      waits for :8080 ready and runs `stalwart-cli apply`. The plan
+#      starts with destroy ops for the objects we own, then creates —
+#      so re-running it (every pod restart) is idempotent.
+#
+# WebUI client_id obstacle — Stalwart's WebUI bundle bakes
+# `stalwart-webui` literally at Vite build time. Zitadel auto-
+# generates numeric client_ids and won't accept a literal one.
+# Workaround: sed-replace the literal in the unpacked bundle JS,
+# repackage, point Stalwart's Application.resource_url at file://
+# instead of the upstream URL.
+
+variable "enabled" {
+  description = "Deploy the Stalwart mail server. When false, no resources are created."
+  type        = bool
+  default     = true
+}
+
+variable "namespace" {
+  description = "Namespace the mail Deployment lives in. Expected to exist already — created by root-level mail.tf alongside its ResourceQuota."
+  type        = string
+  default     = null
+}
+
+variable "volume_base_path" {
+  description = "Parent path used verbatim by the hostPath PV. Stalwart's data + config + bootstrap state land at <volume_base_path>/<namespace>/stalwart/. Survives ./tf bootstrap-k3s on purpose — losing this dir wipes mailboxes, DKIM keys, and the bootstrap admin record."
+  type        = string
+  default     = "/data/vol"
+}
+
+variable "image" {
+  description = "Stalwart server container image. Repo changed from stalwartlabs/mail-server to stalwartlabs/stalwart at 0.16. Pin a specific tag — `latest` would silently pull schema changes between restarts."
+  type        = string
+  default     = "stalwartlabs/stalwart:v0.16.3"
+}
+
+variable "cli_url" {
+  description = "URL of the stalwart-cli linux-x86_64 tarball. The CLI is a separate release from stalwartlabs/cli; not bundled in the server image. Init container downloads + extracts to a shared emptyDir."
+  type        = string
+  default     = "https://github.com/stalwartlabs/cli/releases/download/v1.0.4/stalwart-cli-x86_64-unknown-linux-musl.tar.xz"
+}
+
+variable "webui_url" {
+  description = "URL of the upstream Stalwart WebUI bundle. Pinned to the version that ships with the server image — stale bundles drift the API contract. The init container downloads, sed-patches the OAuth client_id, repackages, and Stalwart's Application is pointed at the local file."
+  type        = string
+  default     = "https://github.com/stalwartlabs/webui/releases/download/v1.0.2/webui.zip"
+}
+
+variable "smtp_relay_listen_ip" {
+  description = "Host IP the SMTP relay forwarder binds to. Specific by design — wants to be reachable from the public-relay tunnel, NOT from the LAN, so this should be the WireGuard interface address (not 0.0.0.0)."
+  type        = string
+  default     = "10.23.0.2"
+}
+
+variable "hostname" {
+  description = "Public hostname Stalwart announces in SMTP banners and signs DKIM with. Should match the relay's reverse DNS — Gmail rejects mismatches."
+  type        = string
+  default     = "mail.ipsupport.us"
+}
+
+variable "primary_domain" {
+  description = "Default mail domain bootstrapped into Stalwart. Used as defaultDomainId on SystemSettings and as the domain Zitadel-OIDC users are auto-provisioned under."
+  type        = string
+  default     = "ipsupport.us"
+}
+
+variable "zitadel_org_id" {
+  description = "Zitadel organisation ID the OIDC application + role land in. Pulled from the parent module's data \"zitadel_orgs\" lookup."
+  type        = string
+  default     = ""
+}
+
+variable "zitadel_issuer_url" {
+  description = "Zitadel public issuer URL (e.g. https://id.example.com). Used by Stalwart's OIDC directory to validate user-presented tokens via /userinfo. Empty string disables OIDC bootstrap (recovery-admin still works)."
+  type        = string
+  default     = ""
+}
+
+variable "zitadel_provider_authenticated" {
+  description = "True when the root TF has been handed a non-empty TF_VAR_zitadel_pat for the Zitadel provider. False trips the precondition with a clear error instead of an opaque provider 'unauthenticated' on apply."
+  type        = bool
+  default     = false
+}
+
+variable "smarthost_address" {
+  description = "Hostname or IP of the outbound SMTP relay. Empty string keeps the default `mx` route (direct MX delivery); set to a relay address (e.g. the WireGuard IP of the public Postfix relay VPS, or `relay.ipsupport.us`) to push every non-local message through it. Residential ISPs and Cloudflare Tunnel both block outbound :25 — without a smart host the queue spools forever and bounces. The relay must be configured to accept mail from this Stalwart's outgoing IP (typically by static IP / WG peer ACL) and to handle SPF/DKIM signing on the public side."
+  type        = string
+  default     = ""
+}
+
+variable "smarthost_port" {
+  description = "Port of the outbound SMTP relay. 25 for plain SMTP relay over a trusted network (WireGuard), 465 for implicit TLS submission, 587 for STARTTLS submission with auth."
+  type        = number
+  default     = 25
+}
+
+variable "smarthost_implicit_tls" {
+  description = "Use TLS for every connection to the smart host (port 465 style)."
+  type        = bool
+  default     = false
+}
+
+variable "smarthost_allow_invalid_certs" {
+  description = "Skip TLS certificate validation when connecting to the smart host. Only flip on for relays presenting a self-signed cert on a trusted network — the public-relay VPS uses a real cert."
+  type        = bool
+  default     = false
+}
+
+variable "smarthost_username" {
+  description = "Optional SMTP AUTH username for the smart host. Empty string skips AUTH (the relay must accept by source IP)."
+  type        = string
+  default     = ""
+}
+
+variable "smarthost_password" {
+  description = "SMTP AUTH password matching `smarthost_username`. Sensitive — pass via TF_VAR_smarthost_password in `.env`. Ignored when `smarthost_username` is empty."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "admin_role_name" {
+  description = "Name of the Zitadel project role that grants Stalwart admin access. The same string is also the name of the Stalwart Group whose membership carries the admin role — Zitadel emits `groups: [\"<role>\"]` in the id_token claim and the OIDC user auto-joins that group on login."
+  type        = string
+  default     = "mail-admin"
+}
+
+variable "cloudflare_zone_id" {
+  description = "Cloudflare zone ID of the primary mail domain. Module emits SPF/DKIM/DMARC TXT records directly into the zone — no manual yaml paste."
+  type        = string
+  default     = ""
+}
+
+variable "spf_authorized_ip" {
+  description = "IPv4 (or `ip4:x ip4:y` chain) authorised to send mail for the primary domain. Defaults to the public Postfix relay IP — every outbound message exits there."
+  type        = string
+  default     = "130.51.23.250"
+}
+
+variable "dmarc_policy" {
+  description = "DMARC policy directive. `quarantine` (move-to-spam on failure) for break-in; tighten to `reject` after a couple of weeks of clean aggregate reports."
+  type        = string
+  default     = "quarantine"
+}
+
+variable "dkim_selector" {
+  description = "DKIM selector — the DNS label `<selector>._domainkey.<domain>` where the public key is published. Stable; rotating means generating a new key under a new selector and dual-signing through the cutover."
+  type        = string
+  default     = "stalwart"
+}
+
+variable "user_role_name" {
+  description = "Name of the Zitadel project role that grants ordinary mailbox access. Required for any user who should be able to log into Roundcube — the Zitadel project gate (`project_role_check = true`) rejects users without a project-role, so absent this grant a Zitadel org member cannot reach the mail UI at all."
+  type        = string
+  default     = "mail-user"
+}
+
+variable "memory_request" {
+  description = "Memory request for the Stalwart container. Idle Stalwart is ~50Mi; the request just keeps the kubelet from evicting under host pressure."
+  type        = string
+  default     = "128Mi"
+}
+
+variable "memory_limit" {
+  description = "Memory limit for the Stalwart container. SQLite + a small mailbox set fits under 512Mi comfortably; bump if many tenants or large mailboxes show up."
+  type        = string
+  default     = "768Mi"
+}
+
+variable "cpu_request" {
+  description = "CPU request for the Stalwart container. Idle is near-zero; this is the floor the scheduler reserves."
+  type        = string
+  default     = "50m"
+}
+
+variable "cpu_limit" {
+  description = "CPU limit for the Stalwart container. Burst headroom for SMTP/JMAP spikes and DKIM signing — sustained usage is well below this."
+  type        = string
+  default     = "500m"
+}
+
+locals {
+  instances = var.enabled ? toset(["enabled"]) : toset([])
+
+  # Match Stalwart's auto-bootstrapped default listeners — saves the
+  # plan from having to manage NetworkListener objects (which is
+  # awkward because destroying the http listener mid-apply would
+  # kill the very connection the CLI is using). The pod gets
+  # NET_BIND_SERVICE so uid 1000 can bind :25 directly.
+  smtp_target = 25
+  http_target = 8080
+
+  # Whether to provision the Zitadel app + role + OIDC directory.
+  # Off when zitadel_issuer_url is empty (Zitadel disabled at the
+  # platform root); recovery-admin still works for WebUI access.
+  oidc_enabled = var.enabled && var.zitadel_issuer_url != "" && var.zitadel_org_id != ""
+  oidc_set     = local.oidc_enabled ? toset(["enabled"]) : toset([])
+
+  # Random URL prefix that hides /admin and /account behind
+  # obscurity. `mail.<domain>/<prefix>/admin` is the operator path;
+  # `/<prefix>/account` is self-service (mostly empty for OIDC users
+  # since password lives in Zitadel). Surfaced to the operator via
+  # the `admin_url` / `account_url` outputs and the root cheatsheet.
+  admin_path_prefix = var.enabled ? "/${random_password.admin_path["enabled"].result}" : ""
+  webui_admin_url   = var.enabled ? "https://${var.hostname}${local.admin_path_prefix}/admin" : null
+  webui_account_url = var.enabled ? "https://${var.hostname}${local.admin_path_prefix}/account" : null
+  webui_url_prefixes = local.admin_path_prefix == "" ? {} : {
+    "${local.admin_path_prefix}/admin"   = true
+    "${local.admin_path_prefix}/account" = true
+  }
+
+  # DKIM key + DNS body. tls_private_key.public_key_pem is X.509
+  # SubjectPublicKeyInfo PEM; DKIM TXT for k=rsa wants the
+  # base64 of that SPKI body (between BEGIN/END headers, newlines
+  # stripped). DNS record: `<selector>._domainkey.<domain>` TXT =
+  # "v=DKIM1; k=rsa; p=<body>".
+  dkim_pubkey_body = var.enabled ? trimspace(replace(replace(replace(
+    tls_private_key.dkim["enabled"].public_key_pem,
+    "-----BEGIN PUBLIC KEY-----", ""),
+    "-----END PUBLIC KEY-----", ""),
+  "\n", "")) : ""
+  dkim_dns_value = var.enabled ? "v=DKIM1; k=rsa; p=${local.dkim_pubkey_body}" : ""
+  dkim_dns_name  = "${var.dkim_selector}._domainkey"
+
+  spf_dns_value   = var.enabled ? "v=spf1 ip4:${var.spf_authorized_ip} -all" : ""
+  dmarc_dns_value = var.enabled ? "v=DMARC1; p=${var.dmarc_policy}; rua=mailto:postmaster@${var.primary_domain}" : ""
+
+  # Whether the module manages SPF/DKIM/DMARC TXT records directly
+  # in Cloudflare (bypassing the per-domain yaml). Off when the
+  # operator hasn't passed a zone id — keeps the module usable for
+  # standalone testing without a Cloudflare zone.
+  dns_records_enabled = var.enabled && var.cloudflare_zone_id != ""
+  dns_records_set     = local.dns_records_enabled ? toset(["enabled"]) : toset([])
+
+  # Whether to wire an outbound smart-host. Off (empty address) keeps
+  # Stalwart on its default direct-MX route — which silently bounces
+  # in this deployment because residential ISPs and Cloudflare Tunnel
+  # both block outbound :25. With the relay configured, the queue
+  # delivers via the relay's public IP + DKIM/SPF.
+  smarthost_enabled = var.enabled && var.smarthost_address != ""
+
+  # config.json is a single DataStore object — `@type` discriminator
+  # picks the backend. 0.16 simplified the on-disk file to just this
+  # one object; everything else (BlobStore, InMemoryStore, listeners,
+  # directories, ...) is reachable as JMAP objects in the DB once
+  # the datastore is loaded. SQLite path is a directory; Stalwart
+  # creates the actual db files inside.
+  config_json = jsonencode({
+    "@type" = "Sqlite"
+    # `path` is the actual SQLite file path — passed straight to
+    # `rusqlite::Connection::open`. The docs use the word
+    # "directory" but the code (`SqliteConnectionManager::file(path)`)
+    # treats it as a file. The parent dir is created in the
+    # bootstrap initContainer.
+    path = "/opt/stalwart-mail/data/db.sqlite3"
+  })
+
+  # The OIDC client_id Zitadel auto-generated for the WebUI app.
+  # Empty string when OIDC is off (the bundle will keep its default
+  # `stalwart-webui` literal — works only against Stalwart-as-IDP).
+  webui_client_id = local.oidc_enabled ? zitadel_application_oidc.stalwart["enabled"].client_id : "stalwart-webui"
+
+  # Zitadel issues access tokens with `aud` set to the project_id, not
+  # the client_id. Stalwart's `requireAudience` field is checked
+  # against the `aud` claim — using the project_id here makes
+  # validation pass. (`<client_id>` would mismatch.)
+  webui_aud = local.oidc_enabled ? zitadel_project.stalwart["enabled"].id : ""
+
+  # Plan rendered as NDJSON. Two-pass execution: destroys reverse
+  # then creates/updates forward. Re-running the same plan on
+  # restart is idempotent because the filtered destroys wipe the
+  # objects we own (matched by description / name) before the
+  # creates rebuild them. Update ops on singletons (SystemSettings,
+  # Authentication, Http) are idempotent by definition.
+  #
+  # NetworkListener is intentionally NOT in the plan: the apply runs
+  # against http://127.0.0.1:8080, which is one of Stalwart's
+  # auto-bootstrapped default listeners. Destroying it mid-apply
+  # would kill the very connection the CLI is using. Stalwart's
+  # defaults (smtp 25, http 8080, plus 465/993/995/4190/443 that
+  # bind iff NET_BIND_SERVICE is granted to the pod) cover what we
+  # need; the Service routes :25 and :8080 outward.
+  plan_lines = concat(
+    # ── Destroy pass (filtered to objects we own) ─────────────────
+    # Each object kind exposes a different set of filterable fields
+    # (Stalwart's JMAP query callbacks register them per type) and
+    # rejects unknown filter properties at parse time. Empirically:
+    #   - Domain accepts `name`
+    #   - Account accepts `@type` (per the canonical example plan)
+    #   - Directory accepts `@type` (variants Internal/Ldap/Sql/Oidc)
+    #   - Application has no documented filterable property — relying
+    #     on the empty-filter destroy-all (we only ever own one).
+    # Stalwart-cli is invoked with `--continue-on-error` so any
+    # surprise filter rejection on a fresh JMAP shape doesn't block
+    # the create/update pass that follows.
+    [
+      # Application destroy is fine — no foreign-key dependents and
+      # the resourceUrl is the only thing that ever changes here.
+      jsonencode({ "@type" = "destroy", object = "Application" }),
+      # Domain is intentionally NOT destroyed: DkimSignature rows and
+      # the SystemSettings.defaultDomainId reference link to it, and
+      # `destroy Domain` fails with `objectIsLinked` once those exist.
+      # On re-apply the `create Domain` below will fail with
+      # `primaryKeyViolation` (which `--continue-on-error` swallows);
+      # since Domain shape is just `{name, description}` and never
+      # changes after the first run, this is harmless.
+    ],
+    local.oidc_enabled ? [
+      # Directory has no filterable fields — destroy-all is the
+      # only option. Safe because the only Directory entry we own
+      # is the Oidc one created below; Stalwart's built-in
+      # `Internal` directory is implicit (not stored as a
+      # registry object) and unaffected.
+      #
+      # Detaching Authentication.directoryId is NOT done here — the
+      # `stalwart-cli apply` engine groups all destroys before all
+      # updates, so a plan-level `update Authentication=null` step
+      # always runs AFTER the destroy attempt. The detach is instead
+      # a synchronous pre-step in the applier sidecar command before
+      # `stalwart-cli apply` is invoked.
+      jsonencode({ "@type" = "destroy", object = "Directory" }),
+    ] : [],
+
+    # ── Create pass: parents-first ────────────────────────────────
+    [
+      # Local file replaces upstream URL so Stalwart serves the
+      # patched bundle (bundle's `stalwart-webui` literal sed-
+      # replaced with the Zitadel-issued client_id at init).
+      jsonencode({
+        "@type" = "create"
+        object  = "Application"
+        value = {
+          app-webui = {
+            description = "Stalwart Web Interface"
+            enabled     = true
+            resourceUrl = "file:///shared/webui.zip"
+            # Stalwart's `Map<String>` serializes as an object whose
+            # keys are the elements and values are `true` — not as a
+            # JSON array. Same form below for OidcDirectory.requireScopes.
+            #
+            # The /admin and /account paths sit behind a random URL
+            # prefix so the Stalwart UI doesn't surface on the public
+            # root of mail.<domain> (which serves Roundcube). The
+            # bundle's React Router uses `<base href>` from the
+            # served index.html, so urlPrefix at any depth works
+            # without code changes.
+            urlPrefix = local.webui_url_prefixes
+          }
+        }
+      }),
+
+      # Mail domain. defaultDomainId on SystemSettings is patched
+      # in the update pass below, against this same #-ref.
+      jsonencode({
+        "@type" = "create"
+        object  = "Domain"
+        value = {
+          dom-primary = {
+            name        = var.primary_domain
+            description = "Primary mail domain (managed by terraform-minikube-platform)."
+          }
+        }
+      }),
+    ],
+
+    # ── OIDC bits — only when zitadel is wired in ─────────────────
+    local.oidc_enabled ? [
+      # External IdP for end-user authentication. Stalwart validates
+      # bearer tokens by calling Zitadel /userinfo. usernameDomain
+      # appends @ipsupport.us to bare claim values so a Zitadel user
+      # `roman` becomes `roman@ipsupport.us` mailbox. claimGroups
+      # populates Stalwart group memberships, which carry roles via
+      # the Group entity created below.
+      #
+      # `requireScopes` deliberately omitted — Stalwart enforces it
+      # against the `scope` claim *embedded in the access_token JWT*,
+      # but Zitadel 2.x's default JWT access_token does not carry a
+      # `scope` claim (scopes are tracked at /introspect / /userinfo
+      # only). Setting `requireScopes:{email:true,...}` therefore
+      # produced `Missing required scope 'email', present scopes: []`
+      # → 401 on every login. The actual email/profile/groups data
+      # comes from `/userinfo` via `claimEmail` / `claimName` /
+      # `claimGroups` — those are always populated correctly when the
+      # WebUI requested the right scopes at /authorize.
+      jsonencode({
+        "@type" = "create"
+        object  = "Directory"
+        value = {
+          dir-zitadel = {
+            "@type"         = "Oidc"
+            description     = "Zitadel SSO"
+            issuerUrl       = var.zitadel_issuer_url
+            requireAudience = local.webui_aud
+            # Empty Map<String> — explicitly override Stalwart's default
+            # `requireScopes = {openid, email}`. Zitadel's JWT access_token
+            # doesn't carry a `scope` claim at all, so any non-empty
+            # requirement here fails token validation with `present
+            # scopes: []`. The actual email/groups data comes through
+            # /userinfo via `claimEmail` / `claimGroups`, not through
+            # the access_token's scope claim.
+            requireScopes  = {}
+            claimUsername  = "preferred_username"
+            usernameDomain = var.primary_domain
+            claimName      = "name"
+            claimGroups    = "groups"
+          }
+        }
+      }),
+
+      # Authentication singleton — point at the OIDC directory.
+      # Admin role for OIDC users is intentionally NOT modelled
+      # as a Stalwart Group with `roles: {@type:Admin}` here:
+      # GroupAccount.roles is the `Roles` enum (Default | Custom)
+      # and has no `Admin` variant (that's UserRoles only). v1
+      # admin path is `STALWART_RECOVERY_ADMIN` (env-pinned, password
+      # in Secret); operator logs in as `admin` for any admin task,
+      # OIDC users land as regular mailbox principals. Wiring an
+      # OIDC-claim → Custom role mapping is a follow-up.
+      jsonencode({
+        "@type" = "update"
+        object  = "Authentication"
+        value = {
+          directoryId = "#dir-zitadel"
+        }
+      }),
+    ] : [],
+
+    # ── Outbound smart host (when configured) ─────────────────────
+    # MtaRoute Relay variant + MtaOutboundStrategy.route override.
+    # The pre-existing built-in routes `local` and `mx` are NOT
+    # touched — we add a third route named `smarthost` and rewire the
+    # default else-branch from `'mx'` to `'smarthost'` so non-local
+    # mail goes through the relay. The applier sidecar deletes any
+    # stale MtaRoute named `smarthost` before this create runs (see
+    # the applier command), so plan re-applies are idempotent.
+    local.smarthost_enabled ? [
+      jsonencode({
+        "@type" = "create"
+        object  = "MtaRoute"
+        value = {
+          smarthost = {
+            "@type"           = "Relay"
+            name              = "smarthost"
+            description       = "Outbound relay (residential ISPs and Cloudflare Tunnel block direct :25)."
+            address           = var.smarthost_address
+            port              = var.smarthost_port
+            protocol          = "smtp"
+            implicitTls       = var.smarthost_implicit_tls
+            allowInvalidCerts = var.smarthost_allow_invalid_certs
+            authUsername      = var.smarthost_username != "" ? var.smarthost_username : null
+            authSecret = var.smarthost_username != "" ? {
+              "@type" = "Value"
+              value   = var.smarthost_password
+              } : {
+              "@type" = "None"
+            }
+          }
+        }
+      }),
+      # Route every non-local recipient through the smart host. The
+      # `match` keeps the upstream `is_local_domain → 'local'` branch
+      # so accounts on this Stalwart still deliver locally; the
+      # `else` flips from `'mx'` to `'smarthost'`.
+      jsonencode({
+        "@type" = "update"
+        object  = "MtaOutboundStrategy"
+        value = {
+          route = {
+            match = { "0" = { if = "is_local_domain(rcpt_domain)", then = "'local'" } }
+            else  = "'smarthost'"
+          }
+        }
+      }),
+    ] : [],
+
+    # ── DKIM signing key for the primary domain ───────────────────
+    # tls_private_key in TF state stays stable across applies; the
+    # `--continue-on-error` swallows `alreadyExists` on re-apply so
+    # the key in Stalwart is set once and never rotated by accident.
+    # Public key body is also TF-derived and exported via
+    # `dkim_dns_value` for the operator to drop into the domain yaml.
+    var.enabled ? [
+      jsonencode({
+        "@type" = "create"
+        object  = "DkimSignature"
+        value = {
+          dkim-primary = {
+            "@type"          = "Dkim1RsaSha256"
+            domainId         = "#dom-primary"
+            selector         = var.dkim_selector
+            canonicalization = "relaxed/relaxed"
+            stage            = "active"
+            headers          = ["From", "To", "Subject", "Date", "Message-ID", "MIME-Version"]
+            report           = false
+            privateKey = {
+              "@type" = "Value"
+              value   = tls_private_key.dkim["enabled"].private_key_pem
+            }
+          }
+        }
+      }),
+    ] : [],
+
+    # ── Stdout tracer ─────────────────────────────────────────────
+    # Without a Tracer object Stalwart's default `kubectl logs` view
+    # stays empty (no startup banner, no auth events, no SMTP
+    # decisions). Wipe-and-create on every apply so subsequent
+    # applies converge to the same shape; level=info is enough for
+    # ops day-to-day, switch to debug/trace when chasing an OIDC
+    # token-validation problem.
+    [
+      jsonencode({ "@type" = "destroy", object = "Tracer" }),
+      jsonencode({
+        "@type" = "create"
+        object  = "Tracer"
+        value = {
+          tr-stdout = {
+            "@type"   = "Stdout"
+            enable    = true
+            level     = "info"
+            lossy     = false
+            ansi      = false
+            multiline = false
+          }
+        }
+      }),
+    ],
+
+    # ── Update singletons (always idempotent) ─────────────────────
+    [
+      jsonencode({
+        "@type" = "update"
+        object  = "SystemSettings"
+        value = {
+          defaultDomainId = "#dom-primary"
+          defaultHostname = var.hostname
+        }
+      }),
+      jsonencode({
+        "@type" = "update"
+        object  = "Http"
+        value = {
+          useXForwarded = true
+        }
+      }),
+      jsonencode({
+        "@type" = "update"
+        object  = "BlobStore"
+        value   = { "@type" = "Default" }
+      }),
+      jsonencode({
+        "@type" = "update"
+        object  = "InMemoryStore"
+        value   = { "@type" = "Default" }
+      }),
+      jsonencode({
+        "@type" = "update"
+        object  = "SearchStore"
+        value   = { "@type" = "Default" }
+      }),
+    ],
+  )
+
+  plan_ndjson = join("\n", local.plan_lines)
+}
+
+# ── Zitadel project + application + role ──────────────────────────────────────
+#
+# Single project per Stalwart tenant. PKCE / SPA OIDC application —
+# the WebUI is a public client with no secret, redirect URIs cover
+# both /admin and /account mount points (the WebUI computes its own
+# redirect_uri at runtime from window.location.origin + base path).
+# `mail-admin` role is what an operator assigns to a Zitadel user to
+# grant Stalwart admin; the role name flows through the id_token's
+# `groups` claim to the matching Stalwart group.
+
+resource "zitadel_project" "stalwart" {
+  for_each = local.oidc_set
+
+  org_id = var.zitadel_org_id
+  name   = "stalwart"
+
+  # `project_role_assertion = true` puts the user's project-roles
+  # into the id_token / userinfo `groups` claim — Stalwart's
+  # claimGroups consumes them to assign Group membership for the
+  # auto-provisioned UserAccount.
+  project_role_assertion = true
+
+  # `project_role_check = true` is the auth gate — Zitadel rejects
+  # /authorize if the user has NO role on this project. Operator
+  # grants `mail-user` (or `mail-admin`) to anyone who should have
+  # a mailbox; everyone else gets a Zitadel-side "Forbidden" before
+  # Roundcube sees the request. Without this flag, every Zitadel
+  # org member could log in and Stalwart would auto-provision them
+  # a mailbox.
+  project_role_check = true
+
+  has_project_check        = false
+  private_labeling_setting = "PRIVATE_LABELING_SETTING_UNSPECIFIED"
+
+  lifecycle {
+    precondition {
+      condition     = var.zitadel_provider_authenticated
+      error_message = "Stalwart OIDC needs a Zitadel PAT. Bootstrap once: `kubectl get secret zitadel-tf-pat -n platform -o jsonpath='{.data.access_token}' | base64 -d`, paste it into `.env` as `TF_VAR_zitadel_pat=...`. See operating.md → 'Zitadel PAT bootstrap'."
+    }
+  }
+}
+
+resource "zitadel_application_oidc" "stalwart" {
+  for_each = local.oidc_set
+
+  org_id     = var.zitadel_org_id
+  project_id = zitadel_project.stalwart["enabled"].id
+
+  name = "stalwart-webui"
+
+  # Stalwart WebUI builds its own redirect URI as
+  # ${origin}${basePath}/oauth/callback at runtime. basePath is one
+  # of /<random>/admin or /<random>/account (URL-obscured so the UI
+  # doesn't surface on the public root, where Roundcube lives) — both
+  # are registered with the Zitadel app.
+  redirect_uris = [
+    "https://${var.hostname}${local.admin_path_prefix}/admin/oauth/callback",
+    "https://${var.hostname}${local.admin_path_prefix}/account/oauth/callback",
+  ]
+  post_logout_redirect_uris = [
+    "https://${var.hostname}${local.admin_path_prefix}/admin/login",
+    "https://${var.hostname}${local.admin_path_prefix}/account/login",
+  ]
+
+  response_types   = ["OIDC_RESPONSE_TYPE_CODE"]
+  grant_types      = ["OIDC_GRANT_TYPE_AUTHORIZATION_CODE", "OIDC_GRANT_TYPE_REFRESH_TOKEN"]
+  app_type         = "OIDC_APP_TYPE_USER_AGENT"
+  auth_method_type = "OIDC_AUTH_METHOD_TYPE_NONE"
+  version          = "OIDC_VERSION_1_0"
+
+  dev_mode                    = false
+  access_token_type           = "OIDC_TOKEN_TYPE_JWT"
+  access_token_role_assertion = true
+  id_token_role_assertion     = true
+  id_token_userinfo_assertion = true
+  clock_skew                  = "0s"
+}
+
+resource "zitadel_project_role" "admin" {
+  for_each = local.oidc_set
+
+  org_id       = var.zitadel_org_id
+  project_id   = zitadel_project.stalwart["enabled"].id
+  role_key     = var.admin_role_name
+  display_name = "Mail admin"
+  group        = var.admin_role_name
+}
+
+# `mail-user` — the everyday mailbox role. The Zitadel project gate
+# (`project_role_check = true`) requires every authorising user to hold
+# at least one project-role; a user with neither `mail-user` nor
+# `mail-admin` is rejected at /authorize before Roundcube/Stalwart see
+# the request. Operator grants `mail-user` to each Zitadel user who
+# should have a mailbox, full stop.
+resource "zitadel_project_role" "user" {
+  for_each = local.oidc_set
+
+  org_id       = var.zitadel_org_id
+  project_id   = zitadel_project.stalwart["enabled"].id
+  role_key     = var.user_role_name
+  display_name = "Mail user"
+  group        = var.user_role_name
+}
+
+# ── Recovery / fallback admin secret ──────────────────────────────────────────
+#
+# STALWART_RECOVERY_ADMIN is honoured both in recovery mode and in
+# normal mode, bypassing the directory. The upstream docs frame it
+# as a backdoor that should be removed after bootstrap; for our
+# single-operator setup behind a Zitadel-gated network it doubles
+# as a permanent fallback admin (cookie expired, OIDC down, etc.).
+# Read with: `kubectl get secret stalwart-recovery-admin -n mail \
+#   -o jsonpath='{.data.password}' | base64 -d`.
+
+# ── Mail-auth DNS records (SPF / DKIM / DMARC) ───────────────────────────────
+#
+# Emitted directly as `cloudflare_record` resources rather than going
+# through `config/domains/<x>.yaml` because the values are TF-derived
+# (DKIM body comes from `tls_private_key.dkim`, SPF/DMARC from module
+# vars). Hand-pasting the rendered DKIM body into yaml every key
+# rotation would be busy-work; this keeps the source-of-truth single.
+resource "cloudflare_record" "spf" {
+  for_each = local.dns_records_set
+
+  zone_id = var.cloudflare_zone_id
+  name    = "@"
+  type    = "TXT"
+  content = local.spf_dns_value
+  proxied = false
+  ttl     = 300
+  comment = "SPF — managed by modules/stalwart (terraform-minikube-platform)"
+}
+
+resource "cloudflare_record" "dkim" {
+  for_each = local.dns_records_set
+
+  zone_id = var.cloudflare_zone_id
+  name    = local.dkim_dns_name
+  type    = "TXT"
+  content = local.dkim_dns_value
+  proxied = false
+  ttl     = 300
+  comment = "DKIM — managed by modules/stalwart (terraform-minikube-platform)"
+}
+
+resource "cloudflare_record" "dmarc" {
+  for_each = local.dns_records_set
+
+  zone_id = var.cloudflare_zone_id
+  name    = "_dmarc"
+  type    = "TXT"
+  content = local.dmarc_dns_value
+  proxied = false
+  ttl     = 300
+  comment = "DMARC — managed by modules/stalwart (terraform-minikube-platform)"
+}
+
+# DKIM RSA key — rendered into the bootstrap plan's DkimSignature.
+# Stable: tls_private_key keeps the same value across applies, so the
+# public key in DNS doesn't churn. Rotation = taint this resource +
+# bump the selector var.
+resource "tls_private_key" "dkim" {
+  for_each = local.instances
+
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "random_password" "recovery_admin" {
+  for_each = local.instances
+
+  length  = 32
+  special = false
+}
+
+# Random URL prefix in front of /admin and /account so the operator-only
+# Stalwart UI sits at `mail.<domain>/<random>/admin` etc. The webmail
+# (Roundcube) lives at the root and is the only path normal users
+# touch; admin lives behind URL-obscurity so unauthenticated drive-by
+# scans don't even hit the OIDC-protected admin login screen. Stable
+# across applies (no triggers), changes only when the resource is
+# explicitly tainted.
+resource "random_password" "admin_path" {
+  for_each = local.instances
+
+  length  = 16
+  special = false
+  upper   = false
+}
+
+resource "kubernetes_secret_v1" "recovery_admin" {
+  for_each = local.instances
+
+  metadata {
+    name      = "stalwart-recovery-admin"
+    namespace = var.namespace
+  }
+
+  data = {
+    username = "admin"
+    password = random_password.recovery_admin["enabled"].result
+    # Ready-to-paste env var format (`username:password`) — main
+    # container references this key directly.
+    recovery_admin_env = "admin:${random_password.recovery_admin["enabled"].result}"
+  }
+}
+
+# ── ConfigMap with config.json + plan.ndjson ──────────────────────────────────
+
+resource "kubernetes_config_map_v1" "stalwart_seed" {
+  for_each = local.instances
+
+  metadata {
+    name      = "stalwart-seed"
+    namespace = var.namespace
+  }
+
+  data = {
+    "config.json" = local.config_json
+    "plan.ndjson" = local.plan_ndjson
+  }
+}
+
+# ── hostPath storage for /opt/stalwart-mail (data + etc) ──────────────────────
+
+resource "kubernetes_persistent_volume_v1" "stalwart" {
+  for_each = local.instances
+
+  metadata {
+    name = "platform-stalwart-data"
+  }
+
+  spec {
+    capacity = {
+      storage = "10Gi"
+    }
+    access_modes                     = ["ReadWriteOnce"]
+    persistent_volume_reclaim_policy = "Retain"
+    storage_class_name               = "standard"
+
+    persistent_volume_source {
+      host_path {
+        path = "${var.volume_base_path}/${var.namespace}/stalwart"
+        type = "DirectoryOrCreate"
+      }
+    }
+  }
+}
+
+resource "kubernetes_persistent_volume_claim_v1" "stalwart" {
+  for_each = local.instances
+
+  metadata {
+    name      = "stalwart-data"
+    namespace = var.namespace
+  }
+
+  spec {
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = "standard"
+    volume_name        = kubernetes_persistent_volume_v1.stalwart["enabled"].metadata[0].name
+
+    resources {
+      requests = {
+        storage = "10Gi"
+      }
+    }
+  }
+}
+
+# ── Services ──────────────────────────────────────────────────────────────────
+
+resource "kubernetes_service_v1" "stalwart_http" {
+  for_each = local.instances
+
+  metadata {
+    name      = "stalwart"
+    namespace = var.namespace
+    labels    = { app = "stalwart" }
+  }
+
+  spec {
+    selector = { app = "stalwart" }
+
+    port {
+      name        = "http"
+      port        = 8080
+      target_port = local.http_target
+      protocol    = "TCP"
+    }
+
+    # IMAPS for in-cluster webmail (Roundcube) and IMAP clients
+    # tunnelling through the Cloudflare host. Stalwart's listener
+    # autostarts on :993 inside the pod (see startup logs); Service
+    # just needs to expose it.
+    port {
+      name        = "imaps"
+      port        = 993
+      target_port = 993
+      protocol    = "TCP"
+    }
+
+    # SMTP submission with implicit TLS — Roundcube sends outbound
+    # via this port; Stalwart receives, applies its outbound queue
+    # rules (smart-host route when configured).
+    port {
+      name        = "submissions"
+      port        = 465
+      target_port = 465
+      protocol    = "TCP"
+    }
+
+    # Sieve management (filter scripts) — `managesieve` plugin in
+    # Roundcube uses this if enabled. Cheap to expose now, no
+    # consumer yet.
+    port {
+      name        = "sieve"
+      port        = 4190
+      target_port = 4190
+      protocol    = "TCP"
+    }
+  }
+}
+
+resource "kubernetes_service_v1" "stalwart_smtp" {
+  for_each = local.instances
+
+  metadata {
+    name      = "stalwart-smtp"
+    namespace = var.namespace
+    labels    = { app = "stalwart" }
+  }
+
+  spec {
+    selector = { app = "stalwart" }
+
+    port {
+      name        = "smtp"
+      port        = 25
+      target_port = local.smtp_target
+      protocol    = "TCP"
+    }
+  }
+}
+
+# ── Stalwart admin / account IngressRoutes (URL-obscured) ────────────────────
+# `mail.<domain>/<random-prefix>/admin` and `/<random-prefix>/account`
+# claim the operator-only Stalwart UI back from the default mail.yaml
+# IngressRoute (which now serves Roundcube webmail at the host root).
+# Priority 100 puts these ahead of the project-generated
+# IngressRoute. The random prefix is cosmetic obscurity — there is
+# still proper OIDC auth at the application layer; the prefix just
+# keeps drive-by scans off the login screen.
+resource "kubectl_manifest" "stalwart_admin_ingressroute" {
+  for_each = local.instances
+
+  yaml_body = yamlencode({
+    apiVersion = "traefik.io/v1alpha1"
+    kind       = "IngressRoute"
+    metadata = {
+      name      = "stalwart-admin"
+      namespace = var.namespace
+    }
+    spec = {
+      entryPoints = ["web"]
+      routes = [{
+        match    = "Host(`${var.hostname}`) && PathPrefix(`${local.admin_path_prefix}/admin`)"
+        kind     = "Rule"
+        priority = 100
+        services = [{
+          name = kubernetes_service_v1.stalwart_http["enabled"].metadata[0].name
+          port = 8080
+        }]
+      }]
+    }
+  })
+}
+
+resource "kubectl_manifest" "stalwart_account_ingressroute" {
+  for_each = local.instances
+
+  yaml_body = yamlencode({
+    apiVersion = "traefik.io/v1alpha1"
+    kind       = "IngressRoute"
+    metadata = {
+      name      = "stalwart-account"
+      namespace = var.namespace
+    }
+    spec = {
+      entryPoints = ["web"]
+      routes = [{
+        match    = "Host(`${var.hostname}`) && PathPrefix(`${local.admin_path_prefix}/account`)"
+        kind     = "Rule"
+        priority = 100
+        services = [{
+          name = kubernetes_service_v1.stalwart_http["enabled"].metadata[0].name
+          port = 8080
+        }]
+      }]
+    }
+  })
+}
+
+# ── Stalwart Deployment ───────────────────────────────────────────────────────
+
+resource "kubernetes_deployment_v1" "stalwart" {
+  for_each = local.instances
+
+  metadata {
+    name      = "stalwart"
+    namespace = var.namespace
+    labels    = { app = "stalwart" }
+
+    annotations = {
+      # Force Pod restart when seed changes — without this, a
+      # config.json or plan.ndjson edit only takes effect on the
+      # next unrelated rollout.
+      "platform.local/seed-hash" = sha256(nonsensitive("${local.config_json}|${local.plan_ndjson}|${local.webui_client_id}"))
+    }
+  }
+
+  spec {
+    # Recreate over RollingUpdate — SQLite is single-writer; surge
+    # would have two pods racing on the same DB file.
+    strategy {
+      type = "Recreate"
+    }
+
+    replicas = 1
+
+    selector {
+      match_labels = { app = "stalwart" }
+    }
+
+    template {
+      metadata {
+        labels = { app = "stalwart" }
+
+        annotations = {
+          "platform.local/seed-hash" = sha256(nonsensitive("${local.config_json}|${local.plan_ndjson}|${local.webui_client_id}"))
+        }
+      }
+
+      spec {
+        # ── Init containers ─────────────────────────────────────
+        #
+        # 1) bootstrap: writes config.json into the data PV (idempotent
+        #    overwrite — small file, only datastore stanza), patches the
+        #    upstream WebUI bundle with our Zitadel client_id and places
+        #    the result on /shared, downloads stalwart-cli onto /shared.
+        init_container {
+          name  = "bootstrap"
+          image = "alpine:3.22"
+
+          security_context {
+            run_as_user = 0
+          }
+
+          # Explicit resources — bootstrap downloads stalwart-cli
+          # (~10MB tarball) and the WebUI bundle (~500KB) and runs
+          # unzip + sed + zip on the latter. The namespace's
+          # LimitRange default of 32Mi OOM-kills the apk + xz unpack
+          # midway, so this overrides with enough headroom.
+          resources {
+            requests = { cpu = "10m", memory = "64Mi" }
+            limits   = { cpu = "500m", memory = "256Mi" }
+          }
+
+          env {
+            name  = "WEBUI_URL"
+            value = var.webui_url
+          }
+          env {
+            name  = "CLI_URL"
+            value = var.cli_url
+          }
+          env {
+            name  = "WEBUI_CLIENT_ID"
+            value = local.webui_client_id
+          }
+
+          command = ["sh", "-eu", "-c", <<-EOT
+            apk add --no-cache curl unzip zip xz >/dev/null
+
+            # ── One-time wipe before first 0.16 boot ───────────────
+            # 0.16 only migrates from 0.15.x (per UPGRADING/v0_16.md).
+            # Anything older — including the 0.10.5 TOML state we used
+            # to run — is unsupported and will leave the server in an
+            # unrecoverable state. The platform's mail PVC has no real
+            # mailboxes yet (we never made it past the wizard), so a
+            # wipe is the correct conversion. Sentinel file gates the
+            # operation: present after the first 0.16 bootstrap, absent
+            # on a v0.10-era hostPath.
+            SENTINEL=/opt/stalwart-mail/.v016-bootstrapped
+            if [ ! -f "$SENTINEL" ]; then
+              echo "[bootstrap] no v0.16 sentinel found — wiping legacy data dir before first boot"
+              rm -rf /opt/stalwart-mail/data /opt/stalwart-mail/etc
+            fi
+
+            # ── Datastore config (idempotent overwrite) ────────────
+            mkdir -p /opt/stalwart-mail/etc /opt/stalwart-mail/data/blobs
+            cp /seed/config.json /opt/stalwart-mail/etc/config.json
+            touch "$SENTINEL"
+            chown -R 1000:1000 /opt/stalwart-mail
+
+            # ── stalwart-cli binary ────────────────────────────────
+            mkdir -p /shared/bin
+            curl -sSLf "$CLI_URL" | tar -xJ -C /shared/bin --strip-components=0
+            # Tarball usually unpacks to a dir with binary inside; handle both layouts.
+            if [ ! -x /shared/bin/stalwart-cli ]; then
+              mv /shared/bin/*/stalwart-cli /shared/bin/stalwart-cli
+              rm -rf /shared/bin/*/
+            fi
+            chmod +x /shared/bin/stalwart-cli
+
+            # ── WebUI bundle: download + sed + repackage ───────────
+            mkdir -p /tmp/webui-src
+            curl -sSLfo /tmp/webui.zip "$WEBUI_URL"
+            unzip -qo /tmp/webui.zip -d /tmp/webui-src
+
+            # Single literal `stalwart-webui` appears in the bundle's
+            # JS twice (oauth.ts + api.ts), in both cases as a string.
+            # Zitadel client_ids are URL-safe so the substitution is
+            # straightforward sed.
+            find /tmp/webui-src -name '*.js' -print0 \
+              | xargs -0 sed -i "s/stalwart-webui/$WEBUI_CLIENT_ID/g"
+
+            cd /tmp/webui-src && zip -qr /shared/webui.zip .
+            ls -la /shared/ /shared/bin/
+          EOT
+          ]
+
+          volume_mount {
+            name       = "data"
+            mount_path = "/opt/stalwart-mail"
+          }
+          volume_mount {
+            name       = "shared"
+            mount_path = "/shared"
+          }
+          volume_mount {
+            name       = "seed"
+            mount_path = "/seed"
+          }
+        }
+
+        security_context {
+          run_as_user = 1000
+          fs_group    = 1000
+        }
+
+        # ── Sidecar: applier ────────────────────────────────────
+        # Regular container (not init-as-sidecar — k8s 1.29 feature
+        # the kubernetes TF provider's `~> 2.0` constraint here
+        # doesn't expose). Runs concurrently with main; waits for
+        # stalwart's :8080 to be ready, then runs `stalwart-cli
+        # apply` with the pinned recovery-admin creds. The plan is
+        # idempotent (destroy + create at the head, then upserts),
+        # so re-running every pod restart is fine. Sleeps forever
+        # afterwards to keep the container up — without that the
+        # Pod's RestartPolicy=Always would treat the exit as a
+        # crash loop.
+        container {
+          name  = "applier"
+          image = var.image
+
+          # CLI takes credentials via env: STALWART_URL +
+          # STALWART_USER + STALWART_PASSWORD (or STALWART_TOKEN).
+          # Recovery admin user/password lives in two keys of the
+          # mounted secret — read directly here.
+          #
+          # HOME points at /tmp because stalwart-cli's schema cache
+          # uses `dirs::cache_dir()` (= $HOME/.cache on Linux) and
+          # the container has no $HOME for uid 1000 — without this
+          # the CLI tries to mkdir `/.cache/stalwart-cli/...` and
+          # dies with `Permission denied (os error 13)` before any
+          # JMAP call goes out.
+          env {
+            name  = "HOME"
+            value = "/tmp"
+          }
+          env {
+            name  = "STALWART_URL"
+            value = "http://127.0.0.1:8080"
+          }
+          env {
+            name = "STALWART_USER"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret_v1.recovery_admin["enabled"].metadata[0].name
+                key  = "username"
+              }
+            }
+          }
+          env {
+            name = "STALWART_PASSWORD"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret_v1.recovery_admin["enabled"].metadata[0].name
+                key  = "password"
+              }
+            }
+          }
+
+          command = ["bash", "-eu", "-c", <<-EOT
+            for i in $(seq 1 180); do
+              if curl -sf -o /dev/null http://127.0.0.1:8080/.well-known/openid-configuration; then
+                break
+              fi
+              sleep 2
+            done
+
+            # Detach Authentication.directoryId BEFORE running the
+            # plan. `apply` does destroys, then updates, then creates —
+            # so a destroy of Directory in the plan fails (objectIsLinked,
+            # Authentication still points at it) before the update
+            # could detach it. Run the detach as a synchronous pre-step
+            # so the destroy pass is unblocked. Idempotent: if the field
+            # is already null (fresh DB), the update is a no-op.
+            echo "[applier] detaching Authentication.directoryId before plan"
+            /shared/bin/stalwart-cli update Authentication singleton --field directoryId=null \
+              || echo "[applier] detach update returned non-zero — proceeding anyway"
+
+            # Delete any stale `smarthost` MtaRoute before the plan
+            # tries to create one. MtaRoute has no destroy-by-filter
+            # in `apply` ndjson, so a re-apply with an existing route
+            # would primary-key-violate — handled here by id lookup.
+            echo "[applier] removing stale MtaRoute named 'smarthost' (if present)"
+            SH_ID=$(/shared/bin/stalwart-cli query MtaRoute 2>/dev/null \
+              | awk '$2=="smarthost" {print $1; exit}') || true
+            if [ -n "$${SH_ID:-}" ]; then
+              /shared/bin/stalwart-cli delete MtaRoute --ids "$SH_ID" \
+                || echo "[applier] smarthost delete returned non-zero — proceeding anyway"
+            fi
+
+            # `--continue-on-error` so a JMAP filter rejection on
+            # one destroy doesn't block the rest of the plan.
+            # Updates are idempotent; creates may fail with
+            # `alreadyExists` on a re-apply with no preceding destroy
+            # — that's fine, the converged state is still right.
+            if /shared/bin/stalwart-cli apply --file /seed/plan.ndjson --continue-on-error; then
+              echo "[applier] plan applied OK"
+            else
+              echo "[applier] apply finished with errors — see above; main server stays up"
+            fi
+
+            sleep infinity
+          EOT
+          ]
+
+          resources {
+            requests = { cpu = "10m", memory = "32Mi" }
+            limits   = { cpu = "200m", memory = "128Mi" }
+          }
+
+          volume_mount {
+            name       = "shared"
+            mount_path = "/shared"
+            read_only  = true
+          }
+          volume_mount {
+            name       = "seed"
+            mount_path = "/seed"
+            read_only  = true
+          }
+          volume_mount {
+            name       = "recovery-admin"
+            mount_path = "/etc/recovery"
+            read_only  = true
+          }
+        }
+
+        # ── Main container ──────────────────────────────────────
+        container {
+          name  = "stalwart"
+          image = var.image
+
+          # Pod-level securityContext sets uid 1000; the auto-bootstrapped
+          # listeners include :25 / :465 / :993 / :995 / :443 (all under
+          # 1024) which can't be bound by uid 1000 without a capability.
+          # Granting NET_BIND_SERVICE keeps the rest of the security
+          # posture (non-root user, no privilege escalation) while
+          # letting the listeners come up.
+          security_context {
+            allow_privilege_escalation = false
+            capabilities {
+              add  = ["NET_BIND_SERVICE"]
+              drop = ["ALL"]
+            }
+          }
+
+          env {
+            name  = "CONFIG_PATH"
+            value = "/opt/stalwart-mail/etc/config.json"
+          }
+
+          # Recovery admin: pinned via env so the bootstrap-mode
+          # one-time random password is replaced with our known one.
+          # Same env keeps working in normal mode → fallback admin.
+          env {
+            name = "STALWART_RECOVERY_ADMIN"
+            value_from {
+              secret_key_ref {
+                name = kubernetes_secret_v1.recovery_admin["enabled"].metadata[0].name
+                key  = "recovery_admin_env"
+              }
+            }
+          }
+
+          resources {
+            requests = {
+              cpu    = var.cpu_request
+              memory = var.memory_request
+            }
+            limits = {
+              cpu    = var.cpu_limit
+              memory = var.memory_limit
+            }
+          }
+
+          volume_mount {
+            name       = "data"
+            mount_path = "/opt/stalwart-mail"
+          }
+          volume_mount {
+            name       = "shared"
+            mount_path = "/shared"
+            read_only  = true
+          }
+
+          startup_probe {
+            tcp_socket {
+              port = local.http_target
+            }
+            period_seconds    = 5
+            failure_threshold = 60
+          }
+
+          liveness_probe {
+            tcp_socket {
+              port = local.http_target
+            }
+            period_seconds    = 30
+            failure_threshold = 3
+          }
+
+          readiness_probe {
+            tcp_socket {
+              port = local.http_target
+            }
+            period_seconds    = 10
+            failure_threshold = 3
+          }
+        }
+
+        volume {
+          name = "data"
+          persistent_volume_claim {
+            claim_name = kubernetes_persistent_volume_claim_v1.stalwart["enabled"].metadata[0].name
+          }
+        }
+
+        volume {
+          name = "shared"
+          empty_dir {}
+        }
+
+        volume {
+          name = "seed"
+          config_map {
+            name = kubernetes_config_map_v1.stalwart_seed["enabled"].metadata[0].name
+          }
+        }
+
+        volume {
+          name = "recovery-admin"
+          secret {
+            secret_name = kubernetes_secret_v1.recovery_admin["enabled"].metadata[0].name
+          }
+        }
+      }
+    }
+  }
+}
+
+# ── SMTP relay forwarder ──────────────────────────────────────────────────────
+#
+# Tiny socat pod whose only job is to listen on the WireGuard interface
+# address and forward to the in-cluster Stalwart SMTP Service. Runs with
+# hostNetwork=true because it MUST bind to a specific host IP (the WG
+# address); doing this in the Stalwart pod itself would put Stalwart's
+# HTTP listener on every host interface as a side-effect, which we
+# explicitly want to avoid.
+resource "kubernetes_deployment_v1" "stalwart_smtp_relay" {
+  for_each = local.instances
+
+  metadata {
+    name      = "stalwart-smtp-relay"
+    namespace = var.namespace
+    labels    = { app = "stalwart-smtp-relay" }
+  }
+
+  spec {
+    replicas = 1
+
+    strategy {
+      type = "Recreate"
+    }
+
+    selector {
+      match_labels = { app = "stalwart-smtp-relay" }
+    }
+
+    template {
+      metadata {
+        labels = { app = "stalwart-smtp-relay" }
+      }
+
+      spec {
+        host_network = true
+        dns_policy   = "ClusterFirstWithHostNet"
+
+        container {
+          name  = "socat"
+          image = "alpine/socat:1.8.0.0"
+
+          args = [
+            "TCP-LISTEN:25,bind=${var.smtp_relay_listen_ip},fork,reuseaddr",
+            "TCP:stalwart-smtp.${var.namespace}.svc.cluster.local:25",
+          ]
+
+          security_context {
+            run_as_user                = 0
+            allow_privilege_escalation = false
+            capabilities {
+              add  = ["NET_BIND_SERVICE"]
+              drop = ["ALL"]
+            }
+          }
+
+          resources {
+            requests = { cpu = "10m", memory = "16Mi" }
+            limits   = { cpu = "100m", memory = "32Mi" }
+          }
+        }
+      }
+    }
+  }
+}
+
+# ── Outputs ───────────────────────────────────────────────────────────────────
+
+output "namespace" {
+  value = var.namespace
+}
+
+output "service_http" {
+  description = "ClusterIP Service serving Stalwart's HTTP (admin + webmail + JMAP). Cloudflare Tunnel ingress routes mail.<domain> here via a kind:external component in the domain yaml."
+  value = var.enabled ? {
+    name      = kubernetes_service_v1.stalwart_http["enabled"].metadata[0].name
+    namespace = kubernetes_service_v1.stalwart_http["enabled"].metadata[0].namespace
+    port      = 8080
+  } : null
+}
+
+output "recovery_admin_secret" {
+  description = "Name of the Secret holding the pinned recovery / fallback admin credentials. Read username + password with `kubectl get secret <name> -n mail -o jsonpath='{.data.password}' | base64 -d`."
+  value       = var.enabled ? kubernetes_secret_v1.recovery_admin["enabled"].metadata[0].name : null
+}
+
+output "recovery_admin_username" {
+  description = "Username for the pinned recovery / fallback admin (always `admin`). Pairs with `recovery_admin_password` for direct WebUI login that bypasses the OIDC directory."
+  value       = var.enabled ? "admin" : null
+}
+
+output "recovery_admin_password" {
+  description = "Plaintext password for the pinned recovery / fallback admin. Sensitive — surface with `terraform output -raw stalwart_recovery_admin_password` (root-level alias defined in outputs.tf). Bypasses the directory entirely; use whenever OIDC sign-in is broken or unavailable."
+  value       = var.enabled ? random_password.recovery_admin["enabled"].result : null
+  sensitive   = true
+}
+
+output "zitadel_application_oidc_id" {
+  description = "ID of the Zitadel OIDC application provisioned for Stalwart's WebUI; null when Zitadel integration is disabled. Used by the operator to grant `mail-admin` to specific users."
+  value       = local.oidc_enabled ? zitadel_application_oidc.stalwart["enabled"].id : null
+}
+
+output "zitadel_project_id" {
+  description = "ID of the Zitadel project the Stalwart OIDC app + roles land in. Re-used by sibling modules (roundcube webmail) so additional OIDC clients pile under the same project rather than spawning new ones."
+  value       = local.oidc_enabled ? zitadel_project.stalwart["enabled"].id : null
+}
+
+output "admin_url" {
+  description = "Operator-facing Stalwart admin URL — `https://mail.<domain>/<random>/admin`. The random prefix is generated once per cluster and stays stable across applies; it surfaces ONLY here and in the platform cheatsheet so admin doesn't surface on the host root (which now serves Roundcube webmail). Do not paste publicly."
+  value       = local.webui_admin_url
+  sensitive   = true
+}
+
+output "account_url" {
+  description = "Stalwart self-service account URL — same random prefix as admin_url, lands users on Stalwart's `/account` (sessions, password — mostly empty for OIDC users since password lives in Zitadel)."
+  value       = local.webui_account_url
+  sensitive   = true
+}
+
+output "zitadel_admin_role" {
+  description = "Name of the Zitadel project role that grants Stalwart admin via the OIDC `groups` claim; null when Zitadel integration is disabled."
+  value       = local.oidc_enabled ? zitadel_project_role.admin["enabled"].role_key : null
+}
+
+output "dkim_dns_name" {
+  description = "Name component of the DKIM TXT record (relative to the primary domain). Concatenate with the domain to get the FQDN — e.g. `stalwart._domainkey.ipsupport.us`."
+  value       = var.enabled ? local.dkim_dns_name : null
+}
+
+output "dkim_dns_value" {
+  description = "Value of the DKIM TXT record. Drop verbatim into `config/domains/<primary>.yaml`'s `dns:` block as `{ name: stalwart._domainkey, type: TXT, content: \"<this>\" }`."
+  value       = var.enabled ? local.dkim_dns_value : null
+}
+
+output "spf_dns_value" {
+  description = "Recommended SPF TXT for the primary domain — authorises only the public relay's IP and rejects everything else (`-all`)."
+  value       = var.enabled ? "v=spf1 ip4:130.51.23.250 -all" : null
+}
+
+output "dmarc_dns_name" {
+  description = "Name component of the DMARC TXT record."
+  value       = "_dmarc"
+}
+
+output "dmarc_dns_value" {
+  description = "Recommended DMARC policy — quarantine (move-to-spam) on auth failure, aggregate reports to postmaster of the primary domain. Tighten to `p=reject` after a few weeks of clean reports."
+  value       = var.enabled ? "v=DMARC1; p=quarantine; rua=mailto:postmaster@${var.primary_domain}" : null
+}
+
+output "zitadel_user_role" {
+  description = "Name of the Zitadel project role required for ordinary mailbox access. Operator grants this (or `zitadel_admin_role`) to every Zitadel user who should reach the webmail; users without a project-role are rejected at /authorize."
+  value       = local.oidc_enabled ? zitadel_project_role.user["enabled"].role_key : null
+}

--- a/modules/stalwart/main.tf
+++ b/modules/stalwart/main.tf
@@ -93,21 +93,21 @@ variable "webui_url" {
 }
 
 variable "smtp_relay_listen_ip" {
-  description = "Host IP the SMTP relay forwarder binds to. Specific by design — wants to be reachable from the public-relay tunnel, NOT from the LAN, so this should be the WireGuard interface address (not 0.0.0.0)."
+  description = "Host IP the SMTP relay forwarder binds to. Specific by design — should be reachable from the public-relay tunnel only, NOT from the LAN, so this should be the WireGuard interface address (not 0.0.0.0). Required (no sane default — depends entirely on the operator's overlay topology)."
   type        = string
-  default     = "10.23.0.2"
+  default     = ""
 }
 
 variable "hostname" {
-  description = "Public hostname Stalwart announces in SMTP banners and signs DKIM with. Should match the relay's reverse DNS — Gmail rejects mismatches."
+  description = "Public hostname Stalwart announces in SMTP banners and signs DKIM with. Should match the relay's reverse DNS — Gmail rejects mismatches. Required."
   type        = string
-  default     = "mail.ipsupport.us"
+  default     = ""
 }
 
 variable "primary_domain" {
-  description = "Default mail domain bootstrapped into Stalwart. Used as defaultDomainId on SystemSettings and as the domain Zitadel-OIDC users are auto-provisioned under."
+  description = "Default mail domain bootstrapped into Stalwart. Used as defaultDomainId on SystemSettings and as the domain Zitadel-OIDC users are auto-provisioned under. Required when the module is enabled."
   type        = string
-  default     = "ipsupport.us"
+  default     = ""
 }
 
 variable "zitadel_org_id" {
@@ -129,7 +129,7 @@ variable "zitadel_provider_authenticated" {
 }
 
 variable "smarthost_address" {
-  description = "Hostname or IP of the outbound SMTP relay. Empty string keeps the default `mx` route (direct MX delivery); set to a relay address (e.g. the WireGuard IP of the public Postfix relay VPS, or `relay.ipsupport.us`) to push every non-local message through it. Residential ISPs and Cloudflare Tunnel both block outbound :25 — without a smart host the queue spools forever and bounces. The relay must be configured to accept mail from this Stalwart's outgoing IP (typically by static IP / WG peer ACL) and to handle SPF/DKIM signing on the public side."
+  description = "Hostname or IP of the outbound SMTP relay. Empty string keeps the default `mx` route (direct MX delivery); set to a relay address (typically the WireGuard IP of a public Postfix relay VPS, or its public hostname) to push every non-local message through it. Residential ISPs and Cloudflare Tunnel both block outbound :25 — without a smart host the queue spools forever and bounces. The relay must be configured to accept mail from this Stalwart's outgoing IP (typically by static IP / WG peer ACL) and to handle SPF/DKIM signing on the public side."
   type        = string
   default     = ""
 }
@@ -178,9 +178,9 @@ variable "cloudflare_zone_id" {
 }
 
 variable "spf_authorized_ip" {
-  description = "IPv4 (or `ip4:x ip4:y` chain) authorised to send mail for the primary domain. Defaults to the public Postfix relay IP — every outbound message exits there."
+  description = "IPv4 (or `ip4:x ip4:y` chain) authorised to send mail for the primary domain. Should be the public IP of the relay every outbound message exits through. Empty string omits the SPF TXT record entirely — fine if SPF is published manually elsewhere."
   type        = string
-  default     = "130.51.23.250"
+  default     = ""
 }
 
 variable "dmarc_policy" {
@@ -268,8 +268,8 @@ locals {
   dkim_dns_value = var.enabled ? "v=DKIM1; k=rsa; p=${local.dkim_pubkey_body}" : ""
   dkim_dns_name  = "${var.dkim_selector}._domainkey"
 
-  spf_dns_value   = var.enabled ? "v=spf1 ip4:${var.spf_authorized_ip} -all" : ""
-  dmarc_dns_value = var.enabled ? "v=DMARC1; p=${var.dmarc_policy}; rua=mailto:postmaster@${var.primary_domain}" : ""
+  spf_dns_value   = var.enabled && var.spf_authorized_ip != "" ? "v=spf1 ip4:${var.spf_authorized_ip} -all" : ""
+  dmarc_dns_value = var.enabled && var.primary_domain != "" ? "v=DMARC1; p=${var.dmarc_policy}; rua=mailto:postmaster@${var.primary_domain}" : ""
 
   # Whether the module manages SPF/DKIM/DMARC TXT records directly
   # in Cloudflare (bypassing the per-domain yaml). Off when the
@@ -277,6 +277,12 @@ locals {
   # standalone testing without a Cloudflare zone.
   dns_records_enabled = var.enabled && var.cloudflare_zone_id != ""
   dns_records_set     = local.dns_records_enabled ? toset(["enabled"]) : toset([])
+
+  # Per-record gates so an empty source value (e.g. operator hasn't
+  # set spf_authorized_ip) skips just that record instead of breaking
+  # the apply with an invalid TXT content.
+  spf_record_set   = local.dns_records_enabled && local.spf_dns_value != "" ? toset(["enabled"]) : toset([])
+  dmarc_record_set = local.dns_records_enabled && local.dmarc_dns_value != "" ? toset(["enabled"]) : toset([])
 
   # Whether to wire an outbound smart-host. Off (empty address) keeps
   # Stalwart on its default direct-MX route — which silently bounces
@@ -413,8 +419,8 @@ locals {
     local.oidc_enabled ? [
       # External IdP for end-user authentication. Stalwart validates
       # bearer tokens by calling Zitadel /userinfo. usernameDomain
-      # appends @ipsupport.us to bare claim values so a Zitadel user
-      # `roman` becomes `roman@ipsupport.us` mailbox. claimGroups
+      # appends @<primary_domain> to bare claim values so a Zitadel user
+      # `alice` becomes `alice@<primary_domain>` mailbox. claimGroups
       # populates Stalwart group memberships, which carry roles via
       # the Group entity created below.
       #
@@ -732,7 +738,7 @@ resource "zitadel_project_role" "user" {
 # vars). Hand-pasting the rendered DKIM body into yaml every key
 # rotation would be busy-work; this keeps the source-of-truth single.
 resource "cloudflare_record" "spf" {
-  for_each = local.dns_records_set
+  for_each = local.spf_record_set
 
   zone_id = var.cloudflare_zone_id
   name    = "@"
@@ -756,7 +762,7 @@ resource "cloudflare_record" "dkim" {
 }
 
 resource "cloudflare_record" "dmarc" {
-  for_each = local.dns_records_set
+  for_each = local.dmarc_record_set
 
   zone_id = var.cloudflare_zone_id
   name    = "_dmarc"
@@ -1519,18 +1525,18 @@ output "zitadel_admin_role" {
 }
 
 output "dkim_dns_name" {
-  description = "Name component of the DKIM TXT record (relative to the primary domain). Concatenate with the domain to get the FQDN — e.g. `stalwart._domainkey.ipsupport.us`."
+  description = "Name component of the DKIM TXT record (relative to the primary domain). Concatenate with the domain to get the FQDN — e.g. `<dkim_selector>._domainkey.<primary_domain>`."
   value       = var.enabled ? local.dkim_dns_name : null
 }
 
 output "dkim_dns_value" {
-  description = "Value of the DKIM TXT record. Drop verbatim into `config/domains/<primary>.yaml`'s `dns:` block as `{ name: stalwart._domainkey, type: TXT, content: \"<this>\" }`."
+  description = "Value of the DKIM TXT record. Drop verbatim into `config/domains/<primary>.yaml`'s `dns:` block as `{ name: <dkim_selector>._domainkey, type: TXT, content: \"<this>\" }`."
   value       = var.enabled ? local.dkim_dns_value : null
 }
 
 output "spf_dns_value" {
-  description = "Recommended SPF TXT for the primary domain — authorises only the public relay's IP and rejects everything else (`-all`)."
-  value       = var.enabled ? "v=spf1 ip4:130.51.23.250 -all" : null
+  description = "Recommended SPF TXT for the primary domain — authorises only the relay's public IP and rejects everything else (`-all`). Empty when `var.spf_authorized_ip` is unset."
+  value       = var.enabled ? local.spf_dns_value : null
 }
 
 output "dmarc_dns_name" {

--- a/modules/zitadel/main.tf
+++ b/modules/zitadel/main.tf
@@ -40,9 +40,9 @@ variable "image" {
 }
 
 variable "login_image" {
-  description = "Zitadel Login UI v2 sidecar image. Versioned independently from the main server (separate repo: zitadel/typescript). v3.0.1 (latest tagged release) ships without the wait-for-token-file entrypoint that newer commits added — the `:main` rolling tag has it. Pin to `:main` until the next semver release is cut."
+  description = "Zitadel Login UI v2 sidecar image. Pinned to the last tagged release — the rolling `:main` tag has been observed to ship a SPA race that double-submits `createCallback` and trips `Auth Request has already been handled (COMMAND-Sx208nt)` on every OIDC flow, breaking forward-auth-style gates. The wait-for-token-file behaviour we used to need from `:main` is now done in this module's own container `command` override, so the tagged release is fine."
   type        = string
-  default     = "ghcr.io/zitadel/login:main"
+  default     = "ghcr.io/zitadel/login:v3.0.1"
 }
 
 variable "postgres_host" {
@@ -69,6 +69,13 @@ variable "first_admin_username" {
   description = "Username for the bootstrap human admin."
   type        = string
   default     = "zitadel-admin"
+}
+
+variable "login_client_pat" {
+  description = "Pre-existing PAT for the `login-client` machine user. FIRSTINSTANCE writes a fresh PAT to an emptyDir on first install; that file is lost on pod restart and the Login UI v2 sidecar hangs forever waiting for it. Setting this var to an existing PAT (regenerated via the management API once and pasted into the operator's `.env`) makes the deployment mount it from a Secret instead, surviving any number of pod restarts. Empty (default) keeps the original FIRSTINSTANCE-only behavior — fine on a fresh install, broken on every subsequent restart."
+  type        = string
+  default     = ""
+  sensitive   = true
 }
 
 variable "login_policy" {
@@ -148,6 +155,25 @@ resource "kubernetes_secret_v1" "zitadel" {
     masterkey      = random_password.masterkey["enabled"].result
     db_password    = random_password.db["enabled"].result
     admin_password = random_password.admin["enabled"].result
+  }
+}
+
+# Persisted login-client PAT — only created when the operator supplies
+# one via `var.login_client_pat` (regenerated once via the management
+# API and pasted into `.env`). The Login UI v2 sidecar mounts this and
+# survives pod restarts; without the var, the sidecar still falls back
+# to the FIRSTINSTANCE-written emptyDir file (works for fresh installs,
+# breaks on every restart after that).
+resource "kubernetes_secret_v1" "login_client_pat" {
+  for_each = var.enabled && nonsensitive(var.login_client_pat != "") ? toset(["enabled"]) : toset([])
+
+  metadata {
+    name      = "zitadel-login-client-pat"
+    namespace = var.namespace
+  }
+
+  data = {
+    "login-client.pat" = var.login_client_pat
   }
 }
 
@@ -553,16 +579,23 @@ resource "kubernetes_deployment_v1" "zitadel" {
           # *should* convert _TOKEN_FILE → _TOKEN at startup, but neither
           # v3.0.1 nor :main does it (no entrypoint wrapper, server.js
           # boots straight from PID 1). Do the conversion ourselves —
-          # block until the FIRSTINSTANCE-bootstrapped login-client.pat
-          # file appears, read it, then exec the upstream entrypoint.
+          # prefer the operator-provided PAT mounted from a Secret
+          # (survives pod restart), fall back to the FIRSTINSTANCE-
+          # bootstrapped emptyDir version (works only on the first pod).
           command = ["/bin/sh", "-c"]
           args = [
             <<-EOT
-            until [ -s /var/zitadel/secrets/login-client.pat ]; do
-              echo "login: waiting for login-client.pat..."
-              sleep 2
-            done
-            export ZITADEL_SERVICE_USER_TOKEN="$(cat /var/zitadel/secrets/login-client.pat)"
+            if [ -s /var/zitadel/login-client-pat/login-client.pat ]; then
+              PAT_FILE=/var/zitadel/login-client-pat/login-client.pat
+              echo "login: using Secret-mounted login-client.pat"
+            else
+              PAT_FILE=/var/zitadel/secrets/login-client.pat
+              until [ -s "$PAT_FILE" ]; do
+                echo "login: waiting for login-client.pat..."
+                sleep 2
+              done
+            fi
+            export ZITADEL_SERVICE_USER_TOKEN="$(cat "$PAT_FILE")"
             echo "login: token loaded ($${#ZITADEL_SERVICE_USER_TOKEN} chars), starting next-server..."
             exec node apps/login/server.js
             EOT
@@ -641,6 +674,18 @@ resource "kubernetes_deployment_v1" "zitadel" {
             mount_path = "/var/zitadel/secrets"
             read_only  = true
           }
+
+          # Operator-provided PAT, mounted from a Secret. Only attached
+          # when `var.login_client_pat` is non-empty — falls back to the
+          # FIRSTINSTANCE emptyDir flow above when not set.
+          dynamic "volume_mount" {
+            for_each = nonsensitive(var.login_client_pat == "") ? [] : [1]
+            content {
+              name       = "login-client-pat"
+              mount_path = "/var/zitadel/login-client-pat"
+              read_only  = true
+            }
+          }
         }
 
         service_account_name = kubernetes_service_account_v1.pat_broker["enabled"].metadata[0].name
@@ -648,6 +693,16 @@ resource "kubernetes_deployment_v1" "zitadel" {
         volume {
           name = "pat-output"
           empty_dir {}
+        }
+
+        dynamic "volume" {
+          for_each = nonsensitive(var.login_client_pat == "") ? [] : [1]
+          content {
+            name = "login-client-pat"
+            secret {
+              secret_name = kubernetes_secret_v1.login_client_pat["enabled"].metadata[0].name
+            }
+          }
         }
 
         volume {

--- a/oauth2_proxy.tf
+++ b/oauth2_proxy.tf
@@ -1,0 +1,46 @@
+# Cluster-wide auth gate for `kind: external` services that opt in
+# via `auth: zitadel` in their component yaml. One Zitadel-backed
+# oauth2-proxy in the `ingress-controller` namespace; Traefik's
+# ForwardAuth middleware (also emitted by this module) bounces
+# unauthenticated requests through Zitadel and lets the cookie cover
+# every protected subdomain on the same parent domain.
+#
+# Auth + cookie domain are derived from `zitadel.external_domain`:
+# `id.ipsupport.us` → auth host `auth.ipsupport.us`, cookie scope
+# `.ipsupport.us`. Cookies can't cross parent domains, so this proxy
+# only protects subdomains of *that* parent — services on other
+# tenants' domains would need their own gate, or operator-driven
+# split routing in a follow-up.
+#
+# Gated on `services.zitadel.enabled` — when the operator runs without
+# Zitadel, the module produces zero resources and any `auth: zitadel`
+# on a component yaml fails the modules/project precondition with a
+# clear error before Traefik gets handed a broken IngressRoute.
+locals {
+  # Drop the leftmost label of the Zitadel external_domain to get the
+  # parent zone the proxy serves. Empty string when Zitadel is off so
+  # the module receives a defined value (it's gated anyway).
+  _oauth2_parent_domain = local.platform.services.zitadel.enabled ? join(
+    ".",
+    slice(
+      split(".", local.platform.services.zitadel.external_domain),
+      1,
+      length(split(".", local.platform.services.zitadel.external_domain))
+    )
+  ) : ""
+}
+
+module "oauth2_proxy" {
+  source     = "./modules/oauth2-proxy"
+  depends_on = [module.addons, module.zitadel]
+
+  enabled                        = local.platform.services.zitadel.enabled
+  namespace                      = "ingress-controller"
+  zitadel_provider_authenticated = var.zitadel_pat != ""
+
+  issuer_url    = local.platform.services.zitadel.enabled ? "https://${local.platform.services.zitadel.external_domain}" : ""
+  auth_hostname = local._oauth2_parent_domain == "" ? "" : "auth.${local._oauth2_parent_domain}"
+  # traefik-forward-auth canonicalises the cookie domain itself —
+  # pass the bare parent zone, no leading dot.
+  cookie_domain = local._oauth2_parent_domain
+}

--- a/oauth2_proxy.tf
+++ b/oauth2_proxy.tf
@@ -6,11 +6,11 @@
 # every protected subdomain on the same parent domain.
 #
 # Auth + cookie domain are derived from `zitadel.external_domain`:
-# `id.ipsupport.us` → auth host `auth.ipsupport.us`, cookie scope
-# `.ipsupport.us`. Cookies can't cross parent domains, so this proxy
-# only protects subdomains of *that* parent — services on other
-# tenants' domains would need their own gate, or operator-driven
-# split routing in a follow-up.
+# `id.<parent>` → auth host `auth.<parent>`, cookie scope `.<parent>`.
+# Cookies can't cross parent domains, so this proxy only protects
+# subdomains of *that* parent — services on other tenants' domains
+# would need their own gate, or operator-driven split routing in a
+# follow-up.
 #
 # Gated on `services.zitadel.enabled` — when the operator runs without
 # Zitadel, the module produces zero resources and any `auth: zitadel`

--- a/outputs.tf
+++ b/outputs.tf
@@ -186,7 +186,7 @@ output "cheatsheet" {
       terraform output -raw stalwart_recovery_admin_password
 
     Mail — Roundcube webmail (Zitadel SSO; auto-provisions Stalwart UserAccount on first login):
-      https://mail.ipsupport.us/
+      https://${try(local.mail.hostname, "<configure mail in a domain yaml>")}/
 
     Mail — Stalwart admin panel (operator-only; URL hidden behind a random prefix
     so the login screen doesn't surface to drive-by scans — paste from the

--- a/outputs.tf
+++ b/outputs.tf
@@ -104,6 +104,45 @@ output "zitadel" {
   sensitive = true
 }
 
+output "stalwart_recovery_admin_password" {
+  description = "Plaintext password for the pinned Stalwart recovery admin (username `admin`). Bypasses the OIDC directory entirely — use it whenever Zitadel sign-in is broken or unavailable. Read with `terraform output -raw stalwart_recovery_admin_password`."
+  value       = module.stalwart.recovery_admin_password
+  sensitive   = true
+}
+
+output "stalwart_admin_url" {
+  description = "Operator-facing Stalwart admin URL. Includes a stable random URL prefix so /admin doesn't surface on the public root of mail.<domain> (which serves Roundcube webmail). Sensitive — do not paste publicly. Read with `terraform output -raw stalwart_admin_url`."
+  value       = module.stalwart.admin_url
+  sensitive   = true
+}
+
+output "stalwart_dkim_dns" {
+  description = "DKIM record to publish under the primary mail domain. `name` is relative (`stalwart._domainkey`); paste both into `config/domains/<domain>.yaml`'s `dns:` block as type=TXT."
+  value = {
+    name  = module.stalwart.dkim_dns_name
+    value = module.stalwart.dkim_dns_value
+  }
+}
+
+output "stalwart_spf_dns" {
+  description = "Recommended SPF TXT for the primary mail domain — paste under `name: \"@\"`, type: TXT in the domain yaml."
+  value       = module.stalwart.spf_dns_value
+}
+
+output "stalwart_dmarc_dns" {
+  description = "Recommended DMARC TXT — `name` relative (`_dmarc`), value the policy string."
+  value = {
+    name  = module.stalwart.dmarc_dns_name
+    value = module.stalwart.dmarc_dns_value
+  }
+}
+
+output "stalwart_account_url" {
+  description = "Stalwart self-service account URL. Same random prefix as `stalwart_admin_url`. Mostly empty for OIDC users since password lives in Zitadel. Read with `terraform output -raw stalwart_account_url`."
+  value       = module.stalwart.account_url
+  sensitive   = true
+}
+
 output "zitadel_pat" {
   description = "PAT for the Zitadel TF provider (machine user `tf-platform`, IAM_OWNER, far-future expiry). Lifted from the in-cluster `zitadel-tf-pat` Secret that the FIRSTINSTANCE-bootstrapped pat-broker sidecar populates. Empty when Zitadel is disabled OR the sidecar hasn't run yet (pre-bootstrap clean clone); populated after the first `./tf apply` brings Zitadel up. Fetch with `terraform output -raw zitadel_pat`, then paste into `.env` as `TF_VAR_zitadel_pat=...` so subsequent applies provision kind:app components."
   sensitive   = true
@@ -142,6 +181,25 @@ output "cheatsheet" {
     Redis default-user password (platform-root; tenants use their own
     ACL user, password in the per-namespace `redis-credentials` Secret):
       terraform output -json redis | jq -r '.default_password'
+
+    Stalwart recovery admin (bypasses OIDC; user `admin`):
+      terraform output -raw stalwart_recovery_admin_password
+
+    Mail — Roundcube webmail (Zitadel SSO; auto-provisions Stalwart UserAccount on first login):
+      https://mail.ipsupport.us/
+
+    Mail — Stalwart admin panel (operator-only; URL hidden behind a random prefix
+    so the login screen doesn't surface to drive-by scans — paste from the
+    output, never share):
+      terraform output -raw stalwart_admin_url
+
+    Mail — Stalwart self-service /account (mostly empty for OIDC users):
+      terraform output -raw stalwart_account_url
+
+    Mail — DKIM/SPF/DMARC DNS records to add to config/domains/<domain>.yaml dns:
+      terraform output stalwart_dkim_dns    # name+value (TXT)
+      terraform output -raw stalwart_spf_dns
+      terraform output stalwart_dmarc_dns   # name+value (TXT)
 
     Traefik dashboard login (user: admin):
       terraform output -json basic_auth \
@@ -200,7 +258,7 @@ output "cheatsheet" {
     Plan:       ./tf plan
     Apply:      ./tf apply
     Bootstrap:  ./tf bootstrap-k3s      (or: ./tf bootstrap-minikube)
-    Purge CF:   ./tf cloudflare-purge
+    Purge CF:   ./tf cloudflare-purge   (DESTRUCTIVE: nukes tunnel + DNS)
     Outputs:    terraform output
     Projects:   terraform output -json projects | jq .
 

--- a/variables.tf
+++ b/variables.tf
@@ -117,45 +117,13 @@ variable "zitadel_login_client_pat" {
   sensitive   = true
 }
 
-variable "smarthost_address" {
-  description = "Hostname or IP of the outbound SMTP smart-host (relay) Stalwart sends every non-local message through. Empty disables relaying — direct MX delivery. Residential ISPs and Cloudflare Tunnel both block outbound :25, so a working relay is required for prod mail; the home cluster relays through a Postfix VPS at relay.ipsupport.us via the WireGuard overlay."
-  type        = string
-  default     = ""
-}
-
-variable "smarthost_port" {
-  description = "Smart-host TCP port. 25 for plain SMTP relay over a trusted overlay (WireGuard), 465 for implicit TLS submission, 587 for STARTTLS submission with auth."
-  type        = number
-  default     = 25
-}
-
-variable "smarthost_implicit_tls" {
-  description = "Use TLS for every connection to the smart host (port 465 style). False for plain :25 over a trusted overlay."
-  type        = bool
-  default     = false
-}
-
-variable "smarthost_allow_invalid_certs" {
-  description = "Skip TLS certificate validation when connecting to the smart host. Only flip on for a relay presenting a self-signed cert on a trusted network."
-  type        = bool
-  default     = false
-}
-
-variable "smarthost_username" {
-  description = "Optional SMTP AUTH username for the smart host. Empty skips AUTH (relay accepts by source IP)."
-  type        = string
-  default     = ""
-}
-
-variable "smarthost_password" {
-  description = "SMTP AUTH password matching `smarthost_username`. Sensitive — supply via TF_VAR_smarthost_password in .env. Ignored when username is empty."
-  type        = string
-  default     = ""
-  sensitive   = true
-}
-
-variable "primary_mail_domain" {
-  description = "Tenant domain that owns the platform's mail stack. Must match a `name:` in `config/domains/<x>.yaml` — its `cloudflare_zone_id` drives the SPF/DKIM/DMARC TXT records `modules/stalwart` emits, and `mail.<this>` is the WebUI hostname. Single-domain mail today; the variable lets you flip primary without code edits when a different tenant takes over mail."
-  type        = string
-  default     = "ipsupport.us"
-}
+# Mail-stack tenant settings (smarthost target/port/auth-mode, WG bind
+# IP, public IP for SPF, DKIM selector, DMARC policy, and which domain
+# owns the stack) live under `mail:` in the primary domain's yaml —
+# see `config/domains/example.com.yaml.example`. Domain yamls are
+# gitignored, so tenant-specific values stay out of the repo. The only
+# bit that doesn't fit yaml is the SMTP-AUTH password (when relaying
+# through an AUTH-required SaaS like Mailgun); operators on that path
+# can re-add a sensitive `smarthost_password` variable here and pipe
+# it through `mail.tf`. The home-cluster relay accepts by WG peer-ACL,
+# so no AUTH is needed and the var is unused.

--- a/variables.tf
+++ b/variables.tf
@@ -87,3 +87,75 @@ variable "zitadel_pat" {
   default     = ""
   sensitive   = true
 }
+
+variable "zitadel_login_client_pat" {
+  description = <<-EOT
+    Personal Access Token for the Zitadel `login-client` machine
+    user — read by the Login UI v2 sidecar to talk gRPC to the main
+    Zitadel API. Created automatically at FIRSTINSTANCE and written
+    to an emptyDir; that emptyDir is lost on every pod restart, so
+    the Login UI hangs at "waiting for login-client.pat..." after
+    any reboot. To unstick: paste the value here as
+    `TF_VAR_zitadel_login_client_pat` once, TF mounts it via Secret
+    at the path the sidecar expects, and restarts stop being
+    destructive. Generate a fresh one with the tf-platform PAT:
+
+      TF_PAT=$(kubectl get secret -n platform zitadel-tf-pat -o jsonpath='{.data.access_token}' | base64 -d)
+      kubectl port-forward -n platform svc/zitadel 8080:8080 &
+      USER_ID=$(curl -s -H "Authorization: Bearer $TF_PAT" -H 'Content-Type: application/json' \\
+        -X POST 'http://localhost:8080/v2/users' \\
+        -d '{"queries":[{"userNameQuery":{"userName":"login-client","method":"TEXT_QUERY_METHOD_EQUALS"}}]}' \\
+        | jq -r '.result[0].userId')
+      curl -s -H "Authorization: Bearer $TF_PAT" -H 'Content-Type: application/json' \\
+        -X POST "http://localhost:8080/management/v1/users/$USER_ID/pats" \\
+        -d '{"expirationDate":"2099-12-31T00:00:00Z"}' | jq -r '.token'
+
+    Empty when `services.zitadel.enabled = false`.
+  EOT
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "smarthost_address" {
+  description = "Hostname or IP of the outbound SMTP smart-host (relay) Stalwart sends every non-local message through. Empty disables relaying — direct MX delivery. Residential ISPs and Cloudflare Tunnel both block outbound :25, so a working relay is required for prod mail; the home cluster relays through a Postfix VPS at relay.ipsupport.us via the WireGuard overlay."
+  type        = string
+  default     = ""
+}
+
+variable "smarthost_port" {
+  description = "Smart-host TCP port. 25 for plain SMTP relay over a trusted overlay (WireGuard), 465 for implicit TLS submission, 587 for STARTTLS submission with auth."
+  type        = number
+  default     = 25
+}
+
+variable "smarthost_implicit_tls" {
+  description = "Use TLS for every connection to the smart host (port 465 style). False for plain :25 over a trusted overlay."
+  type        = bool
+  default     = false
+}
+
+variable "smarthost_allow_invalid_certs" {
+  description = "Skip TLS certificate validation when connecting to the smart host. Only flip on for a relay presenting a self-signed cert on a trusted network."
+  type        = bool
+  default     = false
+}
+
+variable "smarthost_username" {
+  description = "Optional SMTP AUTH username for the smart host. Empty skips AUTH (relay accepts by source IP)."
+  type        = string
+  default     = ""
+}
+
+variable "smarthost_password" {
+  description = "SMTP AUTH password matching `smarthost_username`. Sensitive — supply via TF_VAR_smarthost_password in .env. Ignored when username is empty."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "primary_mail_domain" {
+  description = "Tenant domain that owns the platform's mail stack. Must match a `name:` in `config/domains/<x>.yaml` — its `cloudflare_zone_id` drives the SPF/DKIM/DMARC TXT records `modules/stalwart` emits, and `mail.<this>` is the WebUI hostname. Single-domain mail today; the variable lets you flip primary without code edits when a different tenant takes over mail."
+  type        = string
+  default     = "ipsupport.us"
+}

--- a/zitadel.tf
+++ b/zitadel.tf
@@ -113,4 +113,5 @@ module "zitadel" {
   first_admin_email         = local.platform.services.zitadel.first_admin_email
   first_admin_username      = local.platform.services.zitadel.first_admin_username
   login_policy              = local.platform.services.zitadel.login_policy
+  login_client_pat          = var.zitadel_login_client_pat
 }


### PR DESCRIPTION
## Summary

End-to-end OIDC-only mail stack in a dedicated `mail` namespace. Stalwart owns SMTP/IMAP/JMAP, Roundcube owns the mailbox UI, and a new cluster-wide `oauth2-proxy` module ships a `traefik-forward-auth` gate any tenant component can opt into via `auth: zitadel` in its yaml.

- **Stalwart** (`modules/stalwart`, v0.16.x) — declarative bootstrap via `stalwart-cli apply` (Zitadel `OidcDirectory`, `MtaRoute Relay` smarthost, RSA `DkimSignature`, mail UI `defaultDomainId`). DKIM/SPF/DMARC TXT records emitted directly as `cloudflare_record` from the module — values derived from the in-state RSA pubkey, never hand-pasted. Admin/account WebUI sit behind a per-deploy random URL prefix so `/admin` doesn't surface on the public root.
- **Roundcube** (`modules/roundcube`, 1.6.x) — built-in OAuth2 (core feature in 1.5+, NOT the legacy plugin), confidential `OIDC_AUTH_METHOD_TYPE_BASIC` Zitadel client, IMAP/SMTP via SASL XOAUTH2. SQLite hostPath, init container chowns `/var/roundcube/db` to apache uid 33.
- **oauth2-proxy** (`modules/oauth2-proxy`, thomseddon/traefik-forward-auth) — cluster-wide ForwardAuth middleware. Self-attached on `auth.<domain>` so `RootHandler` sees `X-Forwarded-*` on the `/_oauth` callback (otherwise infinite redirect — documented in architecture.md "Known Limitations").
- **modules/project** — new `oauth2_proxy_middlewares` var, IngressRoute middleware chain composes `force-https-proto` → ForwardAuth on components with `auth: zitadel`, with a precondition that fails plan if the gate isn't deployed.
- **modules/zitadel** — pin login UI to `:v3.0.1` (rolling `:main` ships a SPA race that double-submits `createCallback`). Optional operator-provided `login_client_pat` mounted from a Secret survives pod restarts.
- **cloudflare.tf** — `origin_request.origin_server_name` set to the public hostname so Traefik serves the LE cert instead of its self-signed default.

New outputs: `stalwart_admin_url` (sensitive), `stalwart_account_url`, `stalwart_recovery_admin_password`, `stalwart_dkim_dns`, `stalwart_spf_dns`, `stalwart_dmarc_dns`. Cheatsheet updated.

`BACKLOG.md` captures known follow-ups: Stalwart-vs-traditional reconsideration trigger, public-IP deploy mode (drop mandatory Cloudflare Tunnel), Infisical secrets store, `login-client.pat` auto-recovery, Zitadel project consolidation per-domain.

Companion change: outbound smarthost lives in `rromenskyi/ansible-relay.ipsupport.us` (Postfix relay VPS, WireGuard overlay, certbot HTTP-01 with deploy hook).

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform validate` passes
- [x] `terraform plan` produces a sane diff (already applied on the home cluster)
- [x] Outbound flow: Roundcube → Zitadel SSO → Stalwart submission:465 → MtaRoute smarthost → relay → gmail (DKIM/SPF/DMARC pass observed)
- [x] Inbound flow: gmail → MX `relay.ipsupport.us:25` → STARTTLS (LE cert) → forward over WG → Stalwart auto-provisions Zitadel-OIDC user → ingests
- [x] Roundcube auto-discovers IMAP/SMTP via XOAUTH2; no app passwords issued
- [x] Stalwart admin WebUI gated behind random prefix; recovery admin still works for OIDC outage
- [x] Zitadel role gate: user without `mail-user` role bounced at `/authorize` (project_role_check enforced)
- [ ] Re-bootstrap drill on a clean clone (deferred — covered by BACKLOG `login-client.pat` auto-recovery item)

🤖 Generated with [Claude Code](https://claude.com/claude-code)