### PR TITLE
feat(zitadel): native zitadel_default_login_policy resource at root

### DIFF
--- a/zitadel.tf
+++ b/zitadel.tf
@@ -118,3 +118,67 @@ module "zitadel" {
   node_selector = local.platform.services.zitadel.node_selector
   tolerations   = local.platform.services.zitadel.tolerations
 }
+
+# Default Login Policy reconciler.
+#
+# Zitadel's v4 FirstInstance steps schema dropped LoginPolicy — without
+# this resource the instance boots with Zitadel's built-in defaults
+# (registration ON, etc.) regardless of `services.zitadel.login_policy`
+# in `config/platform.yaml`. The native zitadel provider talks to the
+# kubectl-port-forward bypass started by `./tf` (see `provider "zitadel"`
+# config above), so what used to be a bash + curl null_resource inside
+# `modules/zitadel` becomes a direct provider call here.
+#
+# Two reasons to host this at root instead of inside `modules/zitadel`:
+#
+#   1. Sequencing. `module.oauth2_proxy` and `module.platform_dash_oidc`
+#      declare `depends_on = [module.zitadel]`. Terraform defers every
+#      data source inside a depends_on'd module to apply-time whenever
+#      the depended-on module has any pending changes. The `data
+#      "zitadel_orgs" "this"` lookups in those consumer modules then
+#      hand back `(known after apply)`, which propagates as a "must
+#      be replaced" diff on every downstream `zitadel_project` /
+#      `zitadel_application_oidc` / `zitadel_project_role` and rotates
+#      forward-auth + dash login on every apply that touches the policy.
+#
+#   2. The legacy `null_resource.default_login_policy` inside
+#      `modules/zitadel` is intentionally kept in place for now — even
+#      with `removed { destroy = false }` Terraform still treats the
+#      removal as a state-changing event in `module.zitadel`, which
+#      re-triggers the cascade above. Adding this provider-native
+#      resource here lets the cluster get a real `zitadel_default_login_policy`
+#      managed object without disturbing module state. The legacy
+#      bash/curl reconciler runs alongside; both PUT the same values
+#      from `services.zitadel.login_policy`, so the duplication is
+#      idempotent. A future cleanup pass can drop the null_resource
+#      via a coordinated `terraform state rm` + `git rm` once the
+#      depends_on chains in oauth2-proxy / platform-dash-oidc are
+#      reworked to not block on the whole module.
+resource "zitadel_default_login_policy" "main" {
+  count      = local.platform.services.zitadel.enabled ? 1 : 0
+  depends_on = [module.zitadel]
+
+  allow_register     = local.platform.services.zitadel.login_policy.allow_register
+  allow_external_idp = local.platform.services.zitadel.login_policy.allow_external_idp
+  # `user_login` is the v2 gRPC equivalent of the v1 REST
+  # `allowUsernamePassword` field — both gate the username+password
+  # form on the login page.
+  user_login               = local.platform.services.zitadel.login_policy.allow_username_password
+  passwordless_type        = "PASSWORDLESS_TYPE_ALLOWED"
+  ignore_unknown_usernames = true
+
+  password_check_lifetime       = "864000s"
+  external_login_check_lifetime = "864000s"
+  mfa_init_skip_lifetime        = "2592000s"
+  second_factor_check_lifetime  = "64800s"
+  multi_factor_check_lifetime   = "43200s"
+
+  force_mfa                = false
+  force_mfa_local_only     = false
+  hide_password_reset      = false
+  allow_domain_discovery   = false
+  disable_login_with_email = false
+  disable_login_with_phone = false
+
+  default_redirect_uri = ""
+}

--- a/zitadel.tf
+++ b/zitadel.tf
@@ -181,4 +181,11 @@ resource "zitadel_default_login_policy" "main" {
   disable_login_with_phone = false
 
   default_redirect_uri = ""
+
+  # MFA factors. Zitadel ships these enabled out of the box and the
+  # operator hasn't disabled them; an empty `multi_factors` / `second_factors`
+  # in the resource definition would clear them on apply, silently
+  # dropping U2F + TOTP from the login form. Pin to the defaults.
+  multi_factors  = ["MULTI_FACTOR_TYPE_U2F_WITH_VERIFICATION"]
+  second_factors = ["SECOND_FACTOR_TYPE_OTP", "SECOND_FACTOR_TYPE_U2F"]
 }


### PR DESCRIPTION
## Summary

Replace the bash + curl `null_resource.default_login_policy` reconciler with a Terraform-native `zitadel_default_login_policy.main` at the root. The new resource talks to the Zitadel provider's gRPC API via the kubectl-port-forward bypass that `./tf` already starts.

## Why root, not inside `modules/zitadel`

`module.oauth2_proxy` and `module.platform_dash_oidc` both declare `depends_on = [module.zitadel]`. Terraform defers data-source reads inside a depends_on'd module to apply-time whenever the depended-on module has any pending change. The `data "zitadel_orgs" "this"` lookups in those consumer modules then hand back `(known after apply)`, which propagates as a "must be replaced" diff on every downstream `zitadel_project` / `zitadel_application_oidc` / `zitadel_project_role`.

On a live cluster that's a real outage: forward-auth + dash login rotate, and `modules/stalwart` (which reads the Stalwart project_id as `requireAudience`) kicks off a Directory + Application destroy/create cycle inside the Stalwart applier, hits the known [RAM-cache vs DB race on Domain primaryKeyViolation](file:///home/roman220/.claude/projects/-home-roman220/memory/project_stalwart_race_condition.md), and breaks IMAP JWT validation until two manual Stalwart pod restarts. We just lived through that during this session, which is what surfaced the cascade in the first place.

Hosting the provider resource at root → `module.zitadel` stays clean → the data-source-defer condition stays false → no cascade.

## Why the legacy `null_resource.default_login_policy` is kept

Removing it (or even gating it behind `removed { destroy = false }`) still registers as a state-changing event in `module.zitadel` and re-triggers the cascade. Both reconcilers PUT identical values from `services.zitadel.login_policy` on each apply, so leaving them both in place is functionally idempotent.

Future cleanup: drop the null_resource once the `depends_on = [module.zitadel]` chains in oauth2-proxy / platform-dash-oidc are reworked to not block on the whole module — most likely by passing `org_id` in via input variables instead of letting each module do its own `data "zitadel_orgs"` lookup, which removes the need for the module-level depends_on entirely.

## Plan output

```
zitadel_default_login_policy.main[0] will be created
module.stalwart.kubernetes_deployment_v1.stalwart["enabled"] will be updated in-place
Plan: 1 to add, 1 to change, 0 to destroy.
```

The Stalwart in-place change is unrelated — it's just removing the `kubectl.kubernetes.io/restartedAt` annotation that this session's manual rollout left on the Deployment template. Apply will re-roll Stalwart once; applier reruns and recovers cleanly (the OIDC chain is healthy now after the manual two-restart fix).

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform validate` passes
- [x] `terraform plan` shows zero `zitadel_project` / `_application_oidc` / `_project_role` replacements
- [x] Stalwart applier currently recovered, mail working
- [ ] `terraform apply` — creates the new resource, re-rolls Stalwart for the annotation cleanup
- [ ] Post-apply: `dig` and `curl` Roundcube login still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)