### PR TITLE
feat(helm): bump provider to v3; addons module to v2.0.0; add monitoring LimitRange

### DIFF
--- a/_providers.tf
+++ b/_providers.tf
@@ -23,7 +23,9 @@ provider "kubectl" {
 }
 
 provider "helm" {
-  kubernetes {
+  # v3 schema: `kubernetes` is a nested attribute (`= {}`), not a
+  # block. Same `config_path` semantics flow through.
+  kubernetes = {
     config_path = module.k8s.kubeconfig_path
   }
 }

--- a/_versions.tf
+++ b/_versions.tf
@@ -16,7 +16,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.17"
+      version = "~> 3.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ check "k3s_ssh_vars_set" {
 # Layer 2: Platform add-ons (Traefik, cert-manager, monitoring, namespaces).
 # -----------------------------------------------------------------------------
 module "addons" {
-  source = "git::https://github.com/rromenskyi/terraform-k8s-addons.git?ref=v1.1.2"
+  source = "git::https://github.com/rromenskyi/terraform-k8s-addons.git?ref=v2.0.0"
 
   kubeconfig_path      = module.k8s.kubeconfig_path
   cluster_name         = module.k8s.cluster_name

--- a/monitoring.tf
+++ b/monitoring.tf
@@ -52,3 +52,36 @@ resource "kubernetes_resource_quota_v1" "monitoring" {
     }
   }
 }
+
+# Default requests for any container that doesn't declare them. The
+# kube-prometheus-stack chart's main containers all set `requests`
+# explicitly, but its pre-upgrade hook Jobs (admission-create /
+# admission-patch from `kube-webhook-certgen`) do not — and the quota
+# above makes `requests.cpu` / `requests.memory` mandatory at
+# admission. Without this LimitRange the hook Job loops on
+# "must specify requests.cpu" and the helm upgrade times out waiting
+# for the hook to complete (revisions 2 + 4 in this release's history
+# both died this way). Defaults are deliberately small — these are
+# short-lived hook Jobs, not steady-state workloads — and don't push
+# the quota math meaningfully.
+resource "kubernetes_limit_range_v1" "monitoring" {
+  depends_on = [module.addons]
+
+  metadata {
+    name      = "monitoring-defaults"
+    namespace = "monitoring"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+
+  spec {
+    limit {
+      type = "Container"
+      default_request = {
+        cpu    = "10m"
+        memory = "32Mi"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Helm provider v2 → v3 across the platform repo + the sibling `terraform-k8s-addons` (cut as **v2.0.0**, see [addons PR #6](https://github.com/rromenskyi/terraform-k8s-addons/pull/6)).

## Diff

| File | Change |
| --- | --- |
| `_versions.tf` | helm constraint `~> 2.17` → `~> 3.0` |
| `_providers.tf` | `provider "helm" { kubernetes {} }` block → `kubernetes = {}` attribute |
| `main.tf` | `module "addons"` pin `?ref=v1.1.2` → `?ref=v2.0.0` |
| `monitoring.tf` | new `kubernetes_limit_range_v1.monitoring` (default container requests `cpu=10m` / `memory=32Mi`) |

## Why the LimitRange

Surfaced during this PR's apply. The kube-prometheus-stack chart's pre-upgrade hook Jobs (`kube-webhook-certgen` admission-create / admission-patch) don't declare `requests.*`. The namespace's existing `monitoring-budget` ResourceQuota (from PR #38) makes `requests.cpu` / `requests.memory` **mandatory** at admission. Two upgrade attempts looped on `must specify requests.cpu for: create` until this LimitRange went in and gave the hook Jobs a default to fall back on.

## State migration (already executed against live B2 backend)

- `helm_release.cert_manager` — in-place attribute update, no chart bounce
- `helm_release.cluster_issuers` — same
- `helm_release.traefik` — same
- `helm_release.monitoring` — chart upgrade triggered; recovered via the LimitRange. Helm history walked through revisions 2 (failed pre-upgrade), 3 (rollback), 4 (deployed after LimitRange), 5 (rollback churn during recovery), **6 (deployed, current)**.

## Post-apply plan

```
Plan: 1 to add, 0 to change, 0 to destroy.
```

The single add is `module.postgres.kubernetes_job_v1.pg_extensions` recreating itself after `ttl_seconds_after_finished = 300` expired — by-design churn from PR #49, idempotent `CREATE EXTENSION IF NOT EXISTS`.

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform validate` Success
- [x] `terraform apply` against live: 4 helm_releases reconciled to v3 schema, monitoring stack stable on rev 6
- [x] LimitRange in cluster + state
- [x] `terraform plan` post-apply: only the expected pg_extensions Job re-create
- [x] Mail / dash / forward-auth still working through the apply

🤖 Generated with [Claude Code](https://claude.com/claude-code)