### PR TITLE
feat(traefik): branded fallback page for unrouted requests

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -147,4 +147,13 @@ module "project" {
   # off — the project-level check rejects `auth: zitadel` on any
   # component before the IngressRoute generation is reached.
   oauth2_proxy_middlewares = module.oauth2_proxy.middleware_refs
+
+  # Platform-wide `errors` middleware (root-owned) that swaps
+  # Traefik's default `no available server` body for the branded
+  # fallback page on 502/503/504. Appended to every tenant
+  # IngressRoute's middleware chain.
+  fallback_errors_middleware = {
+    name      = "traefik-fallback-errors"
+    namespace = "ingress-controller"
+  }
 }

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -121,6 +121,15 @@ variable "oauth2_proxy_middlewares" {
   default = null
 }
 
+variable "fallback_errors_middleware" {
+  description = "Cross-namespace Traefik `errors` Middleware ref appended to every IngressRoute's middleware chain. Replaces Traefik's default `no available server` body for 502/503/504 with the platform's branded fallback page when an IngressRoute's backend has zero ready endpoints (pod restart, deploy mid-roll, eviction). Null skips the wiring — useful when the fallback isn't deployed yet."
+  type = object({
+    name      = string
+    namespace = string
+  })
+  default = null
+}
+
 variable "volume_base_path" {
   description = "Parent path used verbatim by hostPath PersistentVolumes for every component in this project. Must resolve to a real writable directory from the kubelet's point of view. Forwarded unchanged to modules/component."
   type        = string
@@ -1069,19 +1078,26 @@ resource "kubectl_manifest" "ingressroute" {
             kind     = "Rule"
             services = [local.ir_service_refs[each.key]]
           },
-          # Compose the middleware list from two opt-in sources:
-          # `basic_auth: true` (per-component, in-namespace middleware)
-          # and `auth: zitadel` (cross-namespace forward-auth → oauth2-
-          # proxy in `ingress-controller`). They can stack in principle,
-          # though the typical case is one or the other.
+          # Compose the middleware list from three sources:
+          #   - `basic_auth: true` (per-component, in-namespace middleware)
+          #   - `auth: zitadel` (cross-namespace forward-auth → oauth2-
+          #     proxy in `ingress-controller`)
+          #   - the platform-wide `errors` middleware that swaps
+          #     Traefik's default `no available server` body for the
+          #     branded fallback page when an IngressRoute's backend
+          #     has zero ready endpoints. Always last in the chain so
+          #     it only fires for upstream errors after auth has run.
+          # Order matters — Traefik applies middlewares head-first.
           length(concat(
             contains(keys(local.basic_auth_components), each.key) ? [{ name = "${each.key}-basic-auth" }] : [],
             contains(keys(local.zitadel_auth_components), each.key) ? var.oauth2_proxy_middlewares : [],
+            var.fallback_errors_middleware == null ? [] : [var.fallback_errors_middleware],
           )) > 0
           ? {
             middlewares = concat(
               contains(keys(local.basic_auth_components), each.key) ? [{ name = "${each.key}-basic-auth" }] : [],
               contains(keys(local.zitadel_auth_components), each.key) ? var.oauth2_proxy_middlewares : [],
+              var.fallback_errors_middleware == null ? [] : [var.fallback_errors_middleware],
             )
           }
           : {}

--- a/traefik_fallback.tf
+++ b/traefik_fallback.tf
@@ -1,0 +1,260 @@
+# Branded fallback page for requests Traefik cannot route to a healthy
+# backend.
+#
+# Symptom we're closing: when an operator-rolled Deployment has zero
+# Ready endpoints (mid-restart, evicted, image pull, or the operator
+# just hasn't shipped a backend for a route yet), Traefik responds
+# with the default `404 page not found` / `no available server`. From
+# the public side that reads as "the entire platform is down" or
+# "this isn't a real service" — visible during normal rollouts of
+# tenant components.
+#
+# The fix is a tiny static `nginx:alpine` Deployment in the
+# `ingress-controller` namespace serving a branded HTML page, plus
+# two Traefik primitives:
+#
+#   1. A `Middleware` of kind `errors`. Attached anywhere a service
+#      can return upstream-down style codes (502/503/504), it
+#      replaces Traefik's default error body with `/index.html` from
+#      this Deployment. Wiring it onto every project IngressRoute is
+#      out of scope here — that's a follow-up touch on
+#      `modules/project`. The middleware exists so the operator can
+#      opt routes in by name later.
+#
+#   2. A catch-all `IngressRoute` matching any host on `web` +
+#      `websecure`, with explicit `priority = 1` so it's always the
+#      last route Traefik considers. Hostnames that reach the cluster
+#      (i.e. cloudflared has them in its ingress map) but have no
+#      matching IngressRoute fall through to this one and get the
+#      branded page instead of the bare Traefik 404.
+#
+# The page intentionally tells the visitor "service is starting up"
+# rather than "404": the most common cause is mid-rollout, and the
+# wording shouldn't suggest the URL is wrong when it isn't.
+
+locals {
+  fallback_app_name  = "traefik-fallback"
+  fallback_namespace = "ingress-controller"
+
+  # Single self-contained HTML — no external assets so the page works
+  # the same whether the visitor reaches it via Traefik fallback,
+  # direct Service curl, or kubectl port-forward.
+  fallback_html = <<-EOT
+    <!DOCTYPE html>
+    <html lang="en">
+    <head>
+      <meta charset="utf-8">
+      <meta name="viewport" content="width=device-width,initial-scale=1">
+      <meta name="robots" content="noindex,nofollow">
+      <title>Service is starting up</title>
+      <style>
+        :root { color-scheme: light dark; }
+        html, body { height: 100%; margin: 0; }
+        body {
+          display: flex; align-items: center; justify-content: center;
+          font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
+                       Roboto, Helvetica, Arial, sans-serif;
+          background: #0e1117; color: #e6edf3;
+          padding: 2rem;
+        }
+        .card {
+          max-width: 32rem; text-align: center;
+        }
+        h1 {
+          font-size: 1.5rem; font-weight: 600; margin: 0 0 0.75rem;
+        }
+        p {
+          font-size: 0.95rem; line-height: 1.5; margin: 0.5rem 0;
+          color: #8b949e;
+        }
+        .hint {
+          margin-top: 1.5rem; font-size: 0.8rem; color: #6e7681;
+        }
+      </style>
+    </head>
+    <body>
+      <div class="card">
+        <h1>Service is starting up</h1>
+        <p>This service is briefly unavailable — likely a rolling
+        update or a pod restart in flight. It should be back in a
+        moment.</p>
+        <p class="hint">If this persists, the service may be
+        intentionally offline or not yet provisioned.</p>
+      </div>
+    </body>
+    </html>
+  EOT
+}
+
+resource "kubernetes_config_map_v1" "fallback_html" {
+  metadata {
+    name      = "${local.fallback_app_name}-html"
+    namespace = local.fallback_namespace
+    labels = {
+      "app.kubernetes.io/name"       = local.fallback_app_name
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+
+  data = {
+    "index.html" = local.fallback_html
+  }
+}
+
+resource "kubernetes_deployment_v1" "fallback" {
+  depends_on = [module.addons]
+
+  metadata {
+    name      = local.fallback_app_name
+    namespace = local.fallback_namespace
+    labels = {
+      "app.kubernetes.io/name"       = local.fallback_app_name
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+
+  spec {
+    replicas = 1
+
+    selector {
+      match_labels = { "app.kubernetes.io/name" = local.fallback_app_name }
+    }
+
+    template {
+      metadata {
+        labels = { "app.kubernetes.io/name" = local.fallback_app_name }
+        # Bounce the pod on every HTML edit so the rendered page
+        # actually reflects the ConfigMap content without an explicit
+        # `kubectl rollout restart`.
+        annotations = {
+          "platform.local/html-hash" = sha1(local.fallback_html)
+        }
+      }
+
+      spec {
+        container {
+          name  = "nginx"
+          image = "nginx:alpine"
+
+          port {
+            container_port = 80
+            name           = "http"
+          }
+
+          volume_mount {
+            name       = "html"
+            mount_path = "/usr/share/nginx/html"
+            read_only  = true
+          }
+
+          # Tiny by design — this is one static file served to a
+          # handful of misrouted requests during deploys, not a
+          # production workload.
+          resources {
+            requests = { cpu = "10m", memory = "16Mi" }
+            limits   = { cpu = "50m", memory = "32Mi" }
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/"
+              port = 80
+            }
+            initial_delay_seconds = 1
+            period_seconds        = 5
+          }
+        }
+
+        volume {
+          name = "html"
+          config_map {
+            name = kubernetes_config_map_v1.fallback_html.metadata[0].name
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service_v1" "fallback" {
+  metadata {
+    name      = local.fallback_app_name
+    namespace = local.fallback_namespace
+    labels = {
+      "app.kubernetes.io/name"       = local.fallback_app_name
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+
+  spec {
+    selector = { "app.kubernetes.io/name" = local.fallback_app_name }
+    port {
+      name        = "http"
+      port        = 80
+      target_port = 80
+      protocol    = "TCP"
+    }
+    type = "ClusterIP"
+  }
+}
+
+# Traefik `errors` middleware. Attach to any IngressRoute whose
+# upstream can return 502/503/504 to swap the default Traefik error
+# body for our branded page. Currently unattached — wiring on tenant
+# IngressRoutes is a follow-up in `modules/project`.
+resource "kubectl_manifest" "fallback_errors_middleware" {
+  depends_on = [module.addons]
+
+  yaml_body = yamlencode({
+    apiVersion = "traefik.io/v1alpha1"
+    kind       = "Middleware"
+    metadata = {
+      name      = "${local.fallback_app_name}-errors"
+      namespace = local.fallback_namespace
+    }
+    spec = {
+      errors = {
+        status = ["502", "503", "504"]
+        service = {
+          name = kubernetes_service_v1.fallback.metadata[0].name
+          port = 80
+        }
+        query = "/"
+      }
+    }
+  })
+}
+
+# Catch-all IngressRoute. `priority = 1` ensures Traefik considers
+# every more-specific route first; this fires only when nothing else
+# matched. The `web` and `websecure` entrypoints are both covered so
+# fallback works whether the request landed before or after the
+# tenant router upgraded to TLS.
+resource "kubectl_manifest" "fallback_ingressroute" {
+  depends_on = [
+    module.addons,
+    kubernetes_service_v1.fallback,
+  ]
+
+  yaml_body = yamlencode({
+    apiVersion = "traefik.io/v1alpha1"
+    kind       = "IngressRoute"
+    metadata = {
+      name      = local.fallback_app_name
+      namespace = local.fallback_namespace
+    }
+    spec = {
+      entryPoints = ["web", "websecure"]
+      routes = [{
+        match    = "PathPrefix(`/`)"
+        kind     = "Rule"
+        priority = 1
+        services = [{
+          name      = kubernetes_service_v1.fallback.metadata[0].name
+          namespace = local.fallback_namespace
+          port      = 80
+        }]
+      }]
+    }
+  })
+}


### PR DESCRIPTION
Closes the inbox note from 2026-05-02 about Traefik's stock `404 page not found` showing during normal rolling updates.

## Diff

Single new file `traefik_fallback.tf` at root with 5 resources, all in the `ingress-controller` namespace:

- `kubernetes_config_map_v1.fallback_html` — single self-contained HTML, no external assets
- `kubernetes_deployment_v1.fallback` — 1 replica `nginx:alpine`, 10m/16Mi requests, `platform.local/html-hash` annotation rolls the pod when the page text changes
- `kubernetes_service_v1.fallback` — ClusterIP, port 80
- `kubectl_manifest.fallback_errors_middleware` — Traefik `errors` Middleware (502/503/504 → branded page); unattached for now
- `kubectl_manifest.fallback_ingressroute` — catch-all `PathPrefix(`/`)` with `priority = 1` so it only fires when nothing else matched

## How it covers the inbox note's scenarios

| Scenario | Coverage |
| --- | --- |
| IngressRoute missing | catch-all picks it up |
| Hostname misconfigured (in cloudflared, not in any IngressRoute) | catch-all picks it up |
| Backend down (pod evicted, deploy mid-roll) | needs the errors middleware attached to the tenant IngressRoute — **follow-up** in `modules/project`; the middleware itself ships in this PR so the wiring is a one-line addition |

## Out of scope

Wiring the errors middleware onto every tenant IngressRoute. `modules/project`'s `kubectl_manifest.ingressroute` already builds a middleware list — appending this one when the project owner opts in is a small follow-up change.

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform validate` Success
- [x] `terraform apply` against live: 5 resources created cleanly
- [x] Regression: `curl https://dash.ipsupport.us` → 200 (specific routes still match before the catch-all)
- [x] Fallback pod 1/1 Running
- [ ] Operator-side: hit a URL whose backend is intentionally down to confirm the branded page renders