### PR TITLE
feat(placement): pin shared services + chat per node role (Phase B)

### DIFF
--- a/config/components/chat.yaml
+++ b/config/components/chat.yaml
@@ -2,6 +2,14 @@ image: ghcr.io/open-webui/open-webui:v0.9.2
 port: 8080
 replicas: 1
 
+# Place chat onto the fat compute node — Open WebUI orchestrates the
+# Ollama traffic for every tenant; a Python event loop on the data
+# node steals CPU from MySQL / Postgres / Redis under load. The
+# `general` tier (k3s-2) has 28 CPU + 32G to spare and the same
+# in-cluster latency to Ollama (also pinned to k3s-2 via gpu=intel).
+node_selector:
+  workload-tier: general
+
 # WebUI proxies every LLM call AND every RAG embedding call to the
 # shared Ollama in the platform namespace, so it keeps no model in its
 # own RAM — 1Gi is comfortable for the Python server + SQLite + light

--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -123,3 +123,33 @@ services:
     #   allow_register:          false
     #   allow_external_idp:      true
     #   allow_username_password: true
+
+# Pod placement (Phase B, optional per service)
+#
+# Every service above accepts `node_selector:` (map) and
+# `tolerations:` (list); ollama also accepts `affinity:`. All default
+# empty so nothing changes until you fill them in. Useful when the
+# cluster has more than one node and you need to pin pods by role:
+#
+#   services:
+#     postgres: { enabled: true, node_selector: { workload-tier: stateful } }
+#     mysql:    { enabled: true, node_selector: { workload-tier: stateful } }
+#     redis:    { enabled: true, node_selector: { workload-tier: stateful } }
+#     zitadel:  { enabled: true, node_selector: { workload-tier: stateful }, ... }
+#
+#     ollama:
+#       enabled: true
+#       node_selector: { gpu: intel }       # pin to the GPU node
+#
+#     platform_dash:
+#       enabled: true
+#       node_selector: { workload-tier: general }
+#
+# Example toleration block (edge node carrying
+# `node-role.kubernetes.io/edge=true:NoSchedule`):
+#
+#     tolerations:
+#       - { key: node-role.kubernetes.io/edge, operator: Exists, effect: NoSchedule }
+#
+# Schema mirrors `pod.spec` (k8s API v1) — see modules/component/main.tf
+# variable docs for the exact accepted fields.

--- a/locals.tf
+++ b/locals.tf
@@ -5,14 +5,26 @@ locals {
   # to the default below. Missing file = full defaults.
   _platform_defaults = {
     services = {
+      # Pod-placement defaults — each shared service accepts
+      # `node_selector` (map<string,string>) and `tolerations`
+      # (list<toleration>) as optional yaml keys. Both empty by
+      # default so the scheduler keeps current behaviour. See README
+      # "Pod placement" for the shape; consumed by every service's
+      # *.tf wiring file via `local.platform.services.X.<key>`.
       mysql = {
-        enabled = false
+        enabled       = false
+        node_selector = {}
+        tolerations   = []
       }
       postgres = {
-        enabled = false
+        enabled       = false
+        node_selector = {}
+        tolerations   = []
       }
       redis = {
-        enabled = false
+        enabled       = false
+        node_selector = {}
+        tolerations   = []
       }
       ollama = {
         enabled        = false
@@ -26,7 +38,10 @@ locals {
         # (image, device_path, supplemental_groups, env) — see
         # platform.yaml.example for the expected keys and a worked
         # Intel Arc + Vulkan example.
-        gpu = null
+        gpu           = null
+        node_selector = {}
+        tolerations   = []
+        affinity      = {}
       }
       zitadel = {
         enabled              = false
@@ -54,6 +69,8 @@ locals {
           port     = 443
           insecure = false
         }
+        node_selector = {}
+        tolerations   = []
       }
       # Defaults for the planned `services.platform_dash` block. Not
       # consumed yet — the dashboard currently lives as a tenant
@@ -69,6 +86,8 @@ locals {
           requests = { cpu = "100m", memory = "128Mi" }
           limits   = { cpu = "500m", memory = "512Mi" }
         }
+        node_selector = {}
+        tolerations   = []
       }
     }
   }

--- a/mysql.tf
+++ b/mysql.tf
@@ -11,4 +11,7 @@ module "mysql" {
   enabled          = local.platform.services.mysql.enabled
   namespace        = kubernetes_namespace_v1.platform.metadata[0].name
   volume_base_path = var.host_volume_path
+
+  node_selector = local.platform.services.mysql.node_selector
+  tolerations   = local.platform.services.mysql.tolerations
 }

--- a/ollama.tf
+++ b/ollama.tf
@@ -31,4 +31,8 @@ module "ollama" {
   # operator-supplied keys (image, device_path, supplemental_groups,
   # env). Module bakes in nothing vendor- or hardware-specific.
   gpu = local.platform.services.ollama.gpu
+
+  node_selector = local.platform.services.ollama.node_selector
+  tolerations   = local.platform.services.ollama.tolerations
+  affinity      = local.platform.services.ollama.affinity
 }

--- a/platform_dash.tf
+++ b/platform_dash.tf
@@ -76,6 +76,9 @@ module "platform_dash" {
   hostname             = local.platform.services.platform_dash.hostname
   oidc_secret_name     = try(module.platform_dash_oidc[0].secret_name, "platform-dash-oidc")
   oidc_secret_checksum = try(module.platform_dash_oidc[0].secret_checksum, "no-oidc")
+
+  node_selector = local.platform.services.platform_dash.node_selector
+  tolerations   = local.platform.services.platform_dash.tolerations
 }
 
 output "platform_dash_url" {

--- a/postgres.tf
+++ b/postgres.tf
@@ -11,4 +11,7 @@ module "postgres" {
   enabled          = local.platform.services.postgres.enabled
   namespace        = kubernetes_namespace_v1.platform.metadata[0].name
   volume_base_path = var.host_volume_path
+
+  node_selector = local.platform.services.postgres.node_selector
+  tolerations   = local.platform.services.postgres.tolerations
 }

--- a/redis.tf
+++ b/redis.tf
@@ -10,4 +10,7 @@ module "redis" {
   enabled          = local.platform.services.redis.enabled
   namespace        = kubernetes_namespace_v1.platform.metadata[0].name
   volume_base_path = var.host_volume_path
+
+  node_selector = local.platform.services.redis.node_selector
+  tolerations   = local.platform.services.redis.tolerations
 }

--- a/zitadel.tf
+++ b/zitadel.tf
@@ -114,4 +114,7 @@ module "zitadel" {
   first_admin_username      = local.platform.services.zitadel.first_admin_username
   login_policy              = local.platform.services.zitadel.login_policy
   login_client_pat          = var.zitadel_login_client_pat
+
+  node_selector = local.platform.services.zitadel.node_selector
+  tolerations   = local.platform.services.zitadel.tolerations
 }


### PR DESCRIPTION
## Summary

Phase B uses the primitives shipped in #36 to actually pin pods.

| Service | Selector | Node | Why |
|---|---|---|---|
| postgres / mysql / redis / zitadel | `workload-tier=stateful` | optiplex | hostPath `/data/vol` only exists there |
| ollama | `gpu=intel` | k3s-2 | `/dev/dri/renderD129` CharDevice only exists there — currently blocking ollama-0 in ContainerCreating |
| platform_dash | `workload-tier=general` | k3s-2 | stateless, keep off the data node |
| chat (tenant component) | `workload-tier=general` | k3s-2 | same; co-locates with Ollama for latency |

`config/platform.yaml` is gitignored (operator-private). Defaults land in `locals._platform_defaults` (empty maps/lists, behaviour-preserving). New keys documented in `platform.yaml.example`. Operator picks up the pinning by mirroring the example into their live yaml.

## Out of scope

- **Edge node taint toleration** — `k3s-3` carries `node-role.kubernetes.io/edge=true:NoSchedule`. No edge component lives on the platform yet; future workloads opt in via the `tolerations:` block documented in `platform.yaml.example`.
- **Addons mirror** (Traefik / cert-manager / kube-prometheus-stack) — separate PR in `terraform-k8s-addons` repo, then bump the `?ref=` tag in `main.tf`.

## Test plan

- [ ] Operator updates their `config/platform.yaml` to include the `node_selector:` blocks (per `platform.yaml.example`).
- [ ] `./tf plan` shows pod-template diffs for postgres / mysql / redis / zitadel / ollama / platform-dash StatefulSets / Deployments — exactly one `node_selector` field added per pod spec, no other changes.
- [ ] `./tf apply`. Each shared pod re-rolls onto the targeted node:
  - `kubectl get pod -n platform -o wide` shows postgres/mysql/redis/zitadel on optiplex, ollama on k3s-2, platform-dash on k3s-2.
  - `kubectl get pod -n phost-ipsupport-us-prod -o wide` shows chat on k3s-2.
  - `ollama-0` exits ContainerCreating once it lands on the gpu=intel node.
- [ ] Open WebUI at chat.ipsupport.us still answers (latency unchanged or better).
- [ ] No tenant data lost (pods bind to the same hostPath PVCs they did pre-pin).

🤖 Generated with [Claude Code](https://claude.com/claude-code)