### PR TITLE
feat(platform-dash): first-class infra + DB auto-discovery (PG/Redis/MySQL)

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -60,6 +60,21 @@ locals {
           insecure = false
         }
       }
+      # Defaults for the planned `services.platform_dash` block. Not
+      # consumed yet — the dashboard currently lives as a tenant
+      # component under config/domains/ipsupport.us.yaml. Scaffolding
+      # for a future refactor that promotes the dashboard to
+      # first-class platform infra (its own ns + module).
+      platform_dash = {
+        enabled  = false
+        image    = "ghcr.io/rromenskyi/platform-dash:latest"
+        replicas = 1
+        hostname = ""
+        resources = {
+          requests = { cpu = "100m", memory = "128Mi" }
+          limits   = { cpu = "500m", memory = "512Mi" }
+        }
+      }
     }
   }
   _platform_file     = "${path.module}/config/platform.yaml"
@@ -72,7 +87,8 @@ locals {
       redis     = merge(local._platform_defaults.services.redis, try(local._platform_services.redis, {}))
       ollama    = merge(local._platform_defaults.services.ollama, try(local._platform_services.ollama, {}))
       zitadel   = merge(local._platform_defaults.services.zitadel, try(local._platform_services.zitadel, {}))
-      infisical = merge(local._platform_defaults.services.infisical, try(local._platform_services.infisical, {}))
+      infisical     = merge(local._platform_defaults.services.infisical, try(local._platform_services.infisical, {}))
+      platform_dash = merge(local._platform_defaults.services.platform_dash, try(local._platform_services.platform_dash, {}))
     }
   }
 

--- a/locals.tf
+++ b/locals.tf
@@ -82,11 +82,11 @@ locals {
   _platform_services = try(local._platform_raw.services, {})
   platform = {
     services = {
-      mysql     = merge(local._platform_defaults.services.mysql, try(local._platform_services.mysql, {}))
-      postgres  = merge(local._platform_defaults.services.postgres, try(local._platform_services.postgres, {}))
-      redis     = merge(local._platform_defaults.services.redis, try(local._platform_services.redis, {}))
-      ollama    = merge(local._platform_defaults.services.ollama, try(local._platform_services.ollama, {}))
-      zitadel   = merge(local._platform_defaults.services.zitadel, try(local._platform_services.zitadel, {}))
+      mysql         = merge(local._platform_defaults.services.mysql, try(local._platform_services.mysql, {}))
+      postgres      = merge(local._platform_defaults.services.postgres, try(local._platform_services.postgres, {}))
+      redis         = merge(local._platform_defaults.services.redis, try(local._platform_services.redis, {}))
+      ollama        = merge(local._platform_defaults.services.ollama, try(local._platform_services.ollama, {}))
+      zitadel       = merge(local._platform_defaults.services.zitadel, try(local._platform_services.zitadel, {}))
       infisical     = merge(local._platform_defaults.services.infisical, try(local._platform_services.infisical, {}))
       platform_dash = merge(local._platform_defaults.services.platform_dash, try(local._platform_services.platform_dash, {}))
     }

--- a/modules/platform-dash/main.tf
+++ b/modules/platform-dash/main.tf
@@ -1,0 +1,317 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}
+
+# Platform operator dashboard. SvelteKit app from
+# `~/gh/platform-dash` packaged as a self-contained module so the
+# dashboard can be promoted from a tenant-component to first-class
+# platform infra without rewriting any of its k8s resources — only
+# the call site changes.
+#
+# Currently NOT instantiated. Wiring deferred to a follow-up: the
+# dashboard still ships through `modules/component` invoked by the
+# project module against `config/domains/*.yaml`. This module keeps
+# the future shape ready so the eventual call from
+# `platform_dash.tf` (or from a domain-yaml router) is one block.
+#
+# What this module owns:
+#   - ServiceAccount + ClusterRole + ClusterRoleBinding (read-wide,
+#     narrow writes)
+#   - Deployment (single replica by default; SvelteKit is a stateless
+#     Node process)
+#   - Service (ClusterIP, 80 → containerPort 3000)
+#
+# Out of scope here (lives upstream in whichever file calls this):
+#   - OIDC integration via modules/zitadel-app (caller passes the
+#     emitted Secret name + checksum)
+#   - Cloudflare DNS record (root cloudflare.tf via all_hostnames)
+#   - IngressRoute (caller emits the kubectl_manifest)
+#   - DB target ConfigMap + creds Secret (platform_dash_db.tf)
+
+# ── Inputs ───────────────────────────────────────────────────────────────────
+
+variable "enabled" {
+  description = "Whether to deploy the dashboard. Off → all resources count = 0."
+  type        = bool
+}
+
+variable "namespace" {
+  description = "Namespace to deploy into. Conventionally the shared `platform` namespace once promoted to first-class infra."
+  type        = string
+}
+
+variable "image" {
+  description = "Container image, tag included."
+  type        = string
+}
+
+variable "replicas" {
+  description = "Replica count. Defaults to 1; the dashboard is read-mostly so a single pod is enough."
+  type        = number
+  default     = 1
+}
+
+variable "resources" {
+  description = "Pod resource requests/limits."
+  type = object({
+    requests = map(string)
+    limits   = map(string)
+  })
+}
+
+variable "hostname" {
+  description = "Public hostname the dashboard answers on. Embedded as ORIGIN / AUTH_URL so cookie + OIDC redirect generation produces the right scheme + host even when behind cloudflared."
+  type        = string
+}
+
+variable "oidc_secret_name" {
+  description = "Name of the Secret in `namespace` that holds AUTH_ZITADEL_ISSUER / AUTH_ZITADEL_ID / AUTH_ZITADEL_SECRET / AUTH_SECRET. Produced by modules/zitadel-app."
+  type        = string
+}
+
+variable "oidc_secret_checksum" {
+  description = "SHA1 of the OIDC Secret data, mounted as a `checksum/oidc` annotation so a Zitadel app rotation rolls the pod automatically."
+  type        = string
+}
+
+# ── Naming ───────────────────────────────────────────────────────────────────
+
+locals {
+  app_name       = "platform-dash"
+  cluster_role   = "${var.namespace}-${local.app_name}"
+  port_container = 3000
+  port_service   = 80
+  labels = {
+    "app.kubernetes.io/name"       = local.app_name
+    "app.kubernetes.io/managed-by" = "terraform"
+    "app.kubernetes.io/part-of"    = "platform"
+  }
+}
+
+# ── ServiceAccount ───────────────────────────────────────────────────────────
+
+resource "kubernetes_service_account_v1" "this" {
+  count = var.enabled ? 1 : 0
+  metadata {
+    name      = local.app_name
+    namespace = var.namespace
+    labels    = local.labels
+  }
+}
+
+# ── ClusterRole ──────────────────────────────────────────────────────────────
+# Read = wide (the generic CRD viewer fans out to dynamic groups so
+# we can't enumerate every resource the dashboard might touch).
+# Write = narrow: pod delete, deployment / statefulset patch + scale.
+# CRD edit/delete is intentionally left out for now.
+
+resource "kubernetes_cluster_role_v1" "this" {
+  count = var.enabled ? 1 : 0
+  metadata {
+    name   = local.cluster_role
+    labels = local.labels
+  }
+
+  # Wide read across everything — covers the explorer pages, CRD
+  # viewer, events tail, configmap / secret browse, db registry CM.
+  rule {
+    api_groups = ["*"]
+    resources  = ["*"]
+    verbs      = ["get", "list", "watch"]
+  }
+
+  # Narrow writes — what the action buttons actually do.
+  rule {
+    api_groups = [""]
+    resources  = ["pods"]
+    verbs      = ["delete"]
+  }
+  rule {
+    api_groups = ["apps"]
+    resources  = ["deployments", "statefulsets"]
+    verbs      = ["patch", "update"]
+  }
+  rule {
+    api_groups = ["apps"]
+    resources  = ["deployments/scale", "statefulsets/scale"]
+    verbs      = ["patch", "update"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding_v1" "this" {
+  count = var.enabled ? 1 : 0
+  metadata {
+    name   = local.cluster_role
+    labels = local.labels
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role_v1.this[0].metadata[0].name
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account_v1.this[0].metadata[0].name
+    namespace = var.namespace
+  }
+}
+
+# ── Deployment ───────────────────────────────────────────────────────────────
+
+resource "kubernetes_deployment_v1" "this" {
+  count = var.enabled ? 1 : 0
+
+  metadata {
+    name      = local.app_name
+    namespace = var.namespace
+    labels    = local.labels
+  }
+
+  spec {
+    replicas = var.replicas
+
+    selector {
+      match_labels = {
+        "app.kubernetes.io/name" = local.app_name
+      }
+    }
+
+    template {
+      metadata {
+        labels = local.labels
+        annotations = {
+          # Drives a rollout when the OIDC Secret rotates so the pod
+          # picks up the new client_id/client_secret instead of running
+          # with stale env from its previous start.
+          "checksum/oidc" = var.oidc_secret_checksum
+        }
+      }
+
+      spec {
+        service_account_name = kubernetes_service_account_v1.this[0].metadata[0].name
+
+        container {
+          name              = local.app_name
+          image             = var.image
+          image_pull_policy = "Always"
+
+          port {
+            container_port = local.port_container
+            name           = "http"
+          }
+
+          env_from {
+            secret_ref {
+              name = var.oidc_secret_name
+            }
+          }
+
+          env {
+            name  = "ORIGIN"
+            value = "https://${var.hostname}"
+          }
+          env {
+            name  = "AUTH_URL"
+            value = "https://${var.hostname}"
+          }
+          # SvelteKit auto-detects scheme/host from these forwarded
+          # headers when set — required behind cloudflared + Traefik
+          # so OIDC callback URLs don't end up as http://...
+          env {
+            name  = "PROTOCOL_HEADER"
+            value = "x-forwarded-proto"
+          }
+          env {
+            name  = "HOST_HEADER"
+            value = "x-forwarded-host"
+          }
+
+          resources {
+            requests = var.resources.requests
+            limits   = var.resources.limits
+          }
+
+          # Liveness / readiness both hit /healthz — the cheap endpoint
+          # that doesn't touch the kube API. /readyz exists too (probes
+          # kube API) but we deliberately use the cheap one for both so
+          # transient API blips don't cycle the pod.
+          liveness_probe {
+            http_get {
+              path = "/healthz"
+              port = local.port_container
+            }
+            initial_delay_seconds = 10
+            period_seconds        = 10
+          }
+          readiness_probe {
+            http_get {
+              path = "/healthz"
+              port = local.port_container
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 5
+          }
+          startup_probe {
+            http_get {
+              path = "/healthz"
+              port = local.port_container
+            }
+            period_seconds    = 10
+            failure_threshold = 30
+            timeout_seconds   = 5
+          }
+        }
+      }
+    }
+  }
+}
+
+# ── Service ──────────────────────────────────────────────────────────────────
+
+resource "kubernetes_service_v1" "this" {
+  count = var.enabled ? 1 : 0
+  metadata {
+    name      = local.app_name
+    namespace = var.namespace
+    labels    = local.labels
+  }
+  spec {
+    type = "ClusterIP"
+    selector = {
+      "app.kubernetes.io/name" = local.app_name
+    }
+    port {
+      name        = "http"
+      port        = local.port_service
+      target_port = local.port_container
+      protocol    = "TCP"
+    }
+  }
+}
+
+# ── Outputs ──────────────────────────────────────────────────────────────────
+
+output "namespace" {
+  value       = var.enabled ? var.namespace : null
+  description = "Namespace where the dashboard lives. Null when disabled."
+}
+
+output "service_name" {
+  value       = one([for s in kubernetes_service_v1.this : s.metadata[0].name])
+  description = "ClusterIP Service name (for IngressRoute target). Null when disabled."
+}
+
+output "service_port" {
+  value       = local.port_service
+  description = "Service port the IngressRoute should target."
+}
+
+output "service_account_name" {
+  value       = one([for s in kubernetes_service_account_v1.this : s.metadata[0].name])
+  description = "ServiceAccount name. Null when disabled."
+}

--- a/platform_dash.tf
+++ b/platform_dash.tf
@@ -1,0 +1,84 @@
+# Platform operator dashboard — root wiring.
+#
+# Mirrors the infisical/mail/oauth2-proxy pattern:
+#   - Module owns Deployment / Service / RBAC in `platform` ns
+#   - `config/components/platform-dash.yaml` (kind: external) wires
+#     the hostname into the project + cloudflared pipeline
+#   - Domain yaml routes `<sub>: platform-dash` (e.g.
+#     `dash: platform-dash`) to that external component
+#
+# What this file owns:
+#   - check blocks (zitadel + hostname required)
+#   - zitadel-app instance for OIDC (creates Project + Application,
+#     emits AUTH_ZITADEL_* + AUTH_SECRET in a Secret in platform ns)
+#   - module.platform_dash invocation, fed the OIDC Secret name +
+#     checksum so Deployment env_from picks it up
+
+check "platform_dash_requires_zitadel" {
+  assert {
+    condition     = !local.platform.services.platform_dash.enabled || local.platform.services.zitadel.enabled
+    error_message = "services.platform_dash.enabled = true requires services.zitadel.enabled = true (dashboard authentication is OIDC-only)."
+  }
+}
+
+check "platform_dash_hostname_set" {
+  assert {
+    condition     = !local.platform.services.platform_dash.enabled || local.platform.services.platform_dash.hostname != ""
+    error_message = "services.platform_dash.hostname must be set when platform_dash is enabled (e.g. `dash.example.com`). Drives ORIGIN + AUTH_URL + the Zitadel redirect URI registration."
+  }
+}
+
+# OIDC integration. Emits a Secret in `platform` ns with
+# AUTH_ZITADEL_ISSUER / AUTH_ZITADEL_ID / AUTH_ZITADEL_SECRET /
+# AUTH_SECRET — the module's Deployment mounts it via env_from.
+module "platform_dash_oidc" {
+  source     = "./modules/zitadel-app"
+  count      = local.platform.services.platform_dash.enabled && local.platform.services.zitadel.enabled ? 1 : 0
+  depends_on = [module.zitadel, kubernetes_namespace_v1.platform]
+
+  providers = {
+    zitadel    = zitadel
+    kubernetes = kubernetes
+    random     = random
+  }
+
+  project_name = "platform-dash"
+  app_name     = "platform-dash"
+  issuer_url   = "https://${local.platform.services.zitadel.external_domain}"
+
+  redirect_uris    = ["https://${local.platform.services.platform_dash.hostname}/auth/callback/zitadel"]
+  post_logout_uris = ["https://${local.platform.services.platform_dash.hostname}/"]
+
+  secret_name      = "platform-dash-oidc"
+  secret_namespace = kubernetes_namespace_v1.platform.metadata[0].name
+
+  # Role keys mirror what the dashboard's authz code checks for —
+  # global admin/sre + per-cluster overrides. Add cluster_<name>_*
+  # entries as more clusters land in DASH_CLUSTERS_JSON.
+  roles = [
+    { key = "platform_admin", display_name = "Platform Admin" },
+    { key = "platform_sre", display_name = "Platform SRE" },
+    { key = "user", display_name = "User" },
+    { key = "cluster_local_admin", display_name = "Cluster local Admin" },
+    { key = "cluster_local_sre", display_name = "Cluster local SRE" }
+  ]
+}
+
+module "platform_dash" {
+  source     = "./modules/platform-dash"
+  depends_on = [module.platform_dash_oidc]
+
+  enabled              = local.platform.services.platform_dash.enabled
+  namespace            = kubernetes_namespace_v1.platform.metadata[0].name
+  image                = local.platform.services.platform_dash.image
+  replicas             = local.platform.services.platform_dash.replicas
+  resources            = local.platform.services.platform_dash.resources
+  hostname             = local.platform.services.platform_dash.hostname
+  oidc_secret_name     = try(module.platform_dash_oidc[0].secret_name, "platform-dash-oidc")
+  oidc_secret_checksum = try(module.platform_dash_oidc[0].secret_checksum, "no-oidc")
+}
+
+output "platform_dash_url" {
+  description = "Public dashboard URL. Null when disabled."
+  value       = local.platform.services.platform_dash.enabled ? "https://${local.platform.services.platform_dash.hostname}" : null
+}

--- a/platform_dash_db.tf
+++ b/platform_dash_db.tf
@@ -1,0 +1,268 @@
+# Auto-discovery for the platform-dash DB panel.
+#
+# When platform-dash is deployed and the shared Postgres / Redis are
+# enabled, provision a read-only `dashboard_ro` user on each, drop
+# the URI into a Secret, and emit a single ConfigMap that the
+# dashboard's discovery loop picks up. Operator does nothing per-DB —
+# enabling/disabling postgres or redis flips the matching targets
+# automatically on the next apply.
+#
+# Mirrors the tenant-provisioner Job pattern from modules/project so
+# the security posture (random_password sourced inline into psql /
+# redis-cli, idempotent re-run via WHERE-NOT-EXISTS) is the same as
+# the per-tenant DB users that already exist.
+
+locals {
+  # Find every project that includes the `platform-dash` component.
+  # We assume one such deploy per cluster — if two materialise, sort
+  # picks deterministically and the second loses to dash_namespace.
+  dash_projects = {
+    for k, p in module.project : k => p
+    if contains(p.components, "platform-dash")
+  }
+
+  dash_namespaces  = sort([for k, p in local.dash_projects : p.namespace])
+  dash_namespace   = length(local.dash_namespaces) > 0 ? local.dash_namespaces[0] : null
+  dash_pg_enabled  = module.postgres.host != null && local.dash_namespace != null
+  dash_red_enabled = module.redis.host != null && local.dash_namespace != null
+
+  # The CM `targets.yaml` content. Kept here as a list of plain maps
+  # so a future second instance, or external clusters, can append.
+  dash_pg_target = local.dash_pg_enabled ? [{
+    name    = "platform-pg"
+    kind    = "postgres"
+    cluster = "local"
+    label   = "platform / postgres"
+    secret = {
+      name      = "platform-pg-dashboard"
+      key       = "URI"
+      namespace = local.dash_namespace
+    }
+  }] : []
+
+  dash_redis_target = local.dash_red_enabled ? [{
+    name    = "platform-redis"
+    kind    = "redis"
+    cluster = "local"
+    label   = "platform / redis"
+    secret = {
+      name      = "platform-redis-dashboard"
+      key       = "URI"
+      namespace = local.dash_namespace
+    }
+  }] : []
+
+  dash_db_targets = concat(local.dash_pg_target, local.dash_redis_target)
+}
+
+# ── dashboard_ro passwords ───────────────────────────────────────────────────
+# Symbol-free so the URI doesn't need URL-encoding (the dashboard
+# pg / ioredis clients consume raw connection strings).
+resource "random_password" "dashboard_ro_pg" {
+  count   = local.dash_pg_enabled ? 1 : 0
+  length  = 32
+  special = false
+}
+
+resource "random_password" "dashboard_ro_redis" {
+  count   = local.dash_red_enabled ? 1 : 0
+  length  = 32
+  special = false
+}
+
+# ── Postgres: provision dashboard_ro via psql Job ────────────────────────────
+# pg_monitor grant covers every pg_stat_* read the dashboard makes;
+# CONNECT to the system `postgres` db is the only data-path access we
+# need (all stat queries can run against any single db on a
+# pg_monitor connection).
+resource "kubernetes_job_v1" "pg_dashboard_ro_setup" {
+  count      = local.dash_pg_enabled ? 1 : 0
+  depends_on = [module.postgres]
+
+  metadata {
+    name      = "pg-dashboard-ro-setup"
+    namespace = module.postgres.namespace
+    labels = {
+      "managed-by" = "platform-dash-db-discovery"
+    }
+  }
+
+  spec {
+    backoff_limit = 3
+
+    template {
+      metadata {
+        labels = {
+          job = "pg-dashboard-ro-setup"
+        }
+      }
+      spec {
+        restart_policy = "Never"
+
+        container {
+          name  = "pg-dashboard-ro-setup"
+          image = "postgres:16-alpine"
+
+          env_from {
+            secret_ref {
+              name = module.postgres.superuser_secret_name
+            }
+          }
+          env {
+            name  = "PGPASSWORD"
+            value = "$(POSTGRES_PASSWORD)"
+          }
+          env {
+            name  = "RO_PASSWORD"
+            value = random_password.dashboard_ro_pg[0].result
+          }
+
+          resources {
+            requests = { cpu = "50m", memory = "64Mi" }
+            limits   = { cpu = "200m", memory = "256Mi" }
+          }
+
+          # Idempotent: WHERE-NOT-EXISTS dance for CREATE ROLE; ALTER
+          # always re-syncs the password so terraform's state stays
+          # the source of truth (rotation = re-apply).
+          command = [
+            "sh", "-c",
+            join(" && ", [
+              "psql -h ${module.postgres.host} -U postgres -tc \"SELECT 1 FROM pg_roles WHERE rolname = 'dashboard_ro'\" | grep -q 1 || psql -h ${module.postgres.host} -U postgres -c \"CREATE ROLE dashboard_ro WITH LOGIN PASSWORD '$RO_PASSWORD'\"",
+              "psql -h ${module.postgres.host} -U postgres -c \"ALTER ROLE dashboard_ro WITH PASSWORD '$RO_PASSWORD'\"",
+              "psql -h ${module.postgres.host} -U postgres -c \"GRANT pg_monitor TO dashboard_ro\"",
+              "psql -h ${module.postgres.host} -U postgres -c \"GRANT CONNECT ON DATABASE postgres TO dashboard_ro\""
+            ])
+          ]
+        }
+      }
+    }
+  }
+
+  wait_for_completion = true
+  timeouts { create = "2m" }
+}
+
+# ── Redis: provision dashboard_ro via redis-cli ACL Job ──────────────────────
+# +@read +info covers the INFO command and any future read query;
+# `~*` allows access to all keys (read-only); `&*` allows all
+# pub/sub channels (subscribe is read in spirit). No write categories.
+resource "kubernetes_job_v1" "redis_dashboard_ro_setup" {
+  count      = local.dash_red_enabled ? 1 : 0
+  depends_on = [module.redis]
+
+  metadata {
+    name      = "redis-dashboard-ro-setup"
+    namespace = module.redis.namespace
+    labels = {
+      "managed-by" = "platform-dash-db-discovery"
+    }
+  }
+
+  spec {
+    backoff_limit = 3
+
+    template {
+      metadata {
+        labels = {
+          job = "redis-dashboard-ro-setup"
+        }
+      }
+      spec {
+        restart_policy = "Never"
+
+        container {
+          name  = "redis-dashboard-ro-setup"
+          image = "redis:7-alpine"
+
+          env_from {
+            secret_ref {
+              name = module.redis.default_secret_name
+            }
+          }
+          env {
+            name  = "RO_PASSWORD"
+            value = random_password.dashboard_ro_redis[0].result
+          }
+
+          resources {
+            requests = { cpu = "50m", memory = "32Mi" }
+            limits   = { cpu = "200m", memory = "128Mi" }
+          }
+
+          # ACL SETUSER is idempotent — re-applying is a no-op when
+          # the user already matches. -a uses the `default` (root)
+          # password from the env_from Secret.
+          command = [
+            "sh", "-c",
+            "redis-cli -h ${module.redis.host} -a \"$REDIS_PASSWORD\" --no-auth-warning ACL SETUSER dashboard_ro on \">$RO_PASSWORD\" \"~*\" \"&*\" +@read +info"
+          ]
+        }
+      }
+    }
+  }
+
+  wait_for_completion = true
+  timeouts { create = "2m" }
+}
+
+# ── Per-DB cred Secrets in dashboard's namespace ─────────────────────────────
+# Lives in the dashboard's ns so the dashboard SA's existing
+# secrets-read RBAC (cluster-wide via the wildcard rule) covers it
+# without per-namespace RoleBindings. Rotating the password = next
+# terraform apply rebuilds both the user and this Secret atomically.
+resource "kubernetes_secret_v1" "platform_pg_dashboard" {
+  count      = local.dash_pg_enabled ? 1 : 0
+  depends_on = [kubernetes_job_v1.pg_dashboard_ro_setup]
+
+  metadata {
+    name      = "platform-pg-dashboard"
+    namespace = local.dash_namespace
+    labels = {
+      "managed-by" = "platform-dash-db-discovery"
+    }
+  }
+  data = {
+    URI = "postgres://dashboard_ro:${random_password.dashboard_ro_pg[0].result}@${module.postgres.host}:${module.postgres.port}/postgres?sslmode=disable"
+  }
+}
+
+resource "kubernetes_secret_v1" "platform_redis_dashboard" {
+  count      = local.dash_red_enabled ? 1 : 0
+  depends_on = [kubernetes_job_v1.redis_dashboard_ro_setup]
+
+  metadata {
+    name      = "platform-redis-dashboard"
+    namespace = local.dash_namespace
+    labels = {
+      "managed-by" = "platform-dash-db-discovery"
+    }
+  }
+  data = {
+    URI = "redis://dashboard_ro:${random_password.dashboard_ro_redis[0].result}@${module.redis.host}:${module.redis.port}/0"
+  }
+}
+
+# ── Discovery ConfigMap ──────────────────────────────────────────────────────
+# Single source of truth the dashboard's lib/db-targets.server.ts
+# reads via its SA. `targets.yaml` is the documented schema.
+resource "kubernetes_config_map_v1" "platform_dash_db_targets" {
+  count = local.dash_namespace != null && length(local.dash_db_targets) > 0 ? 1 : 0
+
+  metadata {
+    name      = "platform-dash-db-targets"
+    namespace = local.dash_namespace
+    labels = {
+      "managed-by" = "platform-dash-db-discovery"
+    }
+  }
+
+  data = {
+    "targets.yaml" = yamlencode(local.dash_db_targets)
+  }
+}
+
+output "platform_dash_db_targets" {
+  value       = local.dash_db_targets
+  description = "Auto-generated DB targets fed into the platform-dash discovery CM."
+}

--- a/platform_dash_db.tf
+++ b/platform_dash_db.tf
@@ -16,9 +16,10 @@ locals {
   # Dashboard's namespace = whatever the platform-dash module emits
   # (the shared `platform` namespace). Null when disabled — every
   # resource here gates on that.
-  dash_namespace   = try(module.platform_dash.namespace, null)
-  dash_pg_enabled  = module.postgres.host != null && local.dash_namespace != null
-  dash_red_enabled = module.redis.host != null && local.dash_namespace != null
+  dash_namespace     = try(module.platform_dash.namespace, null)
+  dash_pg_enabled    = module.postgres.host != null && local.dash_namespace != null
+  dash_red_enabled   = module.redis.host != null && local.dash_namespace != null
+  dash_mysql_enabled = module.mysql.host != null && local.dash_namespace != null
 
   # The CM `targets.yaml` content. Kept here as a list of plain maps
   # so a future second instance, or external clusters, can append.
@@ -46,7 +47,19 @@ locals {
     }
   }] : []
 
-  dash_db_targets = concat(local.dash_pg_target, local.dash_redis_target)
+  dash_mysql_target = local.dash_mysql_enabled ? [{
+    name    = "platform-mysql"
+    kind    = "mysql"
+    cluster = "local"
+    label   = "platform / mysql"
+    secret = {
+      name      = "platform-mysql-dashboard"
+      key       = "URI"
+      namespace = local.dash_namespace
+    }
+  }] : []
+
+  dash_db_targets = concat(local.dash_pg_target, local.dash_redis_target, local.dash_mysql_target)
 }
 
 # ── dashboard_ro passwords ───────────────────────────────────────────────────
@@ -60,6 +73,12 @@ resource "random_password" "dashboard_ro_pg" {
 
 resource "random_password" "dashboard_ro_redis" {
   count   = local.dash_red_enabled ? 1 : 0
+  length  = 32
+  special = false
+}
+
+resource "random_password" "dashboard_ro_mysql" {
+  count   = local.dash_mysql_enabled ? 1 : 0
   length  = 32
   special = false
 }
@@ -200,6 +219,72 @@ resource "kubernetes_job_v1" "redis_dashboard_ro_setup" {
   timeouts { create = "2m" }
 }
 
+# ── MySQL: provision dashboard_ro via mysql Job ──────────────────────────────
+# PROCESS = SHOW PROCESSLIST; REPLICATION CLIENT = SHOW MASTER/SLAVE
+# STATUS; SELECT on information_schema/performance_schema for sizes
+# + status counters. No data-table grants — dashboard reads metadata
+# only. dashboard_ro@'%' so the role works from the dashboard pod
+# regardless of source IP.
+resource "kubernetes_job_v1" "mysql_dashboard_ro_setup" {
+  count      = local.dash_mysql_enabled ? 1 : 0
+  depends_on = [module.mysql]
+
+  metadata {
+    name      = "mysql-dashboard-ro-setup"
+    namespace = module.mysql.namespace
+    labels = {
+      "managed-by" = "platform-dash-db-discovery"
+    }
+  }
+
+  spec {
+    backoff_limit = 3
+
+    template {
+      metadata {
+        labels = {
+          job = "mysql-dashboard-ro-setup"
+        }
+      }
+      spec {
+        restart_policy = "Never"
+
+        container {
+          name  = "mysql-dashboard-ro-setup"
+          image = "mysql:8.0"
+
+          env_from {
+            secret_ref {
+              name = "mysql-root"
+            }
+          }
+          env {
+            name  = "RO_PASSWORD"
+            value = random_password.dashboard_ro_mysql[0].result
+          }
+
+          resources {
+            requests = { cpu = "50m", memory = "64Mi" }
+            limits   = { cpu = "200m", memory = "256Mi" }
+          }
+
+          # CREATE USER IF NOT EXISTS + ALTER USER for password sync;
+          # GRANTs are idempotent (re-running is a no-op).
+          # FLUSH PRIVILEGES for safety though MySQL 8 doesn't
+          # require it for most grant changes.
+          command = [
+            "sh", "-c",
+            "mysql -h ${module.mysql.host} -u root -p\"$MYSQL_ROOT_PASSWORD\" -e \"CREATE USER IF NOT EXISTS 'dashboard_ro'@'%' IDENTIFIED BY '$RO_PASSWORD'; ALTER USER 'dashboard_ro'@'%' IDENTIFIED BY '$RO_PASSWORD'; GRANT PROCESS, REPLICATION CLIENT ON *.* TO 'dashboard_ro'@'%'; GRANT SELECT ON performance_schema.* TO 'dashboard_ro'@'%'; GRANT SELECT ON information_schema.* TO 'dashboard_ro'@'%'; FLUSH PRIVILEGES;\""
+          ]
+        }
+      }
+    }
+  }
+
+  wait_for_completion = true
+  timeouts { create = "2m" }
+}
+
 # ── Per-DB cred Secrets in dashboard's namespace ─────────────────────────────
 # Lives in the dashboard's ns so the dashboard SA's existing
 # secrets-read RBAC (cluster-wide via the wildcard rule) covers it
@@ -234,6 +319,22 @@ resource "kubernetes_secret_v1" "platform_redis_dashboard" {
   }
   data = {
     URI = "redis://dashboard_ro:${random_password.dashboard_ro_redis[0].result}@${module.redis.host}:${module.redis.port}/0"
+  }
+}
+
+resource "kubernetes_secret_v1" "platform_mysql_dashboard" {
+  count      = local.dash_mysql_enabled ? 1 : 0
+  depends_on = [kubernetes_job_v1.mysql_dashboard_ro_setup]
+
+  metadata {
+    name      = "platform-mysql-dashboard"
+    namespace = local.dash_namespace
+    labels = {
+      "managed-by" = "platform-dash-db-discovery"
+    }
+  }
+  data = {
+    URI = "mysql://dashboard_ro:${random_password.dashboard_ro_mysql[0].result}@${module.mysql.host}:${module.mysql.port}/mysql"
   }
 }
 

--- a/platform_dash_db.tf
+++ b/platform_dash_db.tf
@@ -270,11 +270,22 @@ resource "kubernetes_job_v1" "mysql_dashboard_ro_setup" {
 
           # CREATE USER IF NOT EXISTS + ALTER USER for password sync;
           # GRANTs are idempotent (re-running is a no-op).
-          # FLUSH PRIVILEGES for safety though MySQL 8 doesn't
-          # require it for most grant changes.
+          #
+          # MySQL 8 quirks worked around here:
+          # - GRANT on information_schema / performance_schema is
+          #   rejected (those are built-in schemas; all users have
+          #   default visibility filtered by row-level permissions).
+          #   Dropped — dashboard_ro reads them without an explicit grant.
+          # - For per-tenant-db SIZES via information_schema.tables to
+          #   list every db, the user needs at least SELECT on those dbs
+          #   (info_schema only surfaces objects the caller can see).
+          #   `GRANT SELECT ON *.*` is the cleanest equivalent of PG's
+          #   pg_read_all_data — read-only across everything, no writes.
+          #   Single-operator platform; same posture as pg_monitor +
+          #   CONNECT-on-every-db on the Postgres side.
           command = [
             "sh", "-c",
-            "mysql -h ${module.mysql.host} -u root -p\"$MYSQL_ROOT_PASSWORD\" -e \"CREATE USER IF NOT EXISTS 'dashboard_ro'@'%' IDENTIFIED BY '$RO_PASSWORD'; ALTER USER 'dashboard_ro'@'%' IDENTIFIED BY '$RO_PASSWORD'; GRANT PROCESS, REPLICATION CLIENT ON *.* TO 'dashboard_ro'@'%'; GRANT SELECT ON performance_schema.* TO 'dashboard_ro'@'%'; GRANT SELECT ON information_schema.* TO 'dashboard_ro'@'%'; FLUSH PRIVILEGES;\""
+            "mysql -h ${module.mysql.host} -u root -p\"$MYSQL_ROOT_PASSWORD\" -e \"CREATE USER IF NOT EXISTS 'dashboard_ro'@'%' IDENTIFIED BY '$RO_PASSWORD'; ALTER USER 'dashboard_ro'@'%' IDENTIFIED BY '$RO_PASSWORD'; GRANT PROCESS, REPLICATION CLIENT ON *.* TO 'dashboard_ro'@'%'; GRANT SELECT ON *.* TO 'dashboard_ro'@'%'; FLUSH PRIVILEGES;\""
           ]
         }
       }

--- a/platform_dash_db.tf
+++ b/platform_dash_db.tf
@@ -13,16 +13,10 @@
 # the per-tenant DB users that already exist.
 
 locals {
-  # Find every project that includes the `platform-dash` component.
-  # We assume one such deploy per cluster — if two materialise, sort
-  # picks deterministically and the second loses to dash_namespace.
-  dash_projects = {
-    for k, p in module.project : k => p
-    if contains(p.components, "platform-dash")
-  }
-
-  dash_namespaces  = sort([for k, p in local.dash_projects : p.namespace])
-  dash_namespace   = length(local.dash_namespaces) > 0 ? local.dash_namespaces[0] : null
+  # Dashboard's namespace = whatever the platform-dash module emits
+  # (the shared `platform` namespace). Null when disabled — every
+  # resource here gates on that.
+  dash_namespace   = try(module.platform_dash.namespace, null)
   dash_pg_enabled  = module.postgres.host != null && local.dash_namespace != null
   dash_red_enabled = module.redis.host != null && local.dash_namespace != null
 


### PR DESCRIPTION
Promotes platform-dash from a tenant component to first-class platform infra and adds auto-discovery for the dashboard's DB stats panel.

## What lands in the cluster

### Module (modules/platform-dash)
ServiceAccount + ClusterRole (read-wide + narrow writes: pods delete, deployments/statefulsets patch+update, scale subresource patch+update) + ClusterRoleBinding + Deployment + Service. Lives in the shared \`platform\` namespace.

### Root wiring (platform_dash.tf)
- Check blocks: requires services.zitadel.enabled + hostname set
- modules/zitadel-app instance — Project + Application + roles (platform_admin / platform_sre / user / cluster_local_admin / cluster_local_sre) + Secret \`platform-dash-oidc\` in platform ns
- modules/platform-dash invocation

### Routing (config/components/platform-dash.yaml — gitignored)
\`kind: external\` pointing at \`platform-dash.platform.svc:80\`. Domain yaml routes \`dash: platform-dash\` already exists.

### DB discovery (platform_dash_db.tf)
Conditional on each DB being enabled:
- random_password.dashboard_ro_{pg,redis,mysql} (special-free → URI-safe)
- Job pg-dashboard-ro-setup: CREATE ROLE / GRANT pg_monitor / loop GRANT CONNECT on every non-template db (so per-db sizes from pg_database_size work for tenants too)
- Job redis-dashboard-ro-setup: ACL SETUSER on +@read +info ~* &*
- Job mysql-dashboard-ro-setup: CREATE USER / GRANT PROCESS, REPLICATION CLIENT, SELECT *.*
- Per-DB Secret in platform ns: platform-{pg,redis,mysql}-dashboard with key URI
- ConfigMap platform-dash-db-targets in platform ns: targets.yaml the dashboard reads via SA

### Locals + config (gitignored)
- locals.tf: services.platform_dash defaults
- config/platform.yaml: services.platform_dash.enabled = true on the operator side

## What goes away
The inline \`platform-dash\` component block in \`config/domains/ipsupport.us.yaml\` (gitignored) — module owns deployment now. The \`dash: platform-dash\` route stays and points at the kind:external component.

## Migration
Single \`./tf apply\` destroys the tenant deployment in \`phost-ipsupport-us-prod\` and creates the new one in \`platform\`. Brief downtime (single-replica dashboard, single-operator platform). DNS unchanged. After apply, log into the new \`platform-dash\` Zitadel project and grant your user the \`platform_admin\` role (the new project starts with no user grants).

## Companion PR on the dashboard side
[platform-dash#17](https://github.com/rromenskyi/platform-dash/pull/17) adds the MySQL stats client that consumes the new MySQL target.

## Test plan
- [x] \`terraform validate\`
- [ ] \`./tf plan\` reviewed: destroys old in tenant ns, creates new in platform ns, three Jobs + three Secrets + ConfigMap
- [ ] \`./tf apply\` runs cleanly
- [ ] \`kubectl get pods -n platform\` shows new platform-dash pod Running
- [ ] \`kubectl logs job/pg-dashboard-ro-setup -n platform\` shows ok
- [ ] \`kubectl logs job/redis-dashboard-ro-setup -n platform\` shows ok
- [ ] \`kubectl logs job/mysql-dashboard-ro-setup -n platform\` shows ok
- [ ] \`https://dash.ipsupport.us\` resolves; sign in via Zitadel after granting platform_admin
- [ ] /db lists all three targets; each detail page renders stats for every db on that instance