### PR TITLE
feat(placement): node_selector / tolerations / affinity primitives (Phase A)

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,43 @@ resources:
 # project exposed via `terraform output basic_auth`.
 basic_auth: true
 
+# Pod placement — three orthogonal scheduler hints, all optional. All
+# three default to empty so existing components see no behaviour
+# change. Each maps directly onto the matching field of `pod.spec`
+# (k8s API v1) — see Kubernetes docs for the exact semantics.
+node_selector:                                # simplest pinning ("this label = this value")
+  workload-tier: stateful                     # land on nodes labelled workload-tier=stateful
+
+tolerations:                                  # opt-in to scheduling on tainted nodes
+  - key: node-role.kubernetes.io/edge
+    operator: Equal
+    value:    "true"
+    effect:   NoSchedule
+  - key: nvidia.com/gpu
+    operator: Exists                          # match any value (omit `value:`)
+    effect:   NoSchedule
+
+affinity:                                     # richer node / pod (anti-)affinity
+  node_affinity:
+    required_during_scheduling_ignored_during_execution:
+      node_selector_terms:
+        - match_expressions:
+            - key:      gpu
+              operator: In
+              values:    [intel, amd]
+    preferred_during_scheduling_ignored_during_execution:
+      - weight: 50
+        preference:
+          match_expressions:
+            - key:      topology.kubernetes.io/zone
+              operator: In
+              values:    [home]
+  # pod_affinity / pod_anti_affinity follow the same shape with
+  # required_during_scheduling_ignored_during_execution accepting a
+  # list of {topology_key, namespaces?, label_selector{match_labels?,
+  # match_expressions?}} entries. See modules/component/main.tf for
+  # the full dynamic-block schema.
+
 # Helper containers co-located in the same Pod. Use for loopback-only
 # tool servers the main container talks to on 127.0.0.1 (MCP, terminal,
 # code interpreter) where a CNI boundary + Service + token would be pure

--- a/modules/component/main.tf
+++ b/modules/component/main.tf
@@ -243,6 +243,59 @@ variable "env_random_keys" {
   default     = []
 }
 
+# ── Pod placement primitives ─────────────────────────────────────────────────
+# Three orthogonal scheduler hints, all empty by default so existing
+# components see no behaviour change. Map directly onto the matching
+# fields of `pod.spec` (k8s API v1):
+#   * node_selector — simplest pinning ("this label = this value")
+#   * tolerations   — opt-in to scheduling on tainted nodes
+#   * affinity      — richer node / pod (anti-)affinity expressions
+# Per-component yaml exposes all three under the same names; the
+# `modules/project` consumer pipes them through unchanged.
+
+variable "node_selector" {
+  description = <<-EOT
+    Node-selector labels the pod must match. Empty map means the
+    scheduler can place the pod on any node that satisfies the other
+    constraints (resources, taints, affinity). Useful for
+    "stateful → optiplex (workload-tier=stateful)" style pinning.
+  EOT
+  type        = map(string)
+  default     = {}
+}
+
+variable "tolerations" {
+  description = <<-EOT
+    Taints the pod tolerates. Each entry is one toleration block with
+    the standard k8s fields. Effects accepted by the API: NoSchedule /
+    PreferNoSchedule / NoExecute. `operator` defaults to "Equal" on
+    the API side; pass "Exists" to match any value (or omit `value`).
+    Empty list = pod cannot land on any tainted node.
+  EOT
+  type = list(object({
+    key                = optional(string)
+    operator           = optional(string)
+    value              = optional(string)
+    effect             = optional(string)
+    toleration_seconds = optional(string)
+  }))
+  default = []
+}
+
+variable "affinity" {
+  description = <<-EOT
+    Pod affinity rules. Mirrors `pod.spec.affinity` — supported
+    sub-blocks: `node_affinity`, `pod_affinity`, `pod_anti_affinity`,
+    each with `required_during_scheduling_ignored_during_execution`
+    and `preferred_during_scheduling_ignored_during_execution`. Empty
+    object = no affinity. Type is `any` because the schema is deeply
+    nested with optional branches at every level; the dynamic blocks
+    below extract via `try()` and only emit fields the caller set.
+  EOT
+  type        = any
+  default     = {}
+}
+
 # ── Locals ────────────────────────────────────────────────────────────────────
 
 locals {
@@ -473,6 +526,120 @@ resource "kubernetes_deployment_v1" "this" {
         # otherwise. K8s defaults to "default" SA in the namespace —
         # leaving service_account_name unset preserves that.
         service_account_name = length(var.cluster_role_rules) > 0 ? kubernetes_service_account_v1.this["enabled"].metadata[0].name : null
+
+        # Pod placement: node_selector, tolerations, affinity. All
+        # default to empty so this block is a no-op for existing
+        # components. Wired identically into the StatefulSet path
+        # below (when one is added) and into shared service modules.
+        node_selector = length(var.node_selector) > 0 ? var.node_selector : null
+
+        dynamic "toleration" {
+          for_each = var.tolerations
+          content {
+            key                = toleration.value.key
+            operator           = toleration.value.operator
+            value              = toleration.value.value
+            effect             = toleration.value.effect
+            toleration_seconds = toleration.value.toleration_seconds
+          }
+        }
+
+        dynamic "affinity" {
+          for_each = length(keys(var.affinity)) > 0 ? [var.affinity] : []
+          content {
+            dynamic "node_affinity" {
+              for_each = try(affinity.value.node_affinity, null) != null ? [affinity.value.node_affinity] : []
+              content {
+                dynamic "required_during_scheduling_ignored_during_execution" {
+                  for_each = try(node_affinity.value.required_during_scheduling_ignored_during_execution, null) != null ? [node_affinity.value.required_during_scheduling_ignored_during_execution] : []
+                  content {
+                    dynamic "node_selector_term" {
+                      for_each = try(required_during_scheduling_ignored_during_execution.value.node_selector_terms, [])
+                      content {
+                        dynamic "match_expressions" {
+                          for_each = try(node_selector_term.value.match_expressions, [])
+                          content {
+                            key      = match_expressions.value.key
+                            operator = match_expressions.value.operator
+                            values   = try(match_expressions.value.values, null)
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                dynamic "preferred_during_scheduling_ignored_during_execution" {
+                  for_each = try(node_affinity.value.preferred_during_scheduling_ignored_during_execution, [])
+                  content {
+                    weight = preferred_during_scheduling_ignored_during_execution.value.weight
+                    preference {
+                      dynamic "match_expressions" {
+                        for_each = try(preferred_during_scheduling_ignored_during_execution.value.preference.match_expressions, [])
+                        content {
+                          key      = match_expressions.value.key
+                          operator = match_expressions.value.operator
+                          values   = try(match_expressions.value.values, null)
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            dynamic "pod_affinity" {
+              for_each = try(affinity.value.pod_affinity, null) != null ? [affinity.value.pod_affinity] : []
+              content {
+                dynamic "required_during_scheduling_ignored_during_execution" {
+                  for_each = try(pod_affinity.value.required_during_scheduling_ignored_during_execution, [])
+                  content {
+                    topology_key = required_during_scheduling_ignored_during_execution.value.topology_key
+                    namespaces   = try(required_during_scheduling_ignored_during_execution.value.namespaces, null)
+                    dynamic "label_selector" {
+                      for_each = try(required_during_scheduling_ignored_during_execution.value.label_selector, null) != null ? [required_during_scheduling_ignored_during_execution.value.label_selector] : []
+                      content {
+                        match_labels = try(label_selector.value.match_labels, null)
+                        dynamic "match_expressions" {
+                          for_each = try(label_selector.value.match_expressions, [])
+                          content {
+                            key      = match_expressions.value.key
+                            operator = match_expressions.value.operator
+                            values   = try(match_expressions.value.values, null)
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+            dynamic "pod_anti_affinity" {
+              for_each = try(affinity.value.pod_anti_affinity, null) != null ? [affinity.value.pod_anti_affinity] : []
+              content {
+                dynamic "required_during_scheduling_ignored_during_execution" {
+                  for_each = try(pod_anti_affinity.value.required_during_scheduling_ignored_during_execution, [])
+                  content {
+                    topology_key = required_during_scheduling_ignored_during_execution.value.topology_key
+                    namespaces   = try(required_during_scheduling_ignored_during_execution.value.namespaces, null)
+                    dynamic "label_selector" {
+                      for_each = try(required_during_scheduling_ignored_during_execution.value.label_selector, null) != null ? [required_during_scheduling_ignored_during_execution.value.label_selector] : []
+                      content {
+                        match_labels = try(label_selector.value.match_labels, null)
+                        dynamic "match_expressions" {
+                          for_each = try(label_selector.value.match_expressions, [])
+                          content {
+                            key      = match_expressions.value.key
+                            operator = match_expressions.value.operator
+                            values   = try(match_expressions.value.values, null)
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
 
         dynamic "security_context" {
           for_each = (

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -29,6 +29,24 @@ variable "volume_base_path" {
   default     = "/data/vol"
 }
 
+variable "node_selector" {
+  description = "Node-selector labels the MySQL pod must match. Empty = scheduler picks. Set to pin the pod on the node that owns the hostPath data dir (e.g. `{ workload-tier = stateful }`)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "tolerations" {
+  description = "Taints the MySQL pod tolerates. Empty list = pod cannot land on any tainted node."
+  type = list(object({
+    key                = optional(string)
+    operator           = optional(string)
+    value              = optional(string)
+    effect             = optional(string)
+    toleration_seconds = optional(string)
+  }))
+  default = []
+}
+
 locals {
   # Singleton-ish toggle. All resources below use `for_each =
   # local.instances` — yields one instance keyed "enabled" when the
@@ -132,6 +150,21 @@ resource "kubernetes_stateful_set_v1" "mysql" {
       }
 
       spec {
+        # Pod placement primitives — empty defaults preserve prior
+        # scheduler behaviour.
+        node_selector = length(var.node_selector) > 0 ? var.node_selector : null
+
+        dynamic "toleration" {
+          for_each = var.tolerations
+          content {
+            key                = toleration.value.key
+            operator           = toleration.value.operator
+            value              = toleration.value.value
+            effect             = toleration.value.effect
+            toleration_seconds = toleration.value.toleration_seconds
+          }
+        }
+
         container {
           name  = "mysql"
           image = "mysql:8.0"

--- a/modules/ollama/main.tf
+++ b/modules/ollama/main.tf
@@ -176,6 +176,47 @@ variable "gpu" {
 # tmpfs /dev — Mesa Anv then enumerates ONLY the projected device
 # instead of probing every renderD* node it finds).
 
+variable "node_selector" {
+  description = <<-EOT
+    Node-selector labels the Ollama pod must match. Empty map means
+    the scheduler can place the pod on any node. Set this to pin
+    Ollama on the node that owns the host GPU device referenced in
+    `var.gpu.device_path` (e.g. `{ gpu = "intel" }` on a multi-node
+    cluster where one box has the Arc card). Without pinning, the
+    pod will land on any node and the gpu hostPath will fail
+    `MountVolume.SetUp failed: not a character device`.
+  EOT
+  type        = map(string)
+  default     = {}
+}
+
+variable "tolerations" {
+  description = <<-EOT
+    Taints the Ollama pod tolerates. Each entry is one toleration
+    block with the standard k8s fields. Empty list = pod cannot
+    land on any tainted node.
+  EOT
+  type = list(object({
+    key                = optional(string)
+    operator           = optional(string)
+    value              = optional(string)
+    effect             = optional(string)
+    toleration_seconds = optional(string)
+  }))
+  default = []
+}
+
+variable "affinity" {
+  description = <<-EOT
+    Pod affinity rules for the Ollama pod (node_affinity /
+    pod_affinity / pod_anti_affinity). Empty object = no affinity.
+    Type is `any` because the schema is deeply nested with optional
+    branches at every level.
+  EOT
+  type        = any
+  default     = {}
+}
+
 locals {
   instances = var.enabled ? toset(["enabled"]) : toset([])
   # Reused as the iteration list for every GPU-only `dynamic` block —
@@ -260,6 +301,68 @@ resource "kubernetes_stateful_set_v1" "ollama" {
       }
 
       spec {
+        # Pod placement primitives. All default empty so existing
+        # deployments are unaffected. Set `var.node_selector =
+        # { gpu = "intel" }` to pin the pod onto the node that owns
+        # the device referenced in `var.gpu.device_path`.
+        node_selector = length(var.node_selector) > 0 ? var.node_selector : null
+
+        dynamic "toleration" {
+          for_each = var.tolerations
+          content {
+            key                = toleration.value.key
+            operator           = toleration.value.operator
+            value              = toleration.value.value
+            effect             = toleration.value.effect
+            toleration_seconds = toleration.value.toleration_seconds
+          }
+        }
+
+        dynamic "affinity" {
+          for_each = length(keys(var.affinity)) > 0 ? [var.affinity] : []
+          content {
+            dynamic "node_affinity" {
+              for_each = try(affinity.value.node_affinity, null) != null ? [affinity.value.node_affinity] : []
+              content {
+                dynamic "required_during_scheduling_ignored_during_execution" {
+                  for_each = try(node_affinity.value.required_during_scheduling_ignored_during_execution, null) != null ? [node_affinity.value.required_during_scheduling_ignored_during_execution] : []
+                  content {
+                    dynamic "node_selector_term" {
+                      for_each = try(required_during_scheduling_ignored_during_execution.value.node_selector_terms, [])
+                      content {
+                        dynamic "match_expressions" {
+                          for_each = try(node_selector_term.value.match_expressions, [])
+                          content {
+                            key      = match_expressions.value.key
+                            operator = match_expressions.value.operator
+                            values   = try(match_expressions.value.values, null)
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+                dynamic "preferred_during_scheduling_ignored_during_execution" {
+                  for_each = try(node_affinity.value.preferred_during_scheduling_ignored_during_execution, [])
+                  content {
+                    weight = preferred_during_scheduling_ignored_during_execution.value.weight
+                    preference {
+                      dynamic "match_expressions" {
+                        for_each = try(preferred_during_scheduling_ignored_during_execution.value.preference.match_expressions, [])
+                        content {
+                          key      = match_expressions.value.key
+                          operator = match_expressions.value.operator
+                          values   = try(match_expressions.value.values, null)
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+
         # Pod-level securityContext only emitted when GPU offload is
         # configured. `run_as_non_root = false` lets the root-running
         # Ollama image through PSS-restricted namespaces;

--- a/modules/platform-dash/main.tf
+++ b/modules/platform-dash/main.tf
@@ -79,6 +79,24 @@ variable "oidc_secret_checksum" {
   type        = string
 }
 
+variable "node_selector" {
+  description = "Node-selector labels the platform-dash pod must match. Empty = scheduler picks. The dash is stateless and can run anywhere; pin via `{ workload-tier = general }` or similar to keep it off the data node."
+  type        = map(string)
+  default     = {}
+}
+
+variable "tolerations" {
+  description = "Taints the platform-dash pod tolerates. Empty list = pod cannot land on any tainted node."
+  type = list(object({
+    key                = optional(string)
+    operator           = optional(string)
+    value              = optional(string)
+    effect             = optional(string)
+    toleration_seconds = optional(string)
+  }))
+  default = []
+}
+
 # ── Naming ───────────────────────────────────────────────────────────────────
 
 locals {
@@ -194,6 +212,21 @@ resource "kubernetes_deployment_v1" "this" {
 
       spec {
         service_account_name = kubernetes_service_account_v1.this[0].metadata[0].name
+
+        # Pod placement primitives — empty defaults preserve prior
+        # scheduler behaviour.
+        node_selector = length(var.node_selector) > 0 ? var.node_selector : null
+
+        dynamic "toleration" {
+          for_each = var.tolerations
+          content {
+            key                = toleration.value.key
+            operator           = toleration.value.operator
+            value              = toleration.value.value
+            effect             = toleration.value.effect
+            toleration_seconds = toleration.value.toleration_seconds
+          }
+        }
 
         container {
           name              = local.app_name

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -29,6 +29,24 @@ variable "volume_base_path" {
   default     = "/data/vol"
 }
 
+variable "node_selector" {
+  description = "Node-selector labels the Postgres pod must match. Empty = scheduler picks. Set to pin the pod on the node that owns the hostPath data dir (e.g. `{ workload-tier = stateful }`)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "tolerations" {
+  description = "Taints the Postgres pod tolerates. Empty list = pod cannot land on any tainted node."
+  type = list(object({
+    key                = optional(string)
+    operator           = optional(string)
+    value              = optional(string)
+    effect             = optional(string)
+    toleration_seconds = optional(string)
+  }))
+  default = []
+}
+
 locals {
   instances = var.enabled ? toset(["enabled"]) : toset([])
 }
@@ -130,6 +148,22 @@ resource "kubernetes_stateful_set_v1" "postgres" {
       }
 
       spec {
+        # Pod placement primitives — empty defaults preserve prior
+        # scheduler behaviour. Pin via `var.node_selector` and tolerate
+        # taints via `var.tolerations`.
+        node_selector = length(var.node_selector) > 0 ? var.node_selector : null
+
+        dynamic "toleration" {
+          for_each = var.tolerations
+          content {
+            key                = toleration.value.key
+            operator           = toleration.value.operator
+            value              = toleration.value.value
+            effect             = toleration.value.effect
+            toleration_seconds = toleration.value.toleration_seconds
+          }
+        }
+
         # The `postgres:` image initdb refuses to run if the mount root
         # itself is not empty — on hostPath that's the kubelet-managed
         # `lost+found` on some filesystems. Pin `PGDATA` to a child

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -933,6 +933,15 @@ module "component" {
   sidecars     = try(each.value.sidecars, {})
 
   cluster_role_rules = try(each.value.cluster_role_rules, [])
+
+  # Pod placement: passed through verbatim from per-component yaml.
+  # Empty defaults preserve prior scheduling behaviour. See README
+  # "Pod placement" for the supported keys (`node_selector:`,
+  # `tolerations:`, `affinity:`) and the documented k8s schema each
+  # mirrors.
+  node_selector = try(each.value.node_selector, {})
+  tolerations   = try(each.value.tolerations, [])
+  affinity      = try(each.value.affinity, {})
 }
 
 # ── BasicAuth (per-component) ─────────────────────────────────────────────────

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -41,6 +41,24 @@ variable "memory_limit" {
   default     = "1Gi"
 }
 
+variable "node_selector" {
+  description = "Node-selector labels the Redis pod must match. Empty = scheduler picks. Set to pin the pod on the node that owns the hostPath data dir (e.g. `{ workload-tier = stateful }`)."
+  type        = map(string)
+  default     = {}
+}
+
+variable "tolerations" {
+  description = "Taints the Redis pod tolerates. Empty list = pod cannot land on any tainted node."
+  type = list(object({
+    key                = optional(string)
+    operator           = optional(string)
+    value              = optional(string)
+    effect             = optional(string)
+    toleration_seconds = optional(string)
+  }))
+  default = []
+}
+
 locals {
   instances = var.enabled ? toset(["enabled"]) : toset([])
 }
@@ -143,6 +161,21 @@ resource "kubernetes_stateful_set_v1" "redis" {
       }
 
       spec {
+        # Pod placement primitives — empty defaults preserve prior
+        # scheduler behaviour.
+        node_selector = length(var.node_selector) > 0 ? var.node_selector : null
+
+        dynamic "toleration" {
+          for_each = var.tolerations
+          content {
+            key                = toleration.value.key
+            operator           = toleration.value.operator
+            value              = toleration.value.value
+            effect             = toleration.value.effect
+            toleration_seconds = toleration.value.toleration_seconds
+          }
+        }
+
         # hostPath under /data/vol/<ns>/redis is root-owned. Redis runs as
         # UID 999 in the official image — without this init, the server
         # crashes on start with "Can't chdir to '/data': Permission denied".

--- a/modules/zitadel/main.tf
+++ b/modules/zitadel/main.tf
@@ -60,6 +60,24 @@ variable "external_domain" {
   type        = string
 }
 
+variable "node_selector" {
+  description = "Node-selector labels every Zitadel pod (main + login + Jobs) must match. Empty = scheduler picks. Set to pin onto the node carrying the platform's stateful tier."
+  type        = map(string)
+  default     = {}
+}
+
+variable "tolerations" {
+  description = "Taints every Zitadel pod tolerates. Empty list = pod cannot land on any tainted node."
+  type = list(object({
+    key                = optional(string)
+    operator           = optional(string)
+    value              = optional(string)
+    effect             = optional(string)
+    toleration_seconds = optional(string)
+  }))
+  default = []
+}
+
 variable "first_admin_email" {
   description = "Email address of the bootstrap human admin (lands on the master instance). Pre-verified so login works without SMTP."
   type        = string
@@ -206,6 +224,19 @@ resource "kubernetes_job_v1" "postgres_setup" {
       spec {
         restart_policy = "Never"
 
+        node_selector = length(var.node_selector) > 0 ? var.node_selector : null
+
+        dynamic "toleration" {
+          for_each = var.tolerations
+          content {
+            key                = toleration.value.key
+            operator           = toleration.value.operator
+            value              = toleration.value.value
+            effect             = toleration.value.effect
+            toleration_seconds = toleration.value.toleration_seconds
+          }
+        }
+
         container {
           name  = "postgres-setup"
           image = "postgres:16-alpine"
@@ -285,6 +316,21 @@ resource "kubernetes_deployment_v1" "zitadel" {
       }
 
       spec {
+        # Pod placement primitives — empty defaults preserve prior
+        # scheduler behaviour.
+        node_selector = length(var.node_selector) > 0 ? var.node_selector : null
+
+        dynamic "toleration" {
+          for_each = var.tolerations
+          content {
+            key                = toleration.value.key
+            operator           = toleration.value.operator
+            value              = toleration.value.value
+            effect             = toleration.value.effect
+            toleration_seconds = toleration.value.toleration_seconds
+          }
+        }
+
         # k8s otherwise injects `ZITADEL_PORT=tcp://<svc-ip>:8080`
         # (legacy docker-link compatibility env vars for every Service
         # in the same namespace). Zitadel reads `ZITADEL_PORT` as its


### PR DESCRIPTION
## Summary

Three orthogonal scheduler primitives plumbed into every workload-creating platform module. **All default empty** — apply plans show no behaviour change against existing yaml. Primitives only kick in once an operator sets a value (Phase B).

| Primitive | Type | Use case |
|---|---|---|
| `node_selector` | `map<string,string>` | "pin onto nodes with this label" |
| `tolerations` | `list<toleration>` | opt-in to scheduling on tainted nodes |
| `affinity` | `any` (passthrough) | richer node / pod (anti-)affinity expressions |

Each maps 1:1 to the matching `pod.spec` field of the k8s API.

## Coverage

- **modules/component** — all three. Consumed via new `node_selector:` / `tolerations:` / `affinity:` keys in `config/components/*.yaml` (piped through `modules/project`).
- **modules/ollama** — all three. Primary use: `node_selector: { gpu = intel }` to pin onto the Arc node so the GPU hostPath device mount succeeds.
- **modules/postgres / mysql / redis / zitadel / platform-dash** — `node_selector` + `tolerations` only. Affinity left as a follow-up if a real need surfaces.

## Out of scope (follow-ups)

1. **Phase B yaml values** — actually pin Ollama → k3s-2, stateful → optiplex, etc. Separate PR.
2. **Addons mirror** — `terraform-k8s-addons` (Traefik / cert-manager / kube-prometheus-stack) is the sibling repo at v1.1.2. Helm-based, accepts the same primitives via chart values; parallel PR there + tag bump in `main.tf`.

## Test plan

- [ ] `./tf plan` against current state shows zero changes (defaults are empty, behaviour preserved)
- [ ] Set `node_selector: { workload-tier: stateful }` on `module.postgres` in a test branch, plan: shows pod-template diff for `kubernetes_stateful_set_v1.postgres` only
- [ ] Set `affinity:` block with node_affinity in a tenant component yaml, plan: shows the expected affinity tree under the Deployment's pod spec
- [ ] README example block parses as valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)