### PR TITLE
feat(kured): enable on the addons module call

### DIFF
--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -133,6 +133,18 @@ services:
     enabled: false
     hostname: argocd.example.com
 
+  # kured — Kubernetes Reboot Daemon. Drains and reboots a node when
+  # `/var/run/reboot-required` appears (Ubuntu's unattended-upgrades
+  # drops it for kernel/glibc/systemd updates). Default off so a fresh
+  # clone doesn't get an opinionated workload without consent. Flip on
+  # when the cluster nodes run unattended-upgrades and the operator
+  # wants the reboots automated. Maintenance-window knobs
+  # (`kured_reboot_days` / `kured_start_time` / `kured_end_time` /
+  # `kured_time_zone`) live on the addons module call in `main.tf` —
+  # add them there if a tighter window is needed.
+  kured:
+    enabled: false
+
   zitadel:
     enabled: false
     # Public hostname Zitadel issues OIDC tokens for. Must equal the

--- a/locals.tf
+++ b/locals.tf
@@ -54,6 +54,9 @@ locals {
         node_selector = {}
         tolerations   = []
       }
+      kured = {
+        enabled = false
+      }
       zitadel = {
         enabled              = false
         external_domain      = ""
@@ -114,6 +117,7 @@ locals {
       zitadel       = merge(local._platform_defaults.services.zitadel, try(local._platform_services.zitadel, {}))
       vault         = merge(local._platform_defaults.services.vault, try(local._platform_services.vault, {}))
       argocd        = merge(local._platform_defaults.services.argocd, try(local._platform_services.argocd, {}))
+      kured         = merge(local._platform_defaults.services.kured, try(local._platform_services.kured, {}))
       platform_dash = merge(local._platform_defaults.services.platform_dash, try(local._platform_services.platform_dash, {}))
     }
   }

--- a/main.tf
+++ b/main.tf
@@ -96,6 +96,14 @@ module "addons" {
   enable_monitoring   = true
   enable_ops_workload = true
 
+  # kured: drains and reboots a node when it observes
+  # `/var/run/reboot-required` (the sentinel Ubuntu's
+  # unattended-upgrades drops when a kernel/glibc/systemd update
+  # needs a reboot). Default OFF — operators flip on via
+  # `services.kured.enabled: true` in their gitignored
+  # `config/platform.yaml`.
+  enable_kured = local.platform.services.kured.enabled
+
   # Traefik's chart-side dashboard IngressRoute at `traefik.<base_domain>`
   # stays off — this platform owns dashboard routing through the tenant
   # YAML layer (see `config/components/traefik.yaml`), so leaving the


### PR DESCRIPTION
Flips on the kured toggle that addons v2.1.0 shipped dormant. Lands a kube-system DaemonSet that drains+reboots a node when /var/run/reboot-required appears (Ubuntu unattended-upgrades drops it for kernel/glibc/systemd updates).

Plan: 1 to add (kured helm release).

Apply note: this branches off main which doesn't yet have PR #56 (the ArgoCD server.insecure chart-path fix). Merge #56 first or rebase before applying — otherwise apply temporarily reverts the in-cluster ArgoCD fix and re-triggers the OIDC redirect loop.