### PR TITLE
fix(mail): close two OIDC/secret-rotation gaps from review

### DIFF
--- a/modules/roundcube/main.tf
+++ b/modules/roundcube/main.tf
@@ -403,6 +403,23 @@ resource "kubernetes_deployment_v1" "roundcube" {
         labels = { app = "roundcube" }
         annotations = {
           "platform.local/config-hash" = local.config_inc_hash
+
+          # Rolls the pod when the OIDC Secret content changes — same
+          # rationale as `modules/component`'s `pod_annotations.checksum/oidc`:
+          # K8s does NOT auto-rollout pods on Secret-data change for
+          # envFrom-mounted vars (env is read at process start). The
+          # client_secret is consumed via env (`ROUNDCUBE_OAUTH_CLIENT_SECRET`),
+          # not interpolated into config_inc_php, so a Zitadel app rotation
+          # that shifts client_secret independently of client_id would slip
+          # past the config-hash above without this. `nonsensitive()` drops
+          # the sensitivity bit on the hash output (the hash itself reveals
+          # nothing).
+          "platform.local/oidc-hash" = local.oidc_enabled ? nonsensitive(sha1(jsonencode({
+            issuer        = var.zitadel_issuer_url
+            client_id     = local.client_id
+            client_secret = local.client_secret
+            des_key       = random_password.des_key["enabled"].result
+          }))) : ""
         }
       }
 

--- a/modules/stalwart/main.tf
+++ b/modules/stalwart/main.tf
@@ -823,9 +823,16 @@ resource "kubernetes_secret_v1" "recovery_admin" {
   }
 }
 
-# ── ConfigMap with config.json + plan.ndjson ──────────────────────────────────
-
-resource "kubernetes_config_map_v1" "stalwart_seed" {
+# ── Secret with config.json + plan.ndjson ────────────────────────────────────
+#
+# Routed via Secret (not ConfigMap) because plan.ndjson can carry
+# `var.smarthost_password` plaintext when the operator uses an
+# AUTH-required outbound relay. ConfigMap data lands in etcd as
+# plaintext; Secret data is base64 + etcd-encryption-at-rest when the
+# cluster is configured for it (k3s enables it by default since
+# 1.20). The applier sidecar reads the same files at the same mount
+# path — only the volume source differs.
+resource "kubernetes_secret_v1" "stalwart_seed" {
   for_each = local.instances
 
   metadata {
@@ -1385,8 +1392,8 @@ resource "kubernetes_deployment_v1" "stalwart" {
 
         volume {
           name = "seed"
-          config_map {
-            name = kubernetes_config_map_v1.stalwart_seed["enabled"].metadata[0].name
+          secret {
+            secret_name = kubernetes_secret_v1.stalwart_seed["enabled"].metadata[0].name
           }
         }
 


### PR DESCRIPTION
## Summary

Two follow-ups to PR #28 that surfaced during the review of PR #27.

**1. Roundcube doesn't rollout when only the OIDC `client_secret` rotates.**
`config_inc_php` interpolates `client_id` (which changes the `platform.local/config-hash` annotation), but `client_secret` is read at runtime via `getenv('ROUNDCUBE_OAUTH_CLIENT_SECRET')` from an envFrom-mounted Secret. K8s does not auto-rollout pods when a Secret's data changes. So a Zitadel-side regenerate-secret call leaves Roundcube serving the stale secret until an unrelated trigger.

Mirrors the `checksum/oidc` pattern from PR #28 — adds a `platform.local/oidc-hash` pod-template annotation hashing issuer + client_id + client_secret + des_key. `nonsensitive()` drops the sensitivity bit on the hash output.

**2. Stalwart's `plan.ndjson` could leak a smarthost SMTP-AUTH password via a ConfigMap.**
When `var.smarthost_password` is set (operator relays through an AUTH-required SaaS like Mailgun/SendGrid), the value renders verbatim into the `MtaRoute Relay` JSON inside `local.plan_ndjson`, which lands in `kubernetes_config_map_v1.stalwart_seed`. ConfigMap data is plaintext in etcd.

Convert `kubernetes_config_map_v1.stalwart_seed` → `kubernetes_secret_v1.stalwart_seed`. Same data keys, same mount path, just a Secret-source volume now. The home cluster's relay accepts by WG peer-ACL (no AUTH), so live plan.ndjson is currently password-free; the fix is for downstream operators.

## Test plan

- [x] `terraform validate` passes
- [x] `./tf plan` shows 4 in-place Deployment updates + 1 ConfigMap → Secret swap; no destroys beyond the seed kind change
- [ ] Apply on the home cluster and confirm Stalwart applier reads plan.ndjson from the Secret-mounted path the same way it did from the ConfigMap mount (idempotent — re-running `stalwart-cli apply` produces no diffs)
- [ ] Sanity-check Roundcube rolls out automatically when `terraform taint module.roundcube.zitadel_application_oidc.roundcube["enabled"]` + `apply` rotates the OIDC client

🤖 Generated with [Claude Code](https://claude.com/claude-code)