### PR TITLE
fix(stalwart): rewrite plan to skip Domain create when already present

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ check "k3s_ssh_vars_set" {
 # Layer 2: Platform add-ons (Traefik, cert-manager, monitoring, namespaces).
 # -----------------------------------------------------------------------------
 module "addons" {
-  source = "git::https://github.com/rromenskyi/terraform-k8s-addons.git?ref=v2.0.0"
+  source = "git::https://github.com/rromenskyi/terraform-k8s-addons.git?ref=v2.1.0"
 
   kubeconfig_path      = module.k8s.kubeconfig_path
   cluster_name         = module.k8s.cluster_name

--- a/modules/stalwart/main.tf
+++ b/modules/stalwart/main.tf
@@ -1227,6 +1227,10 @@ resource "kubernetes_deployment_v1" "stalwart" {
               }
             }
           }
+          env {
+            name  = "PRIMARY_DOMAIN"
+            value = var.primary_domain
+          }
 
           command = ["bash", "-eu", "-c", <<-EOT
             for i in $(seq 1 180); do
@@ -1259,12 +1263,44 @@ resource "kubernetes_deployment_v1" "stalwart" {
                 || echo "[applier] smarthost delete returned non-zero — proceeding anyway"
             fi
 
+            # Domain idempotency. The plan declares
+            # `create Domain dom-primary` with name=$PRIMARY_DOMAIN, but
+            # Stalwart enforces uniqueness on Domain.name. On every
+            # re-apply after the very first one, the create returns
+            # `primaryKeyViolation` and the friendly id `dom-primary`
+            # never resolves — which then cascades onto every plan
+            # entry that references `#dom-primary`
+            # (DkimSignature.dom-primary, SystemSettings.defaultDomainId).
+            # Three ops fail loudly on every Stalwart pod start.
+            #
+            # Pre-step: query the existing Domain by name. If found,
+            # rewrite the plan ndjson on the fly:
+            #   - drop the `create Domain dom-primary` line entirely
+            #   - replace every `#dom-primary` reference with the
+            #     existing internal id
+            # The remaining creates and updates resolve cleanly,
+            # converging without the noisy 3-op failure.
+            #
+            # Plan file is mounted from a Secret (read-only); copy to
+            # tmpfs first so sed -i can rewrite it.
+            cp /seed/plan.ndjson /tmp/plan.ndjson
+            echo "[applier] checking for existing Domain named '$PRIMARY_DOMAIN'"
+            DOM_ID=$(/shared/bin/stalwart-cli query Domain 2>/dev/null \
+              | awk -v name="$PRIMARY_DOMAIN" '$2==name {print $1; exit}') || true
+            if [ -n "$${DOM_ID:-}" ]; then
+              echo "[applier] Domain '$PRIMARY_DOMAIN' already exists as id '$DOM_ID' — rewriting plan to skip its create + resolve refs"
+              # Drop the create-Domain line for friendly id `dom-primary`.
+              sed -i '/"@type":"create","object":"Domain","value":{"dom-primary"/d' /tmp/plan.ndjson
+              # Resolve every `#dom-primary` reference to the existing id.
+              sed -i "s/#dom-primary/$DOM_ID/g" /tmp/plan.ndjson
+            fi
+
             # `--continue-on-error` so a JMAP filter rejection on
             # one destroy doesn't block the rest of the plan.
             # Updates are idempotent; creates may fail with
             # `alreadyExists` on a re-apply with no preceding destroy
             # — that's fine, the converged state is still right.
-            if /shared/bin/stalwart-cli apply --file /seed/plan.ndjson --continue-on-error; then
+            if /shared/bin/stalwart-cli apply --file /tmp/plan.ndjson --continue-on-error; then
               echo "[applier] plan applied OK"
             else
               echo "[applier] apply finished with errors — see above; main server stays up"


### PR DESCRIPTION
The applier sidecar's plan ndjson hard-codes a `create Domain dom-primary` op with `name = $primary_domain`. Stalwart enforces uniqueness on Domain.name → every re-apply after the first one fails the create with `primaryKeyViolation`, the friendly id `dom-primary` never resolves, and downstream entries that reference `#dom-primary` (DkimSignature, SystemSettings) cascade-fail. Three ops loud-fail on every Stalwart pod start. Mail stays up (the existing Domain is still the right one) but the noise distracts during real incidents, and the chain breaks legitimate auto-recovery (the recently-fixed RAM-cache race needed two manual rollouts).

## Diff

Pre-step in the applier script — mirrors the existing `MtaRoute smarthost` delete-by-name handling a few lines above:

```bash
DOM_ID=$(stalwart-cli query Domain | awk -v name="$PRIMARY_DOMAIN" '$2==name {print $1; exit}')
if [ -n "$DOM_ID" ]; then
  cp /seed/plan.ndjson /tmp/plan.ndjson
  sed -i '/"@type":"create","object":"Domain","value":{"dom-primary"/d' /tmp/plan.ndjson
  sed -i "s/#dom-primary/$DOM_ID/g" /tmp/plan.ndjson
fi
```

Plan file is mounted read-only from a Secret, copied to /tmp so `sed -i` can rewrite. `PRIMARY_DOMAIN` env var added on the applier container, sourced from `var.primary_domain`.

## Apply effect

Applier output on a steady-state Stalwart pod start: 3 failed ops → **1 failed op**.

| Op | Before | After |
| --- | --- | --- |
| create Domain dom-primary | ❌ pkViolation | skipped (idempotent) |
| update SystemSettings.defaultDomainId | ❌ ref unresolved | ✓ updated |
| create DkimSignature dkim-primary | ❌ ref unresolved | ❌ `headers`-field schema rejection (unrelated, separate bug) |

DKIM's `headers`-field rejection is a Stalwart 0.16.x schema mismatch unrelated to this PR — existing DKIM (`v1-rsa-20260430` selector) still works; new `stalwart` selector that the plan tries to create has the new failure mode. Tracked separately.

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform validate` Success
- [x] `terraform apply` against live: Stalwart Deployment rolled, applier ran the new pre-step ("Domain 'ipsupport.us' already exists as id 'b' — rewriting plan")
- [x] applier exited with 1 failed op instead of 3
- [x] mail still works through the rollout — Roundcube login intact