### PR TITLE
chore(addons): bump terraform-k8s-addons pin to v2.1.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ check "k3s_ssh_vars_set" {
 # Layer 2: Platform add-ons (Traefik, cert-manager, monitoring, namespaces).
 # -----------------------------------------------------------------------------
 module "addons" {
-  source = "git::https://github.com/rromenskyi/terraform-k8s-addons.git?ref=v2.0.0"
+  source = "git::https://github.com/rromenskyi/terraform-k8s-addons.git?ref=v2.1.0"
 
   kubeconfig_path      = module.k8s.kubeconfig_path
   cluster_name         = module.k8s.cluster_name


### PR DESCRIPTION
Picks up `enable_kured` from [addons PR #7](https://github.com/rromenskyi/terraform-k8s-addons/pull/7) — optional Kubernetes Reboot Daemon for the cluster.

## Diff

One-line bump in `main.tf`: `?ref=v2.0.0` → `?ref=v2.1.0`.

## Apply

`Plan: 1 to add, 0 to change, 0 to destroy.` — single add is the pg_extensions Job TTL recreate (by-design churn from PR #49). The new `enable_kured` knob defaults to false, so the addons module produces zero new resources after this bump alone.

## Operator opt-in (separate change)

Once this lands, flipping kured on is a one-line addition in `main.tf`:

```hcl
module "addons" {
  source = "git::https://github.com/rromenskyi/terraform-k8s-addons.git?ref=v2.1.0"
  ...
  enable_kured     = true
  kured_time_zone  = "America/Denver"
  kured_start_time = "03:00"
  kured_end_time   = "05:00"
}
```