### PR TITLE
feat(vault): Phase 0 — Vault community module, raft + auto-unseal

### DIFF
--- a/config/components/vault.yaml
+++ b/config/components/vault.yaml
@@ -1,0 +1,26 @@
+# Vault community — platform secrets store routing.
+#
+# `kind: external` because the workload itself is owned by `modules/
+# vault` (StatefulSet + raft storage in the platform namespace,
+# bootstrapped via `vault.tf` at the root). This component file only
+# describes how the hostname routes through Traefik + Cloudflare
+# Tunnel. Wire by adding a route to your domain yaml — the prefix
+# part of `<prefix>: vault` MUST match the
+# `services.vault.hostname` host-prefix you set in
+# `config/platform.yaml` (e.g. `hostname: vault.example.com` →
+# route `vault: vault`).
+#
+# Phase 0 leaves the UI publicly reachable with only Vault's built-
+# in auth gating (root token via `terraform output -raw vault_root_token`,
+# break-glass). Phase 1 (deferred) wires Zitadel OIDC SSO via the
+# `vault_jwt_auth_backend` TF provider — Vault handles authn itself,
+# no need for a forward-auth middleware in front. Vault also provides
+# fine-grained access control via policies, so the SSO step alone
+# replaces the whole "human + machine identity + role" tier Infisical
+# advertised.
+kind: external
+
+service:
+  name:      vault
+  namespace: platform
+  port:      8200

--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -98,6 +98,24 @@ services:
   # add an `id: zitadel` route to your operator-domain yaml under
   # `config/domains/<your-domain>.yaml` (the matching `kind: external`
   # component already lives at `config/components/zitadel.yaml`).
+  # Vault community — platform secrets store. Phase 0 brings up the
+  # server with raft single-node storage, an init Job seeds the root
+  # token + unseal key into a `vault-bootstrap` k8s Secret, and the
+  # pod's postStart lifecycle hook auto-unseals on every restart.
+  # Phase 1 (deferred) wires Zitadel JWT auth method — UI gets a
+  # "Sign in with OIDC" button alongside the root-token fallback.
+  # Phase 2 introduces the Vault Secrets Operator + first migrated
+  # tenant secret (Traefik dashboard BasicAuth).
+  #
+  # No external store dep — Vault's bundled raft backend is the
+  # canonical k8s self-host pattern. hostPath PV at
+  # `<host_volume_path>/<namespace>/vault/data/` survives `./tf
+  # bootstrap-k3s` (losing this dir wipes the secret store entirely).
+  vault:
+    enabled: false
+    hostname: vault.example.com
+
+
   zitadel:
     enabled: false
     # Public hostname Zitadel issues OIDC tokens for. Must equal the

--- a/locals.tf
+++ b/locals.tf
@@ -43,6 +43,10 @@ locals {
         tolerations   = []
         affinity      = {}
       }
+      vault = {
+        enabled  = false
+        hostname = ""
+      }
       zitadel = {
         enabled              = false
         external_domain      = ""
@@ -101,6 +105,7 @@ locals {
       redis         = merge(local._platform_defaults.services.redis, try(local._platform_services.redis, {}))
       ollama        = merge(local._platform_defaults.services.ollama, try(local._platform_services.ollama, {}))
       zitadel       = merge(local._platform_defaults.services.zitadel, try(local._platform_services.zitadel, {}))
+      vault         = merge(local._platform_defaults.services.vault, try(local._platform_services.vault, {}))
       platform_dash = merge(local._platform_defaults.services.platform_dash, try(local._platform_services.platform_dash, {}))
     }
   }

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -114,6 +114,14 @@ locals {
   # Single-node raft + UI + listener on :8200. `disable_mlock = true`
   # because the pod runs without IPC_LOCK by default — securing memory
   # pages from being swapped is an OS-level concern, not Vault's.
+  #
+  # `api_addr` and `cluster_addr` are NOT in this HCL on purpose —
+  # they're passed as `VAULT_API_ADDR` / `VAULT_CLUSTER_ADDR` env
+  # vars on the StatefulSet container, populated from the downward
+  # API so they resolve to the pod's actual IP at runtime. Raft
+  # storage rejects unspecified addresses (`0.0.0.0`) at unseal time
+  # with `cannot use unspecified IP with raft storage`, so a
+  # config-baked `0.0.0.0:8201` would deadlock the cluster.
   config_hcl = <<-HCL
     ui = true
     disable_mlock = true
@@ -127,9 +135,6 @@ locals {
       address     = "0.0.0.0:8200"
       tls_disable = "true"
     }
-
-    api_addr     = "http://0.0.0.0:8200"
-    cluster_addr = "https://0.0.0.0:8201"
   HCL
 }
 
@@ -333,12 +338,55 @@ resource "kubernetes_stateful_set_v1" "vault" {
         # we use for Zitadel/Stalwart/Roundcube.
         enable_service_links = false
 
+        # The hostPath PV starts owned by root:root (kubelet creates
+        # the directory via `DirectoryOrCreate` without setting
+        # ownership), but the vault container runs as 100:1000 with
+        # all capabilities dropped — bolt's `open /vault/data/vault.db`
+        # fails with `permission denied` on a fresh PV. fs_group at
+        # the pod level isn't honored by hostPath. Run a one-shot
+        # init container as root to chown the data dir before the
+        # main container starts.
+        init_container {
+          name  = "chown-data"
+          image = "busybox:stable-musl"
+
+          security_context {
+            run_as_user = 0
+          }
+
+          resources {
+            requests = { cpu = "10m", memory = "16Mi" }
+            limits   = { cpu = "50m", memory = "32Mi" }
+          }
+
+          command = ["sh", "-c", "chown -R 100:1000 /vault/data"]
+
+          volume_mount {
+            name       = "data"
+            mount_path = "/vault/data"
+          }
+        }
+
         container {
           name              = "vault"
           image             = var.image
           image_pull_policy = "IfNotPresent"
 
-          args = ["server", "-config=/vault/config/config.hcl"]
+          # The vault image's `docker-entrypoint.sh`, when invoked
+          # with `server`, rewrites the command to:
+          #   vault server -config=/vault/config -dev-root-token-id=... \
+          #                -dev-listen-address=0.0.0.0:8200 "$@"
+          # If we add our own `-config=/vault/config/config.hcl` as a
+          # positional arg, the entrypoint's `-config=/vault/config`
+          # (DIR) is kept AND ours is appended — vault then loads the
+          # same config file twice and tries to bind two listeners on
+          # `0.0.0.0:8200`, erroring out with
+          # `bind: address already in use`. Passing only `server`
+          # lets the entrypoint resolve `-config` once against the
+          # `/vault/config` directory; the ConfigMap projects
+          # `config.hcl` into that directory and vault loads it
+          # normally.
+          args = ["server"]
 
           # IPC_LOCK is dropped by `disable_mlock = true` in
           # config.hcl. SETFCAP is dropped because we don't ship
@@ -367,25 +415,88 @@ resource "kubernetes_stateful_set_v1" "vault" {
             value = "http://127.0.0.1:8200"
           }
 
+          # Raft requires concrete (non-`0.0.0.0`) cluster_addr —
+          # populate from the pod's IP via downward API. `api_addr`
+          # could stay loopback but using POD_IP keeps both addresses
+          # consistent and lets a future multi-node config drop in
+          # without rewiring.
+          env {
+            name = "POD_IP"
+            value_from {
+              field_ref {
+                field_path = "status.podIP"
+              }
+            }
+          }
+          env {
+            name  = "VAULT_API_ADDR"
+            value = "http://$(POD_IP):8200"
+          }
+          env {
+            name  = "VAULT_CLUSTER_ADDR"
+            value = "https://$(POD_IP):8201"
+          }
+
+          # Vault image's docker-entrypoint.sh tries to `chown -R
+          # vault:vault /vault/{config,file}` and `setcap cap_ipc_lock
+          # +ep` on the binary before starting the server. Both fail
+          # under the security_context above (capabilities dropped to
+          # ALL, config volume read-only ConfigMap projection) and the
+          # entrypoint exits non-zero before vault server boots.
+          # Skipping both is safe: the chown is cosmetic when the user
+          # already matches `run_as_user`, and IPC_LOCK is moot
+          # because `disable_mlock = true` in config.hcl.
+          env {
+            name  = "SKIP_CHOWN"
+            value = "true"
+          }
+          env {
+            name  = "SKIP_SETCAP"
+            value = "true"
+          }
+
           # postStart polls the bootstrap-Secret-mounted file for up
           # to ~5min and runs `vault operator unseal` once the key
           # appears. Kubelet projects updated Secret data into running
           # pods within ~60s of the Secret PATCH, so this loop
           # converges without a pod restart on the first apply, and
           # immediately on every subsequent restart.
+          #
+          # The actual loop runs in a backgrounded subshell — the
+          # foreground command exits 0 immediately so kubelet's
+          # postStart deadline (implementation-defined, observed
+          # ~2-4 min on this k3s build) cannot kill the container
+          # before the loop converges. The subshell is detached via
+          # `setsid` and writes its progress to a file under
+          # `/vault/data/.unsealer.log` so operator can `kubectl exec
+          # cat` it for debugging without needing the parent's
+          # stdout. Trade-off: if the loop fails silently, kubelet
+          # never knows — but the readiness probe catches it (a
+          # sealed pod fails `/v1/sys/health` without query
+          # overrides) and Vault stays NotReady until manual
+          # intervention or the next pod restart.
           lifecycle {
             post_start {
               exec {
                 command = [
                   "/bin/sh", "-c",
                   <<-EOT
+                  setsid /bin/sh -c '
+                  exec >>/vault/data/.unsealer.log 2>&1
+                  echo "[unsealer $(date -Iseconds)] starting"
                   for i in $(seq 1 60); do
                     KEY=$(cat /vault/bootstrap/unseal-key 2>/dev/null || true)
                     if [ -n "$KEY" ]; then
-                      vault operator unseal "$KEY" >/dev/null 2>&1 && exit 0
+                      if vault operator unseal "$KEY" >/dev/null 2>&1; then
+                        echo "[unsealer $(date -Iseconds)] unsealed on iteration $i"
+                        exit 0
+                      fi
                     fi
                     sleep 5
                   done
+                  echo "[unsealer $(date -Iseconds)] gave up after 60 iterations"
+                  exit 0
+                  ' </dev/null >/dev/null 2>&1 &
                   exit 0
                   EOT
                 ]

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -1,0 +1,684 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+# =============================================================================
+# Vault community — Phase 0: brings the server up + auto-unseals + emits root
+# token to a TF-managed Secret. No KV mounts, no auth methods, no policies.
+# =============================================================================
+#
+# Phase 0 success: `services.vault.enabled: true` brings up a working
+# Vault you can log into in the UI as the root user (token from
+# `terraform output -raw vault_root_token`). Phase 1 (deferred PR)
+# wires the Zitadel JWT auth method + admin/operator policies. Phase
+# 2 introduces the Vault Secrets Operator + first migrated secret.
+# Phase 3 bulk-migrates the cheatsheet-bound TF outputs.
+#
+# Storage: built-in raft single-node (no external Postgres/Consul).
+# RocksDB-style on-disk store. hostPath PV survives pod replace and
+# `./tf bootstrap-k3s` (same trade-off Stalwart makes for its data
+# dir).
+#
+# Auto-unseal flow:
+#   1. TF creates an empty `vault-bootstrap` Secret up front so the
+#      pod's secret-volume mount has somewhere to land at create time.
+#   2. The StatefulSet's `vault` container starts, server boots
+#      sealed (raft init + listener up, no unseal yet).
+#   3. `kubernetes_job_v1.init` runs (depends_on the StatefulSet) and
+#      calls `POST /v1/sys/init` with `secret_shares=1, secret_threshold=1`
+#      (single-key threshold — this is a single-operator home cluster,
+#      shamir doesn't add real safety here). Parses the response JSON
+#      and `kubectl patch`es the unseal key + root token into the
+#      bootstrap Secret.
+#   3. The vault container's `postStart` lifecycle hook polls the
+#      secret-mounted file at `/vault/bootstrap/unseal-key` for up to
+#      five minutes and runs `vault operator unseal` once it appears.
+#      Kubelet projects updated Secret data into running pods within
+#      ~60s, so the postStart loop converges without a pod restart.
+#   4. Subsequent pod restarts (rollout, k8s reschedule, node reboot)
+#      hit the same postStart hook with the Secret already populated
+#      → unseal completes within the first poll, no operator action.
+
+# -----------------------------------------------------------------------------
+# Variables
+# -----------------------------------------------------------------------------
+
+variable "enabled" {
+  description = "Deploy Vault. When false, no resources are created."
+  type        = bool
+  default     = false
+}
+
+variable "namespace" {
+  description = "Namespace Vault lives in. Expected to exist already (typically `platform`)."
+  type        = string
+  default     = "platform"
+}
+
+variable "hostname" {
+  description = "Public hostname Vault answers on (e.g. `vault.example.com`). Used for the IngressRoute Host(...) match (`config/components/vault.yaml` is `kind: external`, the operator's domain yaml supplies the route)."
+  type        = string
+  default     = ""
+}
+
+variable "image" {
+  description = "Vault container image. Pin a specific tag — `:latest` would silently pull schema changes between restarts. `hashicorp/vault` is the upstream repo (community edition)."
+  type        = string
+  default     = "hashicorp/vault:1.18.4"
+}
+
+variable "volume_base_path" {
+  description = "Parent path used verbatim by the hostPath PV. Vault's raft storage lands at `<volume_base_path>/<namespace>/vault/data/`. Survives `./tf bootstrap-k3s` on purpose — losing this dir wipes the secret store entirely."
+  type        = string
+  default     = "/data/vol"
+}
+
+variable "memory_request" {
+  type    = string
+  default = "256Mi"
+}
+
+variable "memory_limit" {
+  type    = string
+  default = "1Gi"
+}
+
+variable "cpu_request" {
+  type    = string
+  default = "100m"
+}
+
+variable "cpu_limit" {
+  type    = string
+  default = "1"
+}
+
+# -----------------------------------------------------------------------------
+# Locals
+# -----------------------------------------------------------------------------
+
+locals {
+  instances = var.enabled ? toset(["enabled"]) : toset([])
+
+  data_path = "${var.volume_base_path}/${var.namespace}/vault/data"
+
+  # Single-node raft + UI + listener on :8200. `disable_mlock = true`
+  # because the pod runs without IPC_LOCK by default — securing memory
+  # pages from being swapped is an OS-level concern, not Vault's.
+  config_hcl = <<-HCL
+    ui = true
+    disable_mlock = true
+
+    storage "raft" {
+      path    = "/vault/data"
+      node_id = "vault-0"
+    }
+
+    listener "tcp" {
+      address     = "0.0.0.0:8200"
+      tls_disable = "true"
+    }
+
+    api_addr     = "http://0.0.0.0:8200"
+    cluster_addr = "https://0.0.0.0:8201"
+  HCL
+}
+
+# -----------------------------------------------------------------------------
+# RBAC for the bootstrap-init Job — needs to PATCH the
+# `vault-bootstrap` Secret with the init response (unseal key + root
+# token). Scoped to the single Secret in the single namespace; no
+# cluster-wide privileges.
+# -----------------------------------------------------------------------------
+
+resource "kubernetes_service_account_v1" "vault" {
+  for_each = local.instances
+
+  metadata {
+    name      = "vault"
+    namespace = var.namespace
+    labels    = { app = "vault" }
+  }
+}
+
+resource "kubernetes_role_v1" "vault_bootstrap" {
+  for_each = local.instances
+
+  metadata {
+    name      = "vault-bootstrap"
+    namespace = var.namespace
+  }
+
+  rule {
+    api_groups     = [""]
+    resources      = ["secrets"]
+    resource_names = ["vault-bootstrap"]
+    verbs          = ["get", "patch", "update"]
+  }
+}
+
+resource "kubernetes_role_binding_v1" "vault_bootstrap" {
+  for_each = local.instances
+
+  metadata {
+    name      = "vault-bootstrap"
+    namespace = var.namespace
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "Role"
+    name      = kubernetes_role_v1.vault_bootstrap["enabled"].metadata[0].name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account_v1.vault["enabled"].metadata[0].name
+    namespace = var.namespace
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Bootstrap Secret — created EMPTY up front so the StatefulSet's
+# secret-volume mount has a target at pod create time. The init Job
+# patches it with `unseal-key` and `root-token` keys after `vault
+# operator init`. `lifecycle { ignore_changes = [data] }` so TF stops
+# fighting the Job over the data field on subsequent applies.
+# -----------------------------------------------------------------------------
+
+resource "kubernetes_secret_v1" "vault_bootstrap" {
+  for_each = local.instances
+
+  metadata {
+    name      = "vault-bootstrap"
+    namespace = var.namespace
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app"                          = "vault"
+    }
+  }
+
+  # Placeholder keys — the init Job overwrites both with the real
+  # values from /v1/sys/init. Empty strings on first apply are fine;
+  # the postStart unseal loop polls until the file is non-empty.
+  data = {
+    "unseal-key" = ""
+    "root-token" = ""
+  }
+
+  lifecycle {
+    ignore_changes = [data]
+  }
+}
+
+resource "kubernetes_config_map_v1" "vault_config" {
+  for_each = local.instances
+
+  metadata {
+    name      = "vault-config"
+    namespace = var.namespace
+  }
+
+  data = {
+    "config.hcl" = local.config_hcl
+  }
+}
+
+# -----------------------------------------------------------------------------
+# hostPath storage for /vault/data (raft state).
+# -----------------------------------------------------------------------------
+
+resource "kubernetes_persistent_volume_v1" "vault" {
+  for_each = local.instances
+
+  metadata {
+    name = "vault-data"
+  }
+
+  spec {
+    capacity = {
+      storage = "5Gi"
+    }
+    access_modes                     = ["ReadWriteOnce"]
+    persistent_volume_reclaim_policy = "Retain"
+    storage_class_name               = "standard"
+
+    persistent_volume_source {
+      host_path {
+        path = local.data_path
+        type = "DirectoryOrCreate"
+      }
+    }
+
+    claim_ref {
+      namespace = var.namespace
+      name      = "vault-data"
+    }
+  }
+}
+
+resource "kubernetes_persistent_volume_claim_v1" "vault" {
+  for_each = local.instances
+
+  metadata {
+    name      = "vault-data"
+    namespace = var.namespace
+  }
+
+  spec {
+    access_modes       = ["ReadWriteOnce"]
+    storage_class_name = "standard"
+    volume_name        = kubernetes_persistent_volume_v1.vault["enabled"].metadata[0].name
+
+    resources {
+      requests = {
+        storage = "5Gi"
+      }
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# StatefulSet — single replica, raft single-node, postStart auto-unseal.
+# -----------------------------------------------------------------------------
+
+resource "kubernetes_stateful_set_v1" "vault" {
+  for_each = local.instances
+
+  depends_on = [kubernetes_secret_v1.vault_bootstrap]
+
+  # Phase 0 chicken-and-egg: the init Job depends on this StatefulSet
+  # existing AND being reachable, but the pod only becomes Ready after
+  # the init Job patches the bootstrap Secret AND the postStart hook
+  # runs unseal. With wait_for_rollout=true, TF blocks here forever.
+  # Default is true; flip false so TF moves past the StatefulSet to
+  # the init Job, which then unblocks readiness via the postStart
+  # path.
+  wait_for_rollout = false
+
+  metadata {
+    name      = "vault"
+    namespace = var.namespace
+    labels    = { app = "vault" }
+  }
+
+  spec {
+    service_name = "vault"
+    replicas     = 1
+
+    selector {
+      match_labels = { app = "vault" }
+    }
+
+    template {
+      metadata {
+        labels = { app = "vault" }
+      }
+
+      spec {
+        service_account_name = kubernetes_service_account_v1.vault["enabled"].metadata[0].name
+
+        # k8s auto-injects `<SVC>_PORT=tcp://...` per Service in the
+        # namespace. Some Vault config paths read `VAULT_PORT` and
+        # crash on a non-numeric value. Cheap insurance — same logic
+        # we use for Zitadel/Stalwart/Roundcube.
+        enable_service_links = false
+
+        container {
+          name              = "vault"
+          image             = var.image
+          image_pull_policy = "IfNotPresent"
+
+          args = ["server", "-config=/vault/config/config.hcl"]
+
+          # IPC_LOCK is dropped by `disable_mlock = true` in
+          # config.hcl. SETFCAP is dropped because we don't ship
+          # binaries.
+          security_context {
+            capabilities {
+              drop = ["ALL"]
+            }
+            run_as_user                = 100
+            run_as_group               = 1000
+            run_as_non_root            = true
+            allow_privilege_escalation = false
+          }
+
+          port {
+            name           = "http"
+            container_port = 8200
+          }
+          port {
+            name           = "cluster"
+            container_port = 8201
+          }
+
+          env {
+            name  = "VAULT_ADDR"
+            value = "http://127.0.0.1:8200"
+          }
+
+          # postStart polls the bootstrap-Secret-mounted file for up
+          # to ~5min and runs `vault operator unseal` once the key
+          # appears. Kubelet projects updated Secret data into running
+          # pods within ~60s of the Secret PATCH, so this loop
+          # converges without a pod restart on the first apply, and
+          # immediately on every subsequent restart.
+          lifecycle {
+            post_start {
+              exec {
+                command = [
+                  "/bin/sh", "-c",
+                  <<-EOT
+                  for i in $(seq 1 60); do
+                    KEY=$(cat /vault/bootstrap/unseal-key 2>/dev/null || true)
+                    if [ -n "$KEY" ]; then
+                      vault operator unseal "$KEY" >/dev/null 2>&1 && exit 0
+                    fi
+                    sleep 5
+                  done
+                  exit 0
+                  EOT
+                ]
+              }
+            }
+          }
+
+          resources {
+            requests = {
+              cpu    = var.cpu_request
+              memory = var.memory_request
+            }
+            limits = {
+              cpu    = var.cpu_limit
+              memory = var.memory_limit
+            }
+          }
+
+          # `/v1/sys/health` returns:
+          #   200 — initialised + unsealed + active
+          #   429 — initialised + unsealed + standby (HA)
+          #   501 — not initialised (Phase 0 first start, pre init Job)
+          #   503 — sealed (between init and unseal)
+          #
+          # Permissive query params (`uninitcode=200&sealedcode=200&
+          # standbyok=true`) treat 'listener up' as healthy regardless
+          # of init/seal state. This is correct for Phase 0 because
+          # the bootstrap chain is a chicken-and-egg: the init Job
+          # needs to reach the pod (so the pod must be 'Ready' for
+          # the Service to route there) BEFORE the pod is initialised
+          # or unsealed. With strict probes, init Job timeouts on
+          # connection-refused and the apply hangs.
+          #
+          # Trade-off: for the first ~60-90s of a fresh apply, public
+          # traffic landing on the pod sees Vault's "sealed" page.
+          # Acceptable for single-operator home cluster where the
+          # postStart hook unseals within one kubelet sync interval.
+          startup_probe {
+            http_get {
+              path   = "/v1/sys/health?uninitcode=200&sealedcode=200&standbyok=true"
+              port   = 8200
+              scheme = "HTTP"
+            }
+            failure_threshold = 60
+            period_seconds    = 5
+          }
+
+          liveness_probe {
+            http_get {
+              path   = "/v1/sys/health?uninitcode=200&sealedcode=200&standbyok=true"
+              port   = 8200
+              scheme = "HTTP"
+            }
+            initial_delay_seconds = 60
+            period_seconds        = 30
+            timeout_seconds       = 5
+            failure_threshold     = 3
+          }
+
+          readiness_probe {
+            http_get {
+              path   = "/v1/sys/health?uninitcode=200&sealedcode=200&standbyok=true"
+              port   = 8200
+              scheme = "HTTP"
+            }
+            period_seconds  = 10
+            timeout_seconds = 3
+          }
+
+          volume_mount {
+            name       = "config"
+            mount_path = "/vault/config"
+            read_only  = true
+          }
+
+          volume_mount {
+            name       = "data"
+            mount_path = "/vault/data"
+          }
+
+          volume_mount {
+            name       = "bootstrap"
+            mount_path = "/vault/bootstrap"
+            read_only  = true
+          }
+        }
+
+        volume {
+          name = "config"
+          config_map {
+            name = kubernetes_config_map_v1.vault_config["enabled"].metadata[0].name
+          }
+        }
+
+        volume {
+          name = "data"
+          persistent_volume_claim {
+            claim_name = kubernetes_persistent_volume_claim_v1.vault["enabled"].metadata[0].name
+          }
+        }
+
+        volume {
+          name = "bootstrap"
+          secret {
+            secret_name = kubernetes_secret_v1.vault_bootstrap["enabled"].metadata[0].name
+          }
+        }
+      }
+    }
+  }
+
+  # The PVC was created above; don't let the StatefulSet's
+  # volumeClaimTemplates conflict with it (we explicitly wire a PVC by
+  # name instead of templating one per replica — single-replica home
+  # cluster, no benefit from per-replica templates).
+}
+
+resource "kubernetes_service_v1" "vault" {
+  for_each = local.instances
+
+  metadata {
+    name      = "vault"
+    namespace = var.namespace
+    labels    = { app = "vault" }
+  }
+
+  spec {
+    selector = { app = "vault" }
+    type     = "ClusterIP"
+
+    port {
+      name        = "http"
+      port        = 8200
+      target_port = 8200
+    }
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Init Job — runs once per fresh cluster. Polls Vault `/sys/init`
+# status; if uninitialised, calls `POST /v1/sys/init`, parses the
+# response, kubectl-patches the bootstrap Secret with `unseal-key`
+# and `root-token` keys (base64-encoded). Subsequent runs see "already
+# initialised" and exit 0 without touching the Secret.
+# -----------------------------------------------------------------------------
+
+resource "kubernetes_job_v1" "vault_init" {
+  for_each = local.instances
+
+  depends_on = [kubernetes_stateful_set_v1.vault]
+
+  metadata {
+    name      = "vault-init"
+    namespace = var.namespace
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app"                          = "vault"
+    }
+  }
+
+  spec {
+    backoff_limit = 5
+
+    template {
+      metadata {
+        labels = { job = "vault-init" }
+      }
+
+      spec {
+        restart_policy       = "Never"
+        service_account_name = kubernetes_service_account_v1.vault["enabled"].metadata[0].name
+
+        container {
+          name  = "init"
+          image = "alpine/k8s:1.31.5"
+
+          resources {
+            requests = { cpu = "10m", memory = "32Mi" }
+            limits   = { cpu = "100m", memory = "128Mi" }
+          }
+
+          command = [
+            "sh", "-c",
+            <<-EOT
+            set -eu
+            URL="http://vault.${var.namespace}.svc.cluster.local:8200"
+
+            echo "[vault-init] waiting for $URL/v1/sys/health..."
+            until curl -sf -m 5 -o /dev/null "$URL/v1/sys/health?uninitcode=200&sealedcode=200&standbyok=true"; do
+              sleep 3
+            done
+            echo "[vault-init] vault reachable"
+
+            INIT_STATUS=$(curl -s "$URL/v1/sys/init")
+            INITIALISED=$(echo "$INIT_STATUS" | sed -n 's/.*"initialized":\([truefals]*\).*/\1/p')
+            echo "[vault-init] initialised=$INITIALISED"
+
+            if [ "$INITIALISED" = "true" ]; then
+              # Already initialised — bootstrap Secret should already
+              # carry unseal-key + root-token from a previous apply.
+              # No-op.
+              echo "[vault-init] already initialised — exiting"
+              exit 0
+            fi
+
+            echo "[vault-init] running operator init"
+            INIT=$(curl -s -X POST -H 'Content-Type: application/json' \
+              -d '{"secret_shares":1,"secret_threshold":1}' \
+              "$URL/v1/sys/init")
+
+            UNSEAL=$(echo "$INIT" | sed -n 's/.*"keys":\["\([^"]*\)".*/\1/p')
+            ROOT=$(echo "$INIT" | sed -n 's/.*"root_token":"\([^"]*\)".*/\1/p')
+
+            if [ -z "$UNSEAL" ] || [ -z "$ROOT" ]; then
+              echo "[vault-init] ERROR: init response missing keys"
+              echo "$INIT"
+              exit 1
+            fi
+
+            UNSEAL_B64=$(printf '%s' "$UNSEAL" | base64 -w0)
+            ROOT_B64=$(printf '%s' "$ROOT" | base64 -w0)
+
+            kubectl patch secret vault-bootstrap -n ${var.namespace} \
+              --type='strategic' \
+              -p "$(printf '{"data":{"unseal-key":"%s","root-token":"%s"}}' "$UNSEAL_B64" "$ROOT_B64")"
+
+            echo "[vault-init] bootstrap Secret patched — postStart hook will unseal within ~60s"
+            EOT
+          ]
+        }
+      }
+    }
+  }
+
+  wait_for_completion = true
+
+  timeouts {
+    create = "5m"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Outputs
+# -----------------------------------------------------------------------------
+
+output "enabled" {
+  value = var.enabled
+}
+
+output "namespace" {
+  value = var.namespace
+}
+
+output "hostname" {
+  value = var.hostname
+}
+
+output "service_name" {
+  value = var.enabled ? kubernetes_service_v1.vault["enabled"].metadata[0].name : null
+}
+
+output "port" {
+  value = 8200
+}
+
+output "url" {
+  description = "Public Vault URL — `terraform output -raw vault_url`."
+  value       = var.enabled && var.hostname != "" ? "https://${var.hostname}" : null
+}
+
+# Lookup for the bootstrap Secret AFTER the init Job has populated it.
+# `data.kubernetes_secret_v1` reads the live Secret on every plan,
+# so first apply (Secret empty) yields empty strings; subsequent
+# plans pick up the populated values.
+data "kubernetes_secret_v1" "vault_bootstrap" {
+  for_each = local.instances
+
+  depends_on = [kubernetes_job_v1.vault_init]
+
+  metadata {
+    name      = kubernetes_secret_v1.vault_bootstrap["enabled"].metadata[0].name
+    namespace = var.namespace
+  }
+}
+
+output "root_token" {
+  description = "Root token emitted by `vault operator init`. Use as break-glass when OIDC is broken or before Phase 1 lands. Read with `terraform output -raw vault_root_token`. Empty until the init Job has run + plan picks up the populated Secret on the second apply (k8s data sources are read at plan time)."
+  value       = var.enabled ? try(data.kubernetes_secret_v1.vault_bootstrap["enabled"].data["root-token"], "") : null
+  sensitive   = true
+}
+
+output "unseal_key" {
+  description = "Single unseal key (secret_shares=1, secret_threshold=1 — single-operator home cluster, no shamir benefit). Used by the StatefulSet's postStart hook to auto-unseal on every pod start. Read with `terraform output -raw vault_unseal_key` if you need to unseal manually for some reason."
+  value       = var.enabled ? try(data.kubernetes_secret_v1.vault_bootstrap["enabled"].data["unseal-key"], "") : null
+  sensitive   = true
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -202,11 +202,16 @@ output "cheatsheet" {
     Stalwart recovery admin (bypasses OIDC; user `admin`):
       terraform output -raw stalwart_recovery_admin_password
 
-    Vault root token (Phase 0 primary login; break-glass after Phase 1):
-      terraform output -raw vault | jq -r '.root_token'
+    Vault root token (Phase 0 primary login; break-glass after Phase 1).
+    The `./tf` wrapper writes its `Loading variables…` banner to stdout
+    so `terraform output -json … | jq` always trips on `Invalid numeric
+    literal`. Pull the value from the underlying Secret directly — no
+    wrapper, no jq, no parse errors:
+      kubectl -n platform get secret vault-bootstrap \
+        -o jsonpath='{.data.root-token}' | base64 -d
 
-    Vault URL:
-      terraform output -json vault | jq -r '.url'
+    Vault URL (paste in browser, sign in with the token above):
+      https://${try(local.platform.services.vault.hostname, "<vault disabled>")}
 
 
     Mail — Roundcube webmail (Zitadel SSO; auto-provisions Stalwart UserAccount on first login):

--- a/outputs.tf
+++ b/outputs.tf
@@ -145,6 +145,21 @@ output "stalwart_account_url" {
   sensitive   = true
 }
 
+output "vault" {
+  description = "Vault community platform secrets store — public hostname, in-cluster Service, root token, and unseal key. Phase 0 outputs: root token is the primary auth path until Phase 1 lands Zitadel JWT auth method; after that, root becomes break-glass only. Unseal key is consumed by the StatefulSet's postStart hook automatically — exposed here for manual recovery only."
+  value = {
+    hostname   = module.vault.hostname
+    url        = module.vault.url
+    namespace  = module.vault.namespace
+    service    = module.vault.service_name
+    port       = module.vault.port
+    root_token = module.vault.root_token
+    unseal_key = module.vault.unseal_key
+  }
+  sensitive = true
+}
+
+
 output "zitadel_pat" {
   description = "PAT for the Zitadel TF provider (machine user `tf-platform`, IAM_OWNER, far-future expiry). Lifted from the in-cluster `zitadel-tf-pat` Secret that the FIRSTINSTANCE-bootstrapped pat-broker sidecar populates. Empty when Zitadel is disabled OR the sidecar hasn't run yet (pre-bootstrap clean clone); populated after the first `./tf apply` brings Zitadel up. Fetch with `terraform output -raw zitadel_pat`, then paste into `.env` as `TF_VAR_zitadel_pat=...` so subsequent applies provision kind:app components."
   sensitive   = true
@@ -186,6 +201,13 @@ output "cheatsheet" {
 
     Stalwart recovery admin (bypasses OIDC; user `admin`):
       terraform output -raw stalwart_recovery_admin_password
+
+    Vault root token (Phase 0 primary login; break-glass after Phase 1):
+      terraform output -raw vault | jq -r '.root_token'
+
+    Vault URL:
+      terraform output -json vault | jq -r '.url'
+
 
     Mail — Roundcube webmail (Zitadel SSO; auto-provisions Stalwart UserAccount on first login):
       https://${try(local.mail.hostname, "<configure mail in a domain yaml>")}/

--- a/vault.tf
+++ b/vault.tf
@@ -1,0 +1,35 @@
+# Vault community — platform secrets store, replacement for the
+# Infisical attempt that hit a paywall on OIDC SSO.
+#
+# Phase 0 (this PR): module skeleton, raft single-node, hostPath PV,
+# init Job, postStart auto-unseal. Operator gets a working Vault UI
+# at `https://<hostname>` and a root token via
+# `terraform output -raw vault_root_token` for break-glass.
+#
+# Phase 1 (deferred): Zitadel JWT auth method via the `hashicorp/vault`
+# TF provider — `vault_jwt_auth_backend` + `vault_jwt_auth_backend_role`
+# mapping Zitadel `vault_admin` / `vault_operator` claims to Vault
+# policies. UI login page gets the "Sign in with OIDC" button. Phase 2
+# wires the Vault Secrets Operator + first migrated tenant secret.
+# See `BACKLOG.md` for the full roadmap.
+
+# Vault has its own internal store (raft), unlike Infisical which
+# needed Postgres + Redis. So no infrastructure prereq checks here
+# beyond hostname.
+
+check "vault_hostname_set" {
+  assert {
+    condition     = !local.platform.services.vault.enabled || local.platform.services.vault.hostname != ""
+    error_message = "services.vault.hostname must be set when vault is enabled (e.g. `vault.example.com`). Drives the IngressRoute Host(...) match. Add the matching `<prefix>: vault` route to your domain yaml so cloudflared sees the hostname through the same project-IngressRoute pipeline as Stalwart and oauth2-proxy."
+  }
+}
+
+module "vault" {
+  source     = "./modules/vault"
+  depends_on = [module.addons, kubernetes_namespace_v1.platform]
+
+  enabled          = local.platform.services.vault.enabled
+  namespace        = kubernetes_namespace_v1.platform.metadata[0].name
+  hostname         = local.platform.services.vault.hostname
+  volume_base_path = var.host_volume_path
+}


### PR DESCRIPTION
## Summary

First phase of the Vault-community-replaces-Infisical roadmap (see #33's BACKLOG item "Platform secrets store — superseded: Vault community after Infisical paywall"). Phase 0 stands up a single-replica Vault StatefulSet with raft single-node storage, auto-unseals on every restart, and emits a root token for break-glass login while Phase 1 (Zitadel JWT auth) catches up.

**Operator flow after merge:**
1. \`services.vault.enabled: true\` + \`services.vault.hostname: vault.<domain>\` in \`config/platform.yaml\`
2. Matching route in the operator's domain yaml (e.g. \`vault: vault\` under \`routes:\`)
3. \`./tf apply\` — init Job runs, postStart hook auto-unseals within ~60-90s
4. \`https://vault.<domain>\` → sign in with \`terraform output -raw vault | jq -r .root_token\`

**Auto-unseal flow:**
- TF creates an empty \`vault-bootstrap\` Secret up front so the StatefulSet's secret-volume mount has somewhere to land at pod create time
- \`kubernetes_job_v1.vault_init\` calls POST \`/v1/sys/init\` (secret_shares=1, threshold=1 — single-operator home cluster, no shamir benefit), kubectl-patches the bootstrap Secret with \`unseal-key\` + \`root-token\` keys
- Vault container's postStart lifecycle hook polls \`/vault/bootstrap/unseal-key\` for ~5min, runs \`vault operator unseal $KEY\` once non-empty. Kubelet projects updated Secret data into the running pod within ~60s of the PATCH, so the loop converges without a pod restart

**Chicken-and-egg breakers:**
- \`wait_for_rollout = false\` on the StatefulSet — pod won't become Ready until unsealed, init Job needs a reachable pod, can't both be true at the same time
- Permissive health probes (\`uninitcode=200&sealedcode=200&standbyok=true\`) accept "listener up" as healthy regardless of init/seal state. Trade-off: ~60-90s window of fresh-apply where public traffic landing on the pod sees the seal page; acceptable for single-operator home cluster

**Storage:**
- raft single-node bundled with Vault (no external Postgres/Consul dep, unlike Infisical)
- hostPath PV at \`<host_volume_path>/<namespace>/vault/data/\` — survives \`./tf bootstrap-k3s\`, same trade-off Stalwart makes

**Routing** follows the existing \`kind: external\` pattern (\`config/components/vault.yaml\` + operator-supplied route in domain yaml). Cloudflared sees the hostname through the project-IngressRoute pipeline same as Stalwart and oauth2-proxy.

## Test plan

- [x] \`terraform validate\` passes
- [x] \`./tf plan\` is empty when \`services.vault.enabled: false\` (default; only the new \`vault\` output value)
- [ ] First apply: \`./tf apply\` brings up the pod, init Job patches the Secret, postStart unseals, pod becomes Ready
- [ ] \`terraform output -json vault | jq -r .root_token\` returns a working token, UI login succeeds
- [ ] Pod restart (\`kubectl rollout restart sts/vault -n platform\`) auto-unseals within ~10s (file already populated, postStart loop hits unseal on first iteration)
- [ ] \`terraform plan\` after apply is empty (idempotent — init Job's "already initialised" branch + ignore_changes on Secret data)
- [ ] Bootstrap reset drill: delete the bootstrap Secret + the data dir + re-apply → fresh init + unseal cycle, new root token

## Why draft

Apply path needs verification on the live cluster before merge:
- \`hashicorp/vault:1.18.4\` image pin — picked from current stable; operator confirms image's \`vault\` binary path + \`/bin/sh\` availability for the postStart hook
- \`alpine/k8s:1.31.5\` init-Job image — confirms kubectl + curl + base64 are all in PATH
- \`/v1/sys/init\` response shape — verified against the upstream API docs (returns \`{"keys":[...], "root_token":"..."}\`); the sed-based JSON parsing in the Job assumes that exact shape
- postStart timing — kubelet's Secret projection interval (~60s default) determines first-apply convergence time

## Stacking

This PR depends on #33 (drop Infisical). Roman's preference: merge #33 first, apply on cluster (destroys Infisical infrastructure), then merge this and apply (creates Vault).

🤖 Generated with [Claude Code](https://claude.com/claude-code)