### PR TITLE
feat(monitoring): namespace request budget for kube-prometheus-stack

### DIFF
--- a/config/limits/monitoring.yaml
+++ b/config/limits/monitoring.yaml
@@ -1,0 +1,2 @@
+cpu: "2"
+memory: "6Gi"

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -1,0 +1,54 @@
+# Monitoring namespace request budget.
+#
+# The `monitoring` namespace itself is owned upstream by
+# `module.addons` (terraform-k8s-addons → kube-prometheus-stack
+# chart). The chart sets `requests` on a few containers (Prometheus,
+# Alertmanager) but no `limits` on anything. Under node pressure the
+# OOMKiller picks the largest unbounded process first — usually
+# Prometheus' head block — which is the failure mode this stack is
+# closest to.
+#
+# This file does NOT add per-container limits — that must come from
+# Helm values on the kube-prometheus-stack release (separate PR in
+# terraform-k8s-addons + a tag bump). Setting them here via
+# `LimitRange.default` is tempting but breaks the math: ~12
+# chart-managed containers × any sane default exceeds a per-namespace
+# memory quota the operator can stomach. Per-pod values are the
+# correct lever.
+#
+# What this file DOES do is a request-side namespace budget:
+#   * caps total `requests.cpu` / `requests.memory` summed across all
+#     pods in the namespace — the scheduler can't oversubscribe the
+#     node by stacking unbounded chart upgrades.
+#   * caps pod count so a runaway Operator can't fork off thousands
+#     of probes and exhaust IPs / kubelet budget.
+#
+# Sizing comes from `config/limits/monitoring.yaml` (committed). When
+# Prometheus retention or scrape volume grows past the cap, bump
+# there — the apply re-renders the quota in seconds, no pod
+# disruption.
+#
+# Critical: only `requests.*` and `pods` go into quota.hard —
+# Kubernetes makes any field listed there mandatory on every new pod
+# in the namespace. Adding `limits.cpu` / `limits.memory` would force
+# every chart-managed container to declare its own limits or get
+# rejected at admission. The chart doesn't, so we don't either.
+resource "kubernetes_resource_quota_v1" "monitoring" {
+  depends_on = [module.addons]
+
+  metadata {
+    name      = "monitoring-budget"
+    namespace = "monitoring"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+
+  spec {
+    hard = {
+      "requests.cpu"    = try(local.namespace_limits.monitoring.cpu, local.default_limits.cpu)
+      "requests.memory" = try(local.namespace_limits.monitoring.memory, local.default_limits.memory)
+      "pods"            = tostring(try(local.namespace_limits.monitoring.pods, local.default_limits.pods, 30))
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The `kube-prometheus-stack` Helm release (under `module.addons`) owns the `monitoring` namespace but ships nothing for `ResourceQuota` or `LimitRange`. Every container in there runs unbounded — under node pressure the OOMKiller picks the largest unbounded process first, which is usually Prometheus' head block. User flagged "Grafana в инфаркте OOM кажись" — currently no actual OOMs (Grafana 377Mi, Prometheus 731Mi, Alertmanager 44Mi, all 0 restarts), but no guardrail either.

## What lands

1. New `monitoring.tf` — `kubernetes_resource_quota_v1.monitoring` referencing the existing `local.namespace_limits.monitoring` slot. Mirrors the pattern from `platform.tf` (`platform-budget`) and `mail.tf` (`mail-budget`).
2. New `config/limits/monitoring.yaml` (already on disk locally, was untracked — `cpu: "2"`, `memory: "6Gi"`). Operator tunes there.

## What this PR deliberately does NOT do

- **No `limits.*` in the quota.** Kubernetes mandates that any field in `quota.hard` be present on every new pod. The chart sets memory limits on nothing and CPU limits on nothing; adding `limits.cpu` / `limits.memory` here would block every chart-managed pod re-creation at admission. Per-pod *limits* must come from Helm values on the chart — that's a follow-up PR in `terraform-k8s-addons` + a `?ref=` bump in `main.tf`.
- **No `LimitRange.default`.** Same reason — applying a default would push every chart-managed container into `limits.*` mode and instantly fight the quota math (12 containers × 1Gi default = 12Gi > 6Gi). Per-pod precision via Helm is the right lever.

## Test plan

- [ ] `./tf plan` shows one new `kubernetes_resource_quota_v1.monitoring` resource and nothing else
- [ ] `./tf apply` — quota lands, no chart pods get evicted (verify `kubectl -n monitoring get pods` shows the same set, all Running)
- [ ] `kubectl -n monitoring describe resourcequota monitoring-budget` shows `Used` ≪ `Hard` for cpu/memory/pods
- [ ] Bump `config/limits/monitoring.yaml` to a tiny value (e.g. cpu 100m), re-apply, confirm new pods get rejected at admission. Revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)