### PR TITLE
fix(redis): persist dashboard_ro ACL via ACL SAVE

### DIFF
--- a/platform_dash_db.tf
+++ b/platform_dash_db.tf
@@ -206,9 +206,19 @@ resource "kubernetes_job_v1" "redis_dashboard_ro_setup" {
           # ACL SETUSER is idempotent — re-applying is a no-op when
           # the user already matches. -a uses the `default` (root)
           # password from the env_from Secret.
+          #
+          # The trailing `ACL SAVE` persists `dashboard_ro` to Redis's
+          # aclfile (/data/users.acl on the shared PV). Without it the
+          # user lives only in-memory and vanishes on the next redis-0
+          # restart — the dashboard then fails with `WRONGPASS invalid
+          # username-password pair or user is disabled` until the next
+          # `terraform apply` re-runs this Job. SETUSER and SAVE run as
+          # two separate redis-cli invocations so the shell `&&`
+          # short-circuits SAVE if SETUSER fails. Matches the per-tenant
+          # ACL provisioner in modules/project.
           command = [
             "sh", "-c",
-            "redis-cli -h ${module.redis.host} -a \"$REDIS_PASSWORD\" --no-auth-warning ACL SETUSER dashboard_ro on \">$RO_PASSWORD\" \"~*\" \"&*\" +@read +info"
+            "redis-cli -h ${module.redis.host} -a \"$REDIS_PASSWORD\" --no-auth-warning ACL SETUSER dashboard_ro on \">$RO_PASSWORD\" \"~*\" \"&*\" +@read +info && redis-cli -h ${module.redis.host} -a \"$REDIS_PASSWORD\" --no-auth-warning ACL SAVE"
           ]
         }
       }


### PR DESCRIPTION
## Summary

`platform_dash_db.tf`'s redis-dashboard-ro-setup Job ran `ACL SETUSER` without `ACL SAVE`. Redis is started with `--aclfile /data/users.acl`, so tenant users only survive a pod restart if they're explicitly persisted. The dashboard's Redis credentials lived in-memory only and vanished on every redis-0 restart, leaving platform-dash with:

```
Redis: WRONGPASS invalid username-password pair or user is disabled.
```

…until the next `terraform apply` re-ran the Job.

## Fix

Mirror the per-tenant pattern in `modules/project/main.tf` line 728-748: SETUSER + SAVE as two separate `redis-cli` invocations chained with `&&` (so SAVE short-circuits if SETUSER fails).

The Job's pod template changes, which forces TF to recreate it. The recreated Job runs once against the live Redis and writes `dashboard_ro` to `/data/users.acl` durably.

## Test plan

- [ ] `./tf plan` shows the redis-dashboard-ro-setup Job will be force-replaced (and nothing else cluster-affecting)
- [ ] `./tf apply` — Job recreated, completes within 2m
- [ ] Open dash.ipsupport.us → Databases → platform / redis. INFO call succeeds, no WRONGPASS
- [ ] `kubectl -n platform exec redis-0 -- redis-cli ACL LIST` shows `user dashboard_ro on …` (manually verifies persistence)
- [ ] Optional: `kubectl -n platform delete pod redis-0` and re-open the dash. Pod restarts, ACL survives, dash still loads stats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)