### PR TITLE
feat(cloudflare): bump provider to v5

### DIFF
--- a/_versions.tf
+++ b/_versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -138,15 +138,6 @@ resource "cloudflare_dns_record" "tunnel" {
   ttl     = 1
 }
 
-# State migration: v4 used `cloudflare_record`, v5 split DNS records
-# into a dedicated `cloudflare_dns_record` resource. The `moved`
-# block lets Terraform rewire state by name without `terraform state
-# mv` calls per for_each key.
-moved {
-  from = cloudflare_record.tunnel
-  to   = cloudflare_dns_record.tunnel
-}
-
 # ── Manual DNS records — declared per-domain in YAML ─────────────────────────
 #
 # The auto-generated CNAMEs above cover everything routed through the
@@ -205,9 +196,4 @@ resource "cloudflare_dns_record" "manual" {
       error_message = "DNS record ${each.key}: domain has no `cloudflare_zone_id` — set it on the domain YAML before declaring `dns:` records."
     }
   }
-}
-
-moved {
-  from = cloudflare_record.manual
-  to   = cloudflare_dns_record.manual
 }

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -28,10 +28,10 @@ resource "random_password" "cloudflare_tunnel_secret" {
 }
 
 resource "cloudflare_zero_trust_tunnel_cloudflared" "main" {
-  account_id = var.cloudflare_account_id
-  name       = "platform"
-  config_src = "cloudflare"
-  secret     = base64encode(random_password.cloudflare_tunnel_secret.result)
+  account_id    = var.cloudflare_account_id
+  name          = "platform"
+  config_src    = "cloudflare"
+  tunnel_secret = base64encode(random_password.cloudflare_tunnel_secret.result)
 }
 
 # Pre-destroy force-delete for the tunnel above.
@@ -85,45 +85,43 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "main" {
   account_id = var.cloudflare_account_id
   tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.main.id
 
-  config {
-    dynamic "ingress_rule" {
-      for_each = local.all_hostnames
-      content {
-        hostname = ingress_rule.key
-        service  = ingress_rule.value.service
-
-        # End-to-end TLS to Traefik. `origin_server_name` sets the SNI
-        # cloudflared presents on the upstream TLS handshake — without
-        # it cloudflared would SNI as the service-URL host
-        # (`traefik.ingress-controller.svc.cluster.local`), Traefik
-        # would fall back to its self-signed default cert, and
-        # cloudflared would reject it. Setting SNI to the public
-        # hostname lets Traefik serve the correct Let's Encrypt cert,
-        # which cloudflared validates cleanly.
-        #
-        # `http2_origin` is opt-in via the component yaml — flips
-        # cloudflared from HTTP/1.1 to HTTP/2 cleartext upstream;
-        # required end-to-end for any service that exposes gRPC
-        # alongside HTTP (Zitadel today, anything kind:app backed by
-        # gRPC tomorrow). Traefik's own `scheme: h2c` knob passes the
-        # HTTP/2 framing through to the pod.
-        origin_request {
-          origin_server_name = ingress_rule.key
-          http2_origin       = try(ingress_rule.value.http2_origin, false)
+  # v5 schema: `ingress_rule` is a list-of-objects attribute, not a
+  # block. End-to-end TLS to Traefik is enforced via `origin_request.
+  # origin_server_name` — without it, cloudflared would SNI as the
+  # upstream service URL host, Traefik would fall back to its
+  # self-signed default cert, and cloudflared would reject it. Setting
+  # SNI to the public hostname lets Traefik serve the correct Let's
+  # Encrypt cert, which cloudflared validates cleanly.
+  #
+  # `http2_origin` is opt-in via the component yaml — flips cloudflared
+  # from HTTP/1.1 to HTTP/2 cleartext upstream; required end-to-end for
+  # any service that exposes gRPC alongside HTTP (Zitadel today,
+  # anything kind:app backed by gRPC tomorrow). Traefik's own
+  # `scheme: h2c` knob passes the HTTP/2 framing through to the pod.
+  config = {
+    ingress = concat(
+      [
+        for hostname, cfg in local.all_hostnames : {
+          hostname = hostname
+          service  = cfg.service
+          origin_request = {
+            origin_server_name = hostname
+            http2_origin       = try(cfg.http2_origin, false)
+          }
         }
-      }
-    }
-
-    # Catch-all (required by Cloudflare)
-    ingress_rule {
-      service = "http_status:404"
-    }
+      ],
+      # Catch-all (required by Cloudflare — must be the last entry,
+      # match-anything by omitting `hostname`).
+      [{
+        service = "http_status:404"
+      }]
+    )
   }
 }
 
 # ── DNS CNAME records — one per hostname ─────────────────────────────────────
 
-resource "cloudflare_record" "tunnel" {
+resource "cloudflare_dns_record" "tunnel" {
   for_each = {
     for hostname, cfg in local.all_hostnames : hostname => cfg
     if cfg.zone_id != null
@@ -131,9 +129,22 @@ resource "cloudflare_record" "tunnel" {
 
   zone_id = each.value.zone_id
   name    = each.key
-  content = cloudflare_zero_trust_tunnel_cloudflared.main.cname
+  # v5 dropped the `cname` attribute on the tunnel resource — construct
+  # the cfargotunnel.com host ourselves. Provider docs say the format
+  # is stable: `<tunnel-uuid>.cfargotunnel.com`.
+  content = "${cloudflare_zero_trust_tunnel_cloudflared.main.id}.cfargotunnel.com"
   type    = "CNAME"
   proxied = true
+  ttl     = 1
+}
+
+# State migration: v4 used `cloudflare_record`, v5 split DNS records
+# into a dedicated `cloudflare_dns_record` resource. The `moved`
+# block lets Terraform rewire state by name without `terraform state
+# mv` calls per for_each key.
+moved {
+  from = cloudflare_record.tunnel
+  to   = cloudflare_dns_record.tunnel
 }
 
 # ── Manual DNS records — declared per-domain in YAML ─────────────────────────
@@ -149,11 +160,14 @@ resource "cloudflare_record" "tunnel" {
 # `dns:` — see config/domains/example.com.yaml.example for the worked
 # shape. Records are domain-scoped (not env-scoped) — they describe the
 # zone, not a per-env routing decision.
-resource "cloudflare_record" "manual" {
+resource "cloudflare_dns_record" "manual" {
   for_each = local.manual_dns_records
 
-  zone_id  = each.value.zone_id
-  name     = each.value.name
+  zone_id = each.value.zone_id
+  # `name` is the FQDN form for the v5 provider; the YAML-shape short
+  # name lives in `each.value.name` and only enters the for_each key
+  # to keep state stable across the v4→v5 transition.
+  name     = each.value.fqdn
   type     = each.value.type
   ttl      = each.value.ttl
   proxied  = each.value.proxied
@@ -161,24 +175,24 @@ resource "cloudflare_record" "manual" {
   comment  = each.value.comment
 
   # Flat `content` for A/AAAA/CNAME/MX/TXT/NS/PTR. SRV/CAA/LOC use the
-  # structured `data` block instead — the provider rejects co-presence
-  # of both, so each record specifies exactly one in YAML.
+  # structured `data` attribute instead — the provider rejects
+  # co-presence of both, so each record specifies exactly one in YAML.
   content = each.value.data == null ? each.value.content : null
 
-  dynamic "data" {
-    for_each = each.value.data == null ? [] : [each.value.data]
-    content {
-      priority = try(data.value.priority, null)
-      weight   = try(data.value.weight, null)
-      port     = try(data.value.port, null)
-      target   = try(data.value.target, null)
-      service  = try(data.value.service, null)
-      proto    = try(data.value.proto, null)
-      name     = try(data.value.name, null)
-      flags    = try(data.value.flags, null)
-      tag      = try(data.value.tag, null)
-      value    = try(data.value.value, null)
-    }
+  # v5 schema: `data` is now a nested attribute (object), not a
+  # dynamic block. CAA flag is a number in v5 (was string in v4) —
+  # cast on the way in so YAML can keep the friendly form.
+  data = each.value.data == null ? null : {
+    priority = try(each.value.data.priority, null)
+    weight   = try(each.value.data.weight, null)
+    port     = try(each.value.data.port, null)
+    target   = try(each.value.data.target, null)
+    service  = try(each.value.data.service, null)
+    proto    = try(each.value.data.proto, null)
+    name     = try(each.value.data.name, null)
+    flags    = try(tonumber(each.value.data.flags), null)
+    tag      = try(each.value.data.tag, null)
+    value    = try(each.value.data.value, null)
   }
 
   lifecycle {
@@ -191,4 +205,9 @@ resource "cloudflare_record" "manual" {
       error_message = "DNS record ${each.key}: domain has no `cloudflare_zone_id` — set it on the domain YAML before declaring `dns:` records."
     }
   }
+}
+
+moved {
+  from = cloudflare_record.manual
+  to   = cloudflare_dns_record.manual
 }

--- a/cloudflared.tf
+++ b/cloudflared.tf
@@ -2,6 +2,16 @@
 # Runs in the ops namespace and connects to the tunnel created in cloudflare.tf.
 # Config is managed from the Cloudflare dashboard (config_src = "cloudflare").
 
+# v5 dropped the `tunnel_token` attribute on the tunnel resource and
+# split it into a dedicated data source. The token is regenerated each
+# time it's read (Cloudflare's behaviour, not Terraform's), but
+# refreshing the data source on every plan keeps the Secret in lockstep
+# with whatever Cloudflare currently considers valid.
+data "cloudflare_zero_trust_tunnel_cloudflared_token" "main" {
+  account_id = var.cloudflare_account_id
+  tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.main.id
+}
+
 resource "kubernetes_secret_v1" "cloudflared_token" {
   depends_on = [module.k8s]
 
@@ -15,7 +25,7 @@ resource "kubernetes_secret_v1" "cloudflared_token" {
   }
 
   data = {
-    token = cloudflare_zero_trust_tunnel_cloudflared.main.tunnel_token
+    token = data.cloudflare_zero_trust_tunnel_cloudflared_token.main.token
   }
 
   type = "Opaque"

--- a/locals.tf
+++ b/locals.tf
@@ -176,14 +176,24 @@ locals {
         for rec in try(cfg.dns, []) : {
           domain_key = domain_key
           zone_id    = cfg.cloudflare_zone_id
-          name       = rec.name
-          type       = rec.type
-          content    = try(rec.content, null)
-          data       = try(rec.data, null)
-          ttl        = try(rec.ttl, 1)
-          proxied    = try(rec.proxied, false)
-          priority   = try(rec.priority, null)
-          comment    = try(rec.comment, null)
+          # `name` keeps the YAML form (`@`, `_dmarc`, `mail`) so the
+          # for_each key stays stable. The FQDN form lives in `fqdn`
+          # below — Cloudflare provider v5 requires FQDN at the
+          # resource level, but routing the FQDN into for_each would
+          # destroy+recreate every record on the v4→v5 transition.
+          name = rec.name
+          fqdn = (
+            rec.name == "@" ? cfg.name :
+            (rec.name == cfg.name || endswith(rec.name, ".${cfg.name}")) ? rec.name :
+            "${rec.name}.${cfg.name}"
+          )
+          type     = rec.type
+          content  = try(rec.content, null)
+          data     = try(rec.data, null)
+          ttl      = try(rec.ttl, 1)
+          proxied  = try(rec.proxied, false)
+          priority = try(rec.priority, null)
+          comment  = try(rec.comment, null)
         }
       ]
     ]) : "${entry.domain_key}|${entry.type}|${entry.name}|${md5(coalesce(entry.content, jsonencode(entry.data)))}" => entry

--- a/modules/stalwart/main.tf
+++ b/modules/stalwart/main.tf
@@ -18,7 +18,7 @@ terraform {
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"
-      version = "~> 4.0"
+      version = "~> 5.0"
     }
     zitadel = {
       source  = "zitadel/zitadel"
@@ -737,11 +737,12 @@ resource "zitadel_project_role" "user" {
 # (DKIM body comes from `tls_private_key.dkim`, SPF/DMARC from module
 # vars). Hand-pasting the rendered DKIM body into yaml every key
 # rotation would be busy-work; this keeps the source-of-truth single.
-resource "cloudflare_record" "spf" {
+resource "cloudflare_dns_record" "spf" {
   for_each = local.spf_record_set
 
   zone_id = var.cloudflare_zone_id
-  name    = "@"
+  # v5 requires FQDN — `@` is no longer accepted.
+  name    = var.primary_domain
   type    = "TXT"
   content = local.spf_dns_value
   proxied = false
@@ -749,11 +750,11 @@ resource "cloudflare_record" "spf" {
   comment = "SPF — managed by modules/stalwart (terraform-minikube-platform)"
 }
 
-resource "cloudflare_record" "dkim" {
+resource "cloudflare_dns_record" "dkim" {
   for_each = local.dns_records_set
 
   zone_id = var.cloudflare_zone_id
-  name    = local.dkim_dns_name
+  name    = "${local.dkim_dns_name}.${var.primary_domain}"
   type    = "TXT"
   content = local.dkim_dns_value
   proxied = false
@@ -761,16 +762,33 @@ resource "cloudflare_record" "dkim" {
   comment = "DKIM — managed by modules/stalwart (terraform-minikube-platform)"
 }
 
-resource "cloudflare_record" "dmarc" {
+resource "cloudflare_dns_record" "dmarc" {
   for_each = local.dmarc_record_set
 
   zone_id = var.cloudflare_zone_id
-  name    = "_dmarc"
+  name    = "_dmarc.${var.primary_domain}"
   type    = "TXT"
   content = local.dmarc_dns_value
   proxied = false
   ttl     = 300
   comment = "DMARC — managed by modules/stalwart (terraform-minikube-platform)"
+}
+
+# State migrations from the v4 `cloudflare_record` to v5
+# `cloudflare_dns_record` — same underlying DNS record, just a new
+# resource type. Without these, `terraform plan` would treat the
+# rename as destroy+create and break mail delivery during the apply.
+moved {
+  from = cloudflare_record.spf
+  to   = cloudflare_dns_record.spf
+}
+moved {
+  from = cloudflare_record.dkim
+  to   = cloudflare_dns_record.dkim
+}
+moved {
+  from = cloudflare_record.dmarc
+  to   = cloudflare_dns_record.dmarc
 }
 
 # DKIM RSA key — rendered into the bootstrap plan's DkimSignature.

--- a/modules/stalwart/main.tf
+++ b/modules/stalwart/main.tf
@@ -774,23 +774,6 @@ resource "cloudflare_dns_record" "dmarc" {
   comment = "DMARC — managed by modules/stalwart (terraform-minikube-platform)"
 }
 
-# State migrations from the v4 `cloudflare_record` to v5
-# `cloudflare_dns_record` — same underlying DNS record, just a new
-# resource type. Without these, `terraform plan` would treat the
-# rename as destroy+create and break mail delivery during the apply.
-moved {
-  from = cloudflare_record.spf
-  to   = cloudflare_dns_record.spf
-}
-moved {
-  from = cloudflare_record.dkim
-  to   = cloudflare_dns_record.dkim
-}
-moved {
-  from = cloudflare_record.dmarc
-  to   = cloudflare_dns_record.dmarc
-}
-
 # DKIM RSA key — rendered into the bootstrap plan's DkimSignature.
 # Stable: tls_private_key keeps the same value across applies, so the
 # public key in DNS doesn't churn. Rotation = taint this resource +

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,7 +25,9 @@ output "tunnel_id" {
 
 output "tunnel_cname" {
   description = "Cloudflare Tunnel CNAME target"
-  value       = cloudflare_zero_trust_tunnel_cloudflared.main.cname
+  # v5 dropped the `cname` attribute on the tunnel resource; the format
+  # `<tunnel-uuid>.cfargotunnel.com` is documented as stable.
+  value = "${cloudflare_zero_trust_tunnel_cloudflared.main.id}.cfargotunnel.com"
 }
 
 output "grafana_credentials" {


### PR DESCRIPTION
## Summary

Migrate Cloudflare provider `~> 4.0` → `~> 5.0`. Every resource is rewritten through the v5 schema. **State migration already executed against the live B2 backend** (rm + import for 29 DNS records); current `terraform plan` reports:

```
Plan: 0 to add, 1 to change, 0 to destroy.
```

Where the one in-place change is `cloudflare_zero_trust_tunnel_cloudflared_config.main` — v5 explicitly materialises previously-implicit nullable defaults (`connect_timeout = 30 -> null` etc.). Cloudflare side unchanged.

## Diff hot spots

| Resource | v4 | v5 |
| --- | --- | --- |
| Tunnel `secret` | `secret = ...` | `tunnel_secret = ...` |
| Tunnel `.cname` | exported attribute | dropped — built as `"${id}.cfargotunnel.com"` |
| Tunnel token | `.tunnel_token` on resource | dedicated `data "cloudflare_zero_trust_tunnel_cloudflared_token"` |
| DNS record | `cloudflare_record` | `cloudflare_dns_record` |
| Record `name` | accepted `@` / bare subdomain | requires FQDN |
| Record `data` | dynamic block | nested attribute |
| CAA `flag` | string | number |
| Tunnel config `ingress_rule` | repeating block | list-of-objects attribute |

## State migration (already done)

29 DNS records live in state under `cloudflare_record.*` (v4 type). v5 dropped that resource type, and `terraform state mv` refuses cross-type renames (`resource types don't match`). `moved {}` blocks were considered but explicitly rejected — single-operator repo, transient migration scaffolding isn't worth the file noise. Path actually used: per-record `terraform state rm` + `terraform import`, driven by a one-shot script that read `(zone_id, record_id)` straight from the v4 state JSON (a clean `terraform state pull` snapshot is at `/tmp/state-backup-pre-cf-v5-import-1777731829.tfstate` for rollback).

Result: state references the new `cloudflare_dns_record.*` instances, attribute schema matches v5, no resources lost in transit. Apply will only execute the one in-place schema-rendering update on the tunnel config.

The locals tweak: `cloudflare_dns_record.manual` v5 requires FQDN, but the for_each key includes the record name — flipping the name to FQDN would re-key the for_each map and force destroy+recreate. Fix: keep YAML-shape `name` (`@`, `_dmarc`, `relay`) in the for_each key, expose a separate `fqdn` field for the resource attribute. State stable, resource correct.

## Plan output (current state)

```
cloudflare_zero_trust_tunnel_cloudflared_config.main will be updated in-place
Plan: 0 to add, 1 to change, 0 to destroy.
```

## Honest scope note

The backlog item driving this upgrade was: "v5 might use a keyed map for `ingress_rule` and stop the noisy positional-list diffs on every new hostname." v5 docs confirm it's still an ordered list — that pain is NOT fixed by this migration. Reasons to land anyway: dropped `tunnel_token` exposure (now requires a deliberate data-source read; smaller token-leak blast radius), continued v4 EOL, and the renames must happen eventually.

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform validate` passes
- [x] State migration executed; `terraform plan` reports 0 destroy
- [x] Smoke import on `whoami.dev.paseka.co` succeeded before running the bulk loop
- [ ] `terraform apply` against live cluster — expect ~30s for the in-place tunnel-config update only
- [ ] Post-apply spot-check: `dig +short auth.ipsupport.us` → tunnel CNAME, `kubectl -n ops logs deploy/cloudflared` → connector token still valid

## Out of scope

- The `var.cloudflare_api_token` / null_resource trigger indirection cleanup. Saved for a follow-up so this PR is purely the v5 rewrite.
- Helm 2 → 3 upgrade. Separate PR — two breaking provider bumps in one PR is harder to roll back.
- The commit `chore(cloudflare): drop moved {} blocks; migrate state via terraform state mv` references state mv as the migration path; the actual path used was state rm + import (state mv refuses cross-type). Code change still correct (moved blocks dropped); commit message is mildly off — kept as-is to avoid a force-push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)