### PR TITLE
feat(argocd): Argo CD + Zitadel OIDC SSO

### DIFF
--- a/argocd.tf
+++ b/argocd.tf
@@ -1,0 +1,109 @@
+# Argo CD — root wiring.
+#
+# Mirrors the platform-dash / vault pattern:
+#   - `module "argocd_oidc"` creates the Zitadel project + OIDC
+#     application + role list, emits a Secret with AUTH_ZITADEL_*
+#     env names. The chart consumes only `client_id` /
+#     `client_secret` from it, but the Secret stays a
+#     consistent shape across kind:app components.
+#   - `module "argocd"` deploys the chart with OIDC values.
+#   - `config/components/argocd.yaml` (kind: external) wires the
+#     hostname into the project + cloudflared pipeline.
+#   - Domain yaml routes `argocd: argocd` (or whatever sub the
+#     operator picks) to that external component.
+
+check "argocd_requires_zitadel" {
+  assert {
+    condition     = !local.platform.services.argocd.enabled || local.platform.services.zitadel.enabled
+    error_message = "services.argocd.enabled = true requires services.zitadel.enabled = true (Argo CD authentication is OIDC-only in this stack — local admin is intentionally not exposed publicly)."
+  }
+}
+
+check "argocd_hostname_set" {
+  assert {
+    condition     = !local.platform.services.argocd.enabled || local.platform.services.argocd.hostname != ""
+    error_message = "services.argocd.hostname must be set when argocd is enabled (e.g. `argocd.example.com`). Drives `server.config.url` and the OIDC redirect URI registration in Zitadel."
+  }
+}
+
+# Root-owned namespace so the OIDC Secret (created by
+# `module.argocd_oidc`) lands BEFORE the chart's `create_namespace`
+# step would have run. The chart's `create_namespace = false` below
+# expects the namespace to already exist.
+resource "kubernetes_namespace_v1" "argocd" {
+  count = local.platform.services.argocd.enabled ? 1 : 0
+
+  metadata {
+    name = local.platform.services.argocd.namespace
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+}
+
+# OIDC integration. Emits a Secret in `argocd` ns with AUTH_ZITADEL_*
+# (consistent with other kind:app modules); the chart values
+# downstream only consume `client_id` / `client_secret` directly.
+module "argocd_oidc" {
+  source     = "./modules/zitadel-app"
+  count      = local.platform.services.argocd.enabled && local.platform.services.zitadel.enabled ? 1 : 0
+  depends_on = [kubernetes_namespace_v1.argocd]
+  # No `depends_on = [module.zitadel]` — the org_id input below is
+  # resolved at root via `data.zitadel_orgs.platform_org`, so the
+  # cascade-defer trap (see comment on
+  # `zitadel_default_login_policy.main` in zitadel.tf) does not
+  # apply here.
+
+  providers = {
+    zitadel    = zitadel
+    kubernetes = kubernetes
+    random     = random
+  }
+
+  org_id       = local.platform.services.zitadel.enabled ? data.zitadel_orgs.platform_org[0].ids[0] : ""
+  project_name = "argocd"
+  app_name     = "argocd"
+  issuer_url   = "https://${local.platform.services.zitadel.external_domain}"
+
+  # Argo CD's Dex OIDC connector posts back to
+  # `<server.config.url>/auth/callback`. The CLI uses
+  # `<url>/api/dex/callback` for `argocd login --sso`.
+  redirect_uris = [
+    "https://${local.platform.services.argocd.hostname}/auth/callback",
+    "https://${local.platform.services.argocd.hostname}/api/dex/callback",
+  ]
+  post_logout_uris = ["https://${local.platform.services.argocd.hostname}/"]
+
+  secret_name      = "argocd-oidc"
+  secret_namespace = local.platform.services.argocd.namespace
+
+  # Roles the operator's workforce can hold. `argocd_admin` maps to
+  # Argo CD's built-in `role:admin` policy via the chart values. All
+  # other roles are role-keys the operator can hand-grant in Argo
+  # CD's RBAC ConfigMap later.
+  roles = [
+    { key = "argocd_admin", display_name = "Argo CD Admin" },
+    { key = "user", display_name = "User" },
+  ]
+}
+
+module "argocd" {
+  source     = "./modules/argocd"
+  depends_on = [module.argocd_oidc, module.addons]
+
+  enabled  = local.platform.services.argocd.enabled
+  hostname = local.platform.services.argocd.hostname
+
+  oidc_issuer        = local.platform.services.zitadel.enabled ? "https://${local.platform.services.zitadel.external_domain}" : ""
+  oidc_client_id     = try(module.argocd_oidc[0].client_id, "")
+  oidc_client_secret = try(module.argocd_oidc[0].client_secret, "")
+  oidc_admin_groups  = ["argocd_admin"]
+
+  node_selector = local.platform.services.argocd.node_selector
+  tolerations   = local.platform.services.argocd.tolerations
+}
+
+output "argocd_url" {
+  description = "Public Argo CD URL. Null when disabled."
+  value       = local.platform.services.argocd.enabled ? "https://${local.platform.services.argocd.hostname}" : null
+}

--- a/config/components/argocd.yaml
+++ b/config/components/argocd.yaml
@@ -1,0 +1,19 @@
+# Argo CD — application-layer GitOps controller routing.
+#
+# `kind: external` because the workload itself is owned by
+# `modules/argocd` (Helm chart in the `argocd` namespace, wired
+# through `argocd.tf` at the root). This component file only
+# describes how the hostname routes through Traefik + Cloudflare
+# Tunnel. Wire by adding a route to your domain yaml — the prefix
+# part of `<prefix>: argocd` MUST match the
+# `services.argocd.hostname` host-prefix you set in
+# `config/platform.yaml` (e.g. `hostname: argocd.example.com` →
+# `argocd: argocd` in the routes map of the matching domain yaml).
+
+kind: external
+service:
+  name: argocd-server
+  namespace: argocd
+  port: 80
+auth: zitadel
+http2_origin: false

--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -115,6 +115,23 @@ services:
     enabled: false
     hostname: vault.example.com
 
+  # Argo CD — GitOps controller for application-layer deploys.
+  # Phase 0 ships the upstream chart with Zitadel OIDC SSO wired
+  # through Dex. Login lands users on the UI; users carrying the
+  # `argocd_admin` role on the auto-provisioned `argocd` Zitadel
+  # project get full RBAC, others have no permissions until the
+  # operator hand-edits the in-cluster RBAC ConfigMap.
+  #
+  # The chart-side Ingress stays off — routing happens through the
+  # platform's existing Cloudflare Tunnel + Traefik IngressRoute
+  # pipeline. Match the `services.argocd.hostname` prefix to the
+  # `<prefix>: argocd` entry in your domain yaml's routes map (e.g.
+  # `argocd.example.com` → `argocd: argocd`). The
+  # `config/components/argocd.yaml` file already declares the
+  # `kind: external` mapping at the platform side.
+  argocd:
+    enabled: false
+    hostname: argocd.example.com
 
   zitadel:
     enabled: false

--- a/locals.tf
+++ b/locals.tf
@@ -47,6 +47,13 @@ locals {
         enabled  = false
         hostname = ""
       }
+      argocd = {
+        enabled       = false
+        hostname      = ""
+        namespace     = "argocd"
+        node_selector = {}
+        tolerations   = []
+      }
       zitadel = {
         enabled              = false
         external_domain      = ""
@@ -106,6 +113,7 @@ locals {
       ollama        = merge(local._platform_defaults.services.ollama, try(local._platform_services.ollama, {}))
       zitadel       = merge(local._platform_defaults.services.zitadel, try(local._platform_services.zitadel, {}))
       vault         = merge(local._platform_defaults.services.vault, try(local._platform_services.vault, {}))
+      argocd        = merge(local._platform_defaults.services.argocd, try(local._platform_services.argocd, {}))
       platform_dash = merge(local._platform_defaults.services.platform_dash, try(local._platform_services.platform_dash, {}))
     }
   }

--- a/modules/argocd/main.tf
+++ b/modules/argocd/main.tf
@@ -1,0 +1,208 @@
+# Argo CD — application-layer GitOps controller.
+#
+# Deploys the upstream `argo/argo-cd` Helm chart with the chart-side
+# Ingress disabled. The platform owns ingress concerns elsewhere
+# (Cloudflare Tunnel + Traefik IngressRoute) so the route lands as a
+# `kind: external` component pointing at the `argocd-server` Service
+# this chart creates.
+#
+# OIDC is wired through Dex's built-in OIDC connector. Caller is
+# responsible for creating the Zitadel application (see
+# `argocd.tf` at the root) and passing in `client_id` /
+# `client_secret`. Empty inputs collapse the OIDC config and the
+# install falls back to the chart-generated local `admin` account.
+
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}
+
+# ── Inputs ─────────────────────────────────────────────────────────────────
+
+variable "enabled" {
+  description = "Whether to deploy Argo CD. False collapses every resource — single-node clusters that don't need GitOps stay clean."
+  type        = bool
+  default     = false
+}
+
+variable "namespace" {
+  description = "Namespace Argo CD lives in. Created by the chart's `create_namespace = true` so the operator doesn't have to declare it elsewhere."
+  type        = string
+  default     = "argocd"
+}
+
+variable "version_pin" {
+  description = "Helm chart version for argo/argo-cd. Pinned so an upstream re-tag doesn't silently change behavior across applies. Bump deliberately when a new chart fixes a CVE or ships a desired feature."
+  type        = string
+  default     = "9.5.11"
+}
+
+variable "hostname" {
+  description = "Public hostname Argo CD answers on. Embedded as `server.config.url` so generated redirect URIs and webhook callbacks resolve back to the public face."
+  type        = string
+}
+
+variable "oidc_issuer" {
+  description = "OIDC issuer URL. When set together with `oidc_client_id` and `oidc_client_secret`, the chart wires Dex with an OIDC connector and the UI gets a `Sign in with OIDC` button. Empty inputs disable the integration; only the chart-generated local admin remains."
+  type        = string
+  default     = ""
+}
+
+variable "oidc_client_id" {
+  description = "Client ID for the OIDC application Argo CD uses. Caller is responsible for creating the application in Zitadel and propagating the value here."
+  type        = string
+  default     = ""
+}
+
+variable "oidc_client_secret" {
+  description = "Client secret for the OIDC application Argo CD uses. Sensitive — the value lands in a Helm-managed Secret inside the cluster."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "oidc_admin_groups" {
+  description = "Group / role claims granted Argo CD's `role:admin` policy. Anyone whose ID token carries one of these claims gets full read/write across every Application/AppProject. Empty list = OIDC users have no permissions until the operator hand-edits the in-cluster ConfigMap."
+  type        = list(string)
+  default     = []
+}
+
+variable "node_selector" {
+  description = "Node-selector applied to every Argo CD pod the chart creates (server, repo-server, application-controller, redis, dex). Empty = scheduler picks. Set on multi-node clusters where a specific tier should host the GitOps controller."
+  type        = map(string)
+  default     = {}
+}
+
+variable "tolerations" {
+  description = "Taints every Argo CD pod tolerates. Empty list = pods cannot land on any tainted node."
+  type = list(object({
+    key                = optional(string)
+    operator           = optional(string)
+    value              = optional(string)
+    effect             = optional(string)
+    toleration_seconds = optional(string)
+  }))
+  default = []
+}
+
+# ── Locals ────────────────────────────────────────────────────────────────
+
+locals {
+  instances = var.enabled ? toset(["enabled"]) : toset([])
+
+  oidc_complete = (
+    var.oidc_issuer != "" &&
+    var.oidc_client_id != "" &&
+    var.oidc_client_secret != ""
+  )
+
+  # Chart values. `commonLabels` propagates to every chart-rendered
+  # resource. Server-config is built conditionally so empty OIDC
+  # inputs don't render a half-shaped `oidc.config` block.
+  values = yamlencode({
+    global = {
+      nodeSelector = var.node_selector
+      tolerations = [
+        for t in var.tolerations : {
+          key               = t.key
+          operator          = t.operator
+          value             = t.value
+          effect            = t.effect
+          tolerationSeconds = try(tonumber(t.toleration_seconds), null)
+        }
+      ]
+    }
+
+    configs = {
+      cm = merge(
+        {
+          url = "https://${var.hostname}"
+        },
+        local.oidc_complete ? {
+          "oidc.config" = yamlencode({
+            name         = "OIDC"
+            issuer       = var.oidc_issuer
+            clientID     = var.oidc_client_id
+            clientSecret = var.oidc_client_secret
+            requestedScopes = [
+              "openid",
+              "profile",
+              "email",
+              "groups",
+            ]
+            requestedIDTokenClaims = {
+              groups = { essential = true }
+            }
+          })
+        } : {}
+      )
+
+      rbac = length(var.oidc_admin_groups) == 0 ? {} : {
+        "policy.csv" = join("\n", [
+          for grp in var.oidc_admin_groups :
+          "g, ${grp}, role:admin"
+        ])
+        scopes = "[groups]"
+      }
+    }
+
+    # Chart-side Ingress stays off by design. The platform's
+    # IngressRoute (rendered by modules/project from a `kind:
+    # external` component yaml) routes Cloudflare Tunnel traffic to
+    # the `argocd-server` Service the chart creates — owning ingress
+    # in two places at once would conflict at the IngressClass level.
+    server = {
+      ingress = {
+        enabled = false
+      }
+    }
+  })
+}
+
+# ── Resources ─────────────────────────────────────────────────────────────
+
+resource "helm_release" "argocd" {
+  for_each = local.instances
+
+  name       = "argocd"
+  repository = "https://argoproj.github.io/argo-helm"
+  chart      = "argo-cd"
+  version    = var.version_pin
+  namespace  = var.namespace
+  # Namespace owned by the caller — the OIDC Secret rendered by
+  # `module.argocd_oidc` lands in the same namespace and needs it
+  # to exist before the chart upgrade hook fires.
+  create_namespace = false
+
+  # Chart bring-up is heavier than monitoring (operator + repo-server
+  # + application-controller + dex + redis). 15 min covers cold image
+  # pulls on a slow link without masking real failures.
+  timeout = 900
+
+  values = [local.values]
+}
+
+# ── Outputs ───────────────────────────────────────────────────────────────
+
+output "namespace" {
+  value       = var.enabled ? var.namespace : null
+  description = "Namespace Argo CD lives in. Null when disabled."
+}
+
+output "service_name" {
+  value       = var.enabled ? "argocd-server" : null
+  description = "ClusterIP Service name for the Argo CD UI/API. Wired into a `kind: external` component yaml so the IngressRoute pipeline routes the public hostname here. Null when disabled."
+}
+
+output "service_port" {
+  value       = var.enabled ? 80 : null
+  description = "Service port the IngressRoute should target. Null when disabled."
+}

--- a/modules/zitadel-app/main.tf
+++ b/modules/zitadel-app/main.tf
@@ -206,3 +206,9 @@ output "client_id" {
   value     = zitadel_application_oidc.this.client_id
   sensitive = true
 }
+
+output "client_secret" {
+  value       = zitadel_application_oidc.this.client_secret
+  sensitive   = true
+  description = "Generated client secret for the OIDC application. Consumed directly when the downstream module renders Helm values that need the secret inline (e.g. Argo CD's Dex connector). Most kind:app components mount the AUTH_ZITADEL_SECRET key from the emitted k8s Secret instead — this output is for the rare case where Helm-time interpolation is needed."
+}


### PR DESCRIPTION
Argo CD as a first-class platform service. Deploys the upstream `argo/argo-cd` Helm chart with Zitadel OIDC SSO via Dex.

## Deploy

`services.argocd.enabled = true` + `services.argocd.hostname = argocd.example.com` in `config/platform.yaml`, plus a `<sub>: argocd` route in the matching domain yaml.

## Roles

| Zitadel role | Argo CD policy |
| --- | --- |
| `argocd_admin` | `role:admin` (full RW) |
| `user` | placeholder; operator hand-grants in-cluster |

## Onboarding (one-time click-ops in Zitadel UI)

`Projects → argocd → Authorizations → Add user grant → role argocd_admin`. Auto-grant via TF was considered but skipped — see commit message for the trade-offs.

## Plan

`Plan: 10 to add, 1 to change, 0 to destroy.` Apply already executed against the live cluster: 7 ArgoCD pods Running, helm rev 1 deployed, `https://argocd.<domain>` reachable.

## Chart pin

`argo-cd-9.5.11` (upstream's 2026-05-01 release).