### PR TITLE
fix(component): rollout pods on OIDC Secret rotation via checksum annotation

### DIFF
--- a/modules/component/main.tf
+++ b/modules/component/main.tf
@@ -116,6 +116,12 @@ variable "oidc_secret_name" {
   default     = null
 }
 
+variable "pod_annotations" {
+  description = "Pod-template annotations rendered under `spec.template.metadata.annotations`. Primary use: a `checksum/<name>` entry whose value is a hash of an envFrom-mounted Secret's contents — when the Secret rotates, the annotation flips, and the Deployment rolls out so the pod picks up the new env. K8s does NOT rollout pods on Secret change by itself (envFrom values are read at process start), so anything that drives env from an externally-rotatable Secret (Zitadel OIDC client, etc.) needs this. Caller computes the hash and passes it here."
+  type        = map(string)
+  default     = {}
+}
+
 variable "static_env" {
   description = "Additional static env vars (name → literal value) mounted directly on the container. Use when a component needs a plain env knob that isn't a secret and doesn't come from a shared service."
   type        = map(string)
@@ -458,7 +464,8 @@ resource "kubernetes_deployment_v1" "this" {
 
     template {
       metadata {
-        labels = { app = var.name }
+        labels      = { app = var.name }
+        annotations = var.pod_annotations
       }
 
       spec {

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -887,6 +887,13 @@ module "component" {
     module.zitadel_app[each.key].secret_name
   ) : null
 
+  # Drive a pod rollout whenever the OIDC Secret rotates. K8s doesn't
+  # do this on its own for envFrom-sourced env vars — see the
+  # `pod_annotations` var in modules/component for the why.
+  pod_annotations = contains(keys(local.app_components_with_oidc), each.key) ? {
+    "checksum/oidc" = module.zitadel_app[each.key].secret_checksum
+  } : {}
+
   static_env = try(each.value.env_static, {})
 
   random_env_secret_name = contains(local.env_random_components, each.key) ? (

--- a/modules/zitadel-app/main.tf
+++ b/modules/zitadel-app/main.tf
@@ -202,6 +202,16 @@ output "secret_name" {
   description = "Name of the Secret holding AUTH_ZITADEL_ISSUER, AUTH_ZITADEL_ID, AUTH_ZITADEL_SECRET, AUTH_SECRET — feed into the component as `oidc_secret_name`."
 }
 
+output "secret_checksum" {
+  description = "SHA1 of the OIDC Secret's data, surfaced for use as a pod-template `checksum/oidc` annotation. Drives a Deployment rollout when the Zitadel app is recreated (e.g. after `terraform destroy`+`apply`, or after a manual app rotation in Zitadel) so the pod picks up the new client_id/client_secret instead of carrying the stale env from its previous start. The hash itself reveals nothing — `nonsensitive()` is used to drop the sensitivity bit so the annotation is renderable."
+  value = nonsensitive(sha1(jsonencode({
+    issuer        = var.issuer_url
+    client_id     = zitadel_application_oidc.this.client_id
+    client_secret = zitadel_application_oidc.this.client_secret
+    auth_secret   = random_password.auth_secret.result
+  })))
+}
+
 output "project_id" {
   value = zitadel_project.this.id
 }


### PR DESCRIPTION
## Summary

Fixes the bug behind today's `dash.ipsupport.us` `Errors.App.NotFound` flow: K8s does not auto-rollout pods when an envFrom-mounted Secret's data changes (envFrom values are read at process start and stay stale until the pod restarts). For TF-owned Secrets that rotate as a side effect of a Zitadel app destroy/recreate, the running pod keeps serving the old `client_id`/`client_secret` while the on-disk Secret is already current.

Fix: hash the OIDC Secret's source values (issuer + client_id + client_secret + auth_secret) in `modules/zitadel-app`, surface as a new `secret_checksum` output, and let `modules/project` paste it into the component's pod-template `annotations["checksum/oidc"]` via a new `pod_annotations` var on `modules/component`. Any change to the underlying OIDC values now flips the annotation → TF template diff → Deployment rollout → pod boots fresh against the current Secret.

Scoped to the OIDC Secret only:
- DB/Postgres/Redis/Ollama Secrets are TF-owned `random_password`s whose rotation already manifests as a TF diff on every consumer
- OIDC is the special case because the SOURCE of rotation is external (a Zitadel app's lifecycle in the Zitadel API), not a `random_password` in TF state

## Test plan

- [x] `terraform validate` passes
- [x] `./tf plan` shows in-place template updates on every kind:app component (platform-dash, sipmesh-frontend) — the annotation gets seeded once on the next apply, then participates in diffs going forward
- [x] `nonsensitive(sha1(...))` drops the sensitivity bit so the annotation is renderable; the hash itself reveals nothing about the secret values
- [ ] Apply on the home cluster and confirm a manual `zitadel_application_oidc` rotation (e.g. terraform taint/destroy/apply) now triggers a Deployment rollout instead of leaving stale pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)