### PR TITLE
refactor(tf): wrapper exports plain .env keys under both native + TF_VAR_ names

### DIFF
--- a/.claude/skills/platform/operating.md
+++ b/.claude/skills/platform/operating.md
@@ -31,7 +31,18 @@ Loads `.env` and either delegates to `terraform` or runs an orchestration subcom
 
 `bootstrap-*` stops on an interactive confirmation listing what gets destroyed and what's preserved. `-y` / `--yes` skips for CI. Host volume data under `$HOST_VOLUME_PATH` is NEVER deleted by bootstrap. Cloudflare-side: bootstrap fails preflight if a tunnel with the same name already exists — operator decides purge vs `terraform import`.
 
-The wrapper double-wraps `TF_VAR_` keys correctly (a key already prefixed `TF_VAR_` is NOT prefixed again — this used to silently turn `TF_VAR_ssh_host` into `TF_VAR_tf_var_ssh_host`).
+`.env` keys are loaded in one of two shapes, on purpose:
+- **Plain key** (e.g. `CLOUDFLARE_API_TOKEN`, `AWS_ACCESS_KEY_ID`,
+  `LETSENCRYPT_EMAIL`, `HOST_VOLUME_PATH`): exported under both the
+  native name AND as `TF_VAR_<lowercase>`. SDKs (Cloudflare provider,
+  S3 backend, kubectl) read the native name; modules that thread the
+  value through a `variable "foo" {}` block read the `TF_VAR_` form.
+  Both forms see the same value, the operator picks per consumer.
+- **Pre-prefixed key** (e.g. `TF_VAR_ssh_host`, `TF_VAR_zitadel_pat`):
+  exported only as the `TF_VAR_*` form. Use this when the value has
+  no SDK consumer — Terraform inputs only. (Without the dedicated
+  branch, a pre-prefixed key would double up as
+  `TF_VAR_tf_var_ssh_host` and silently never reach Terraform.)
 
 ## `.env` shape (current values, sanitised)
 

--- a/README.md
+++ b/README.md
@@ -558,7 +558,16 @@ Local `terraform.tfstate` is the default. To move to Backblaze B2 (S3-compatible
 ## The `./tf` wrapper
 
 `tf` is a thin shell wrapper that:
-1. Loads `.env` variables as `TF_VAR_*` exports
+1. Loads `.env` variables and exports them in two complementary forms:
+   - **Plain keys** (`FOO_BAR=...`) get exported under their original
+     name AND as `TF_VAR_foo_bar`. This means SDK-native env vars
+     (`CLOUDFLARE_API_TOKEN`, `AWS_ACCESS_KEY_ID`, `KUBECONFIG`, etc.)
+     are visible to providers and backends under the names those SDKs
+     actually read, while `variable "foo_bar" {}` declarations still
+     receive the value via the `TF_VAR_*` form.
+   - **Pre-prefixed keys** (`TF_VAR_foo_bar=...`) are exported as-is
+     (just lowercased). Use this for inputs that have no SDK consumer —
+     the k3s SSH knobs are the canonical example.
 2. Provides `bootstrap-minikube` / `bootstrap-k3s` / `cloudflare-purge` subcommands
 
 ```bash

--- a/tf
+++ b/tf
@@ -56,7 +56,7 @@ ENV_FILE="${SCRIPT_DIR}/.env"
 if [[ ! -f "$ENV_FILE" ]]; then
   echo "Warning: $ENV_FILE not found"
 else
-  echo "Loading variables from .env as TF_VAR_*..."
+  echo "Loading variables from .env..."
   while IFS= read -r line || [[ -n "$line" ]]; do
     [[ "$line" =~ ^[[:space:]]*(#|$) ]] && continue
     if [[ "$line" == *"="* ]]; then
@@ -67,20 +67,43 @@ else
       value="${value#\'}"
       value="${value%\'}"
       # Two accepted key styles in .env:
-      #   FOO_BAR=...        (plain)       → exported as TF_VAR_foo_bar
-      #   TF_VAR_foo_bar=... (pre-fixed)   → exported as-is (just lowercased)
-      # Without this branch, pre-fixed keys would double up as
-      # TF_VAR_tf_var_foo_bar and the variable would silently not reach
-      # Terraform. The .env.example uses the pre-fixed style for the k3s SSH
-      # knobs because that is the idiomatic Terraform env-var form.
+      #   FOO_BAR=...        (plain)     → exported under TWO names:
+      #                                       FOO_BAR=... (native, original case)
+      #                                       TF_VAR_foo_bar=...
+      #   TF_VAR_foo_bar=... (pre-fixed) → exported as TF_VAR_foo_bar
+      #                                    (only — there is no native form
+      #                                    for a TF-input-only key)
+      #
+      # Why both forms for plain keys: provider SDKs (Cloudflare, AWS S3
+      # backend, kubectl, GCP, etc.) read native env-var names directly
+      # — `CLOUDFLARE_API_TOKEN`, `AWS_ACCESS_KEY_ID` — and do NOT
+      # understand `TF_VAR_*`. The S3 backend block in particular is
+      # parsed BEFORE Terraform evaluates `var.*`, so a backend
+      # configured to read credentials cannot reference an input
+      # variable; it has to find the SDK env vars under their native
+      # names. Meanwhile, modules that thread a value through a
+      # `variable "foo" {}` block need `TF_VAR_foo`. Exporting both
+      # lets the operator's TF code use whichever path is appropriate
+      # without rewriting `.env` per consumer.
+      #
+      # Why the pre-fixed branch exists at all: without it, a key like
+      # `TF_VAR_ssh_host` in `.env` would double up as
+      # `TF_VAR_tf_var_ssh_host` and silently not reach Terraform.
+      # `.env.example` uses the pre-fixed style for the k3s SSH knobs
+      # because that is the idiomatic Terraform env-var form for inputs
+      # that have no SDK consumer.
       lower_key="$(echo "$key" | tr '[:upper:]' '[:lower:]')"
       if [[ "$lower_key" == tf_var_* ]]; then
         tf_var_name="TF_VAR_${lower_key#tf_var_}"
+        export "$tf_var_name"="$value"
+        echo "  $tf_var_name=*** (hidden)"
       else
+        export "$key"="$value"
         tf_var_name="TF_VAR_${lower_key}"
+        export "$tf_var_name"="$value"
+        echo "  $key=*** (hidden)"
+        echo "  $tf_var_name=*** (hidden)"
       fi
-      export "$tf_var_name"="$value"
-      echo "  $tf_var_name=*** (hidden)"
     fi
   done < "$ENV_FILE"
 fi


### PR DESCRIPTION
## Summary
- `./tf` no longer translates plain `.env` keys into TF_VAR_-only — it now exports each plain key under **both** its native name (`CLOUDFLARE_API_TOKEN`, `AWS_ACCESS_KEY_ID`, …) AND `TF_VAR_<lowercase>`.
- Pre-prefixed keys (`TF_VAR_ssh_host`, `TF_VAR_zitadel_pat`) keep their existing TF-only behavior.
- Removes the need for the per-SDK case-statement hack that was attempted (and rejected) in #41.

## Why
The S3 backend block is parsed **before** Terraform evaluates `var.*`. A `backend \"s3\" {}` cannot reference input variables, and the AWS S3 SDK reads `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` from the process environment under those exact names. The same is true for the Cloudflare provider (`CLOUDFLARE_API_TOKEN`), kubectl (`KUBECONFIG`), and most other provider SDKs — they all want native names, not `TF_VAR_*`.

The old wrapper exported only `TF_VAR_<lower>`, which meant:
- The S3 backend never saw credentials → remote-state migration didn't work without `set -a; source .env; set +a` by hand.
- The Cloudflare provider only worked because the repo wires `CLOUDFLARE_API_TOKEN` through a `variable \"cloudflare_api_token\" {}` indirection.
- Adding any new SDK-native env var would require a fresh wrapper hack.

Exporting both forms lets the operator pick whichever consumer style fits per call site without rewriting `.env`. Existing `variable {}` blocks keep working unchanged.

## Behavior matrix

| `.env` line                  | Old export                   | New export                                                |
| ---                          | ---                          | ---                                                       |
| `FOO_BAR=v`                  | `TF_VAR_foo_bar=v`           | `FOO_BAR=v` **and** `TF_VAR_foo_bar=v`                    |
| `TF_VAR_foo_bar=v`           | `TF_VAR_foo_bar=v`           | `TF_VAR_foo_bar=v` (unchanged)                            |
| `CLOUDFLARE_API_TOKEN=...`   | `TF_VAR_cloudflare_api_token` only | `CLOUDFLARE_API_TOKEN` **and** `TF_VAR_cloudflare_api_token` |
| `AWS_ACCESS_KEY_ID=...`      | `TF_VAR_aws_access_key_id` only    | `AWS_ACCESS_KEY_ID` **and** `TF_VAR_aws_access_key_id`    |

## Compatibility
- 100% backward compatible — every existing `TF_VAR_*` consumer keeps receiving its value.
- Removes the silent failure mode where the S3 backend / SDK-native env vars weren't reaching their consumers.
- No `.env` migration needed.

## Test plan
- [x] `bash -n tf` passes
- [x] Smoke test on a synthetic `.env` (mixed plain + `TF_VAR_`) confirms both forms exported for plain keys, single form for pre-prefixed
- [ ] `./tf init` against the live `.env` (operator-side test) — backend should pick up `AWS_ACCESS_KEY_ID` natively without `source .env` first

🤖 Generated with [Claude Code](https://claude.com/claude-code)