### PR TITLE
refactor(cloudflare): drop var.cloudflare_api_token indirection

### DIFF
--- a/_providers.tf
+++ b/_providers.tf
@@ -1,6 +1,10 @@
-provider "cloudflare" {
-  api_token = var.cloudflare_api_token
-}
+# Cloudflare provider reads `CLOUDFLARE_API_TOKEN` from the process
+# environment when `api_token` is not set explicitly. The `./tf`
+# wrapper exports the value under both the native name and
+# `TF_VAR_cloudflare_api_token`; passing it via a `variable` block
+# would just round-trip the same value and pin a copy of the token
+# into Terraform state.
+provider "cloudflare" {}
 
 # Consume the kubeconfig emitted by the chosen cluster module. Both sibling
 # modules (`terraform-minikube-k8s` and `terraform-k3s-k8s`) export a

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -38,10 +38,10 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "main" {
 #
 # Cloudflare's API refuses to delete a tunnel while it sees "active
 # connections" on its side — which lags the actual cloudflared pods by
-# 30-90s after they stop. The v4 provider retries internally with no
+# 30-90s after they stop. The provider retries internally with no
 # user-configurable ceiling and blocks `terraform destroy` for 3-5
-# minutes on every teardown (the `timeouts` block is not on the
-# resource's schema).
+# minutes on every teardown (no `timeouts` / `force_delete` on the
+# resource schema as of v5.19.x).
 #
 # Short-circuit by hitting the Cloudflare API directly with
 # `?force=true` on a 30s curl timeout. The null_resource runs its
@@ -52,13 +52,20 @@ resource "cloudflare_zero_trust_tunnel_cloudflared" "main" {
 # `on_failure = continue` so a missing tunnel (already purged by the
 # wrapper's `cloudflare-purge` subcommand) or a transient network hiccup
 # does not strand the destroy.
+#
+# Credentials and account scope are read from the Cloudflare provider's
+# native env vars (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`) at
+# exec time rather than threaded through `triggers`. Triggers are
+# stored verbatim in `terraform.tfstate`, so a token in there leaks
+# the secret into B2 state on every teardown that touches this
+# resource. `tunnel_id` stays as the only trigger because it's the
+# value that actually changes when the resource is replaced — the
+# token + account are operator-scope constants.
 resource "null_resource" "cloudflare_tunnel_force_delete" {
   depends_on = [cloudflare_zero_trust_tunnel_cloudflared.main]
 
   triggers = {
-    tunnel_id  = cloudflare_zero_trust_tunnel_cloudflared.main.id
-    account_id = var.cloudflare_account_id
-    api_token  = var.cloudflare_api_token
+    tunnel_id = cloudflare_zero_trust_tunnel_cloudflared.main.id
   }
 
   provisioner "local-exec" {
@@ -66,16 +73,16 @@ resource "null_resource" "cloudflare_tunnel_force_delete" {
     on_failure  = continue
     interpreter = ["bash", "-c"]
     environment = {
-      ACCOUNT_ID = self.triggers.account_id
-      TUNNEL_ID  = self.triggers.tunnel_id
-      API_TOKEN  = self.triggers.api_token
+      TUNNEL_ID = self.triggers.tunnel_id
     }
     command = <<-EOT
       set -euo pipefail
+      : "$${CLOUDFLARE_API_TOKEN:?must be set in process env (./tf wrapper exports it)}"
+      : "$${CLOUDFLARE_ACCOUNT_ID:?must be set in process env (./tf wrapper exports it)}"
       curl -fsS --max-time 30 \
         -X DELETE \
-        -H "Authorization: Bearer $API_TOKEN" \
-        "https://api.cloudflare.com/client/v4/accounts/$ACCOUNT_ID/cfd_tunnel/$TUNNEL_ID?force=true" \
+        -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+        "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/cfd_tunnel/$TUNNEL_ID?force=true" \
         > /dev/null
     EOT
   }

--- a/variables.tf
+++ b/variables.tf
@@ -51,12 +51,6 @@ variable "letsencrypt_email" {
   type        = string
 }
 
-variable "cloudflare_api_token" {
-  description = "Cloudflare API Token"
-  type        = string
-  sensitive   = true
-}
-
 variable "cloudflare_account_id" {
   description = "Cloudflare Account ID"
   type        = string


### PR DESCRIPTION
## Summary

Stop leaking the broad-scope Cloudflare API token into Terraform state via two paths:

1. `provider "cloudflare" { api_token = var.cloudflare_api_token }` → `provider "cloudflare" {}`. Provider reads `CLOUDFLARE_API_TOKEN` from the process env (the `./tf` wrapper exports it natively after PR #43).
2. `null_resource.cloudflare_tunnel_force_delete.triggers` shrinks from `{tunnel_id, account_id, api_token}` → `{tunnel_id}`. Triggers are persisted verbatim in `terraform.tfstate` (i.e. on the B2 backend, in every state-pull, in every backup). The destroy-time bash now reads `$CLOUDFLARE_API_TOKEN` / `$CLOUDFLARE_ACCOUNT_ID` directly from the process env with `:?must be set` checks that fail loudly if the operator runs `terraform destroy` outside `./tf`.

`variable "cloudflare_api_token"` had only those two consumers; it's deleted. `TF_VAR_cloudflare_api_token` still flows out of the wrapper but is now a no-op (Terraform warns about the undeclared var and continues).

## State migration (existing setups only)

The trigger reshape would otherwise force `replace` on the existing `null_resource.cloudflare_tunnel_force_delete`, which **runs the OLD destroy provisioner first** — and that provisioner curls `?force=true` against the live Cloudflare tunnel, taking down all public routing. Run **before** `./tf apply`:

```bash
./tf state rm null_resource.cloudflare_tunnel_force_delete
```

Plan after the rm:

```
cloudflare_zero_trust_tunnel_cloudflared_config.main will be updated in-place
null_resource.cloudflare_tunnel_force_delete will be created
Plan: 1 to add, 1 to change, 0 to destroy.
```

Greenfield setups (no existing state) are unaffected — the resource is just created with the new trigger shape on first apply. The `cloudflare_zero_trust_tunnel_cloudflared_config` in-place change is the residual from PR #44 (v5 nullable defaults).

## Out of scope (separate PR pending investigation)

Replacing `null_resource.default_login_policy` with the native `zitadel_default_login_policy` provider resource. Drafted locally and reverted from this branch — adding the resource cascaded a "must be replaced" diff onto every downstream `zitadel_project` / `zitadel_application_oidc` / `zitadel_project_role` (`org_id` chained through `data.zitadel_orgs.this`, which becomes "(known after apply)" when any zitadel resource is being created in the same plan). Replacing those would tear down forward-auth + dash login. Needs a deeper look at how the zitadel provider plans org-id refresh.

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform validate` passes
- [x] `terraform plan` shows `1 add, 1 change, 0 destroy` (after one-time state rm)
- [x] State rm executed against the live B2 backend; backup at `/tmp/state-pre-null-rm-1777734626.json`
- [ ] `terraform apply` against live cluster — null_resource recreated cleanly, no curl runs against the live tunnel
- [ ] Post-apply: `kubectl -n ops get pods -l app=cloudflared` still healthy, `dig +short auth.ipsupport.us` still resolves through the tunnel

🤖 Generated with [Claude Code](https://claude.com/claude-code)