### PR TITLE
feat(backup): platform-wide backups → Backblaze B2 via restic

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,19 @@ LETSENCRYPT_EMAIL=your-email@example.com
 # AWS_REGION=us-east-1
 # B2_BUCKET=your-tfstate-bucket
 # B2_ENDPOINT=https://s3.<your-b2-region>.backblazeb2.com
+
+# --- Backups → Backblaze B2 (when services.backup.enabled = true) ---------
+# Use a SEPARATE B2 application key from the tfstate one — a tfstate-key
+# leak must not also delete or overwrite encrypted backups. The bucket is
+# accessed via S3 API; same endpoint shape as the tfstate config.
+# TF_VAR_backup_b2_bucket=your-platform-backups
+# TF_VAR_backup_b2_endpoint=https://s3.<your-b2-region>.backblazeb2.com
+# TF_VAR_backup_b2_access_key_id=your-backup-key-id
+# TF_VAR_backup_b2_secret_access_key=your-backup-key-secret
+#
+# Optional: pre-set the restic passphrase. Leave commented to let TF
+# generate a 32-char random value (pull via `terraform output -raw
+# backup_passphrase` and stash in a password manager). Setting an
+# explicit value here is useful when the passphrase is operator-managed
+# externally and TF should NOT touch it.
+# TF_VAR_backup_passphrase=your-strong-passphrase-from-password-manager

--- a/backup.tf
+++ b/backup.tf
@@ -1,0 +1,249 @@
+# Platform backups → Backblaze B2 via restic.
+#
+# Module + repo init only. The CronJobs that actually run live in
+# `modules/backup`. This file's job is to:
+#   1. Bridge the operator's `.env` B2 credentials and the
+#      shared-service Secrets the cluster modules expose into a
+#      single `module "backup"` invocation.
+#   2. Copy the per-target source-of-truth Secrets (Postgres
+#      superuser, MySQL root, Redis default user, Vault root
+#      token) from their owning namespaces into the `backups`
+#      namespace so the CronJobs can `envFrom`/`secret_key_ref`
+#      them locally without cross-namespace RBAC.
+#   3. Surface the restic passphrase as a sensitive root output
+#      the operator can stash in their password manager.
+#
+# `services.backup.enabled` defaults to false. Operators that
+# want backups set it to true in `config/platform.yaml` AND
+# populate the matching `var.backup_b2_*` inputs in their
+# gitignored `.env` (separate keys from the tfstate B2 bucket —
+# blast-radius isolation is the whole point).
+
+variable "backup_b2_bucket" {
+  description = "Backblaze B2 bucket NAME used for backups. Should NOT match the bucket the Terraform S3 backend uses for tfstate. Sourced from the operator's gitignored `.env` as `TF_VAR_backup_b2_bucket`."
+  type        = string
+  default     = ""
+}
+
+variable "backup_b2_endpoint" {
+  description = "S3-compatible endpoint URL for the B2 region the bucket lives in (e.g. `https://s3.us-east-005.backblazeb2.com`). Same shape as the existing `B2_ENDPOINT`. Empty disables the backup module via the precondition below."
+  type        = string
+  default     = ""
+}
+
+variable "backup_b2_access_key_id" {
+  description = "B2 application key id with write access to `backup_b2_bucket`. SHOULD be a key separate from the tfstate-bucket key — a tfstate-key compromise must not delete or overwrite backups."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "backup_b2_secret_access_key" {
+  description = "B2 application key secret matching `backup_b2_access_key_id`."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "backup_passphrase" {
+  description = "Optional pre-set restic passphrase. Empty (default) lets the module generate a 32-char random value. Either way, the operator MUST stash the value (see `terraform output -raw backup_passphrase`) in their password manager — losing it bricks every encrypted backup forever."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+check "backup_inputs_set_when_enabled" {
+  assert {
+    condition = !local.platform.services.backup.enabled || (
+      var.backup_b2_bucket != "" &&
+      var.backup_b2_endpoint != "" &&
+      var.backup_b2_access_key_id != "" &&
+      var.backup_b2_secret_access_key != ""
+    )
+    error_message = "services.backup.enabled = true requires TF_VAR_backup_b2_bucket / TF_VAR_backup_b2_endpoint / TF_VAR_backup_b2_access_key_id / TF_VAR_backup_b2_secret_access_key in the operator's gitignored .env. Use a separate B2 application key from the tfstate one — backup writes should survive a tfstate-key leak."
+  }
+}
+
+# ── Cross-namespace Secret bridge ─────────────────────────────────────────
+#
+# CronJobs in `backups` namespace read DB / Vault credentials via
+# `secret_key_ref`, which is namespace-local. Mirror the source
+# Secrets here. `data` references the live Secret content so a
+# rotation in the source namespace propagates on the next apply.
+
+resource "kubernetes_secret_v1" "backup_postgres_superuser" {
+  count = local.platform.services.backup.enabled && local.platform.services.postgres.enabled ? 1 : 0
+
+  depends_on = [module.backup]
+
+  metadata {
+    name      = "postgres-superuser-mirror"
+    namespace = "backups"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/component"  = "backup-creds"
+    }
+  }
+
+  data = {
+    POSTGRES_PASSWORD = data.kubernetes_secret_v1.postgres_superuser[0].data["POSTGRES_PASSWORD"]
+  }
+}
+
+data "kubernetes_secret_v1" "postgres_superuser" {
+  count = local.platform.services.backup.enabled && local.platform.services.postgres.enabled ? 1 : 0
+
+  metadata {
+    name      = module.postgres.superuser_secret_name
+    namespace = module.postgres.namespace
+  }
+}
+
+resource "kubernetes_secret_v1" "backup_mysql_root" {
+  count = local.platform.services.backup.enabled && local.platform.services.mysql.enabled ? 1 : 0
+
+  depends_on = [module.backup]
+
+  metadata {
+    name      = "mysql-root-mirror"
+    namespace = "backups"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/component"  = "backup-creds"
+    }
+  }
+
+  data = {
+    MYSQL_ROOT_PASSWORD = data.kubernetes_secret_v1.mysql_root[0].data["MYSQL_ROOT_PASSWORD"]
+  }
+}
+
+data "kubernetes_secret_v1" "mysql_root" {
+  count = local.platform.services.backup.enabled && local.platform.services.mysql.enabled ? 1 : 0
+
+  metadata {
+    name      = module.mysql.root_secret_name
+    namespace = module.mysql.namespace
+  }
+}
+
+resource "kubernetes_secret_v1" "backup_redis_default" {
+  count = local.platform.services.backup.enabled && local.platform.services.redis.enabled ? 1 : 0
+
+  depends_on = [module.backup]
+
+  metadata {
+    name      = "redis-default-mirror"
+    namespace = "backups"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/component"  = "backup-creds"
+    }
+  }
+
+  data = {
+    REDIS_PASSWORD = data.kubernetes_secret_v1.redis_default[0].data["REDIS_PASSWORD"]
+  }
+}
+
+data "kubernetes_secret_v1" "redis_default" {
+  count = local.platform.services.backup.enabled && local.platform.services.redis.enabled ? 1 : 0
+
+  metadata {
+    name      = module.redis.default_secret_name
+    namespace = module.redis.namespace
+  }
+}
+
+resource "kubernetes_secret_v1" "backup_vault_token" {
+  count = local.platform.services.backup.enabled && local.platform.services.vault.enabled ? 1 : 0
+
+  depends_on = [module.backup]
+
+  metadata {
+    name      = "vault-token-mirror"
+    namespace = "backups"
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/component"  = "backup-creds"
+    }
+  }
+
+  data = {
+    "root-token" = data.kubernetes_secret_v1.vault_bootstrap[0].data["root-token"]
+  }
+}
+
+data "kubernetes_secret_v1" "vault_bootstrap" {
+  count = local.platform.services.backup.enabled && local.platform.services.vault.enabled ? 1 : 0
+
+  metadata {
+    name      = "vault-bootstrap"
+    namespace = "platform"
+  }
+}
+
+# ── Module call ───────────────────────────────────────────────────────────
+
+module "backup" {
+  source = "./modules/backup"
+
+  enabled = local.platform.services.backup.enabled
+
+  b2_bucket            = var.backup_b2_bucket
+  b2_endpoint          = var.backup_b2_endpoint
+  b2_access_key_id     = var.backup_b2_access_key_id
+  b2_secret_access_key = var.backup_b2_secret_access_key
+  passphrase           = var.backup_passphrase
+
+  # Postgres
+  postgres_enabled          = local.platform.services.backup.enabled && local.platform.services.postgres.enabled
+  postgres_host             = module.postgres.host
+  postgres_superuser_secret = "postgres-superuser-mirror"
+  postgres_databases        = local.platform.services.backup.postgres_databases
+
+  # MySQL
+  mysql_enabled     = local.platform.services.backup.enabled && local.platform.services.mysql.enabled
+  mysql_host        = module.mysql.host
+  mysql_root_secret = "mysql-root-mirror"
+  mysql_databases   = local.platform.services.backup.mysql_databases
+
+  # Redis
+  redis_enabled        = local.platform.services.backup.enabled && local.platform.services.redis.enabled
+  redis_host           = module.redis.host
+  redis_default_secret = "redis-default-mirror"
+
+  # Vault
+  vault_enabled      = local.platform.services.backup.enabled && local.platform.services.vault.enabled
+  vault_addr         = local.platform.services.vault.enabled ? "http://vault.platform.svc.cluster.local:8200" : ""
+  vault_token_secret = "vault-token-mirror"
+
+  # PV
+  pv_enabled       = local.platform.services.backup.enabled && length(local.platform.services.backup.pv_paths) > 0
+  pv_paths         = local.platform.services.backup.pv_paths
+  pv_node_selector = local.platform.services.backup.pv_node_selector
+  pv_tolerations   = local.platform.services.backup.pv_tolerations
+
+  # Schedule + retention overrides (fall through to defaults
+  # inside the module when the operator doesn't set them).
+  schedule_postgres      = local.platform.services.backup.schedule_postgres
+  schedule_mysql         = local.platform.services.backup.schedule_mysql
+  schedule_redis         = local.platform.services.backup.schedule_redis
+  schedule_vault         = local.platform.services.backup.schedule_vault
+  schedule_pv            = local.platform.services.backup.schedule_pv
+  schedule_prune         = local.platform.services.backup.schedule_prune
+  retention_keep_daily   = local.platform.services.backup.retention_keep_daily
+  retention_keep_weekly  = local.platform.services.backup.retention_keep_weekly
+  retention_keep_monthly = local.platform.services.backup.retention_keep_monthly
+}
+
+output "backup_passphrase" {
+  description = "restic repository passphrase. Pull with `terraform output -raw backup_passphrase` and stash in a password manager — losing it bricks every encrypted backup."
+  value       = module.backup.passphrase
+  sensitive   = true
+}
+
+output "backup_repository_url" {
+  description = "restic repository URL (`s3:<endpoint>/<bucket>`). Used by `./tf backup-config` and every restore script."
+  value       = module.backup.repository_url
+}

--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -145,6 +145,54 @@ services:
   kured:
     enabled: false
 
+  # Backups → Backblaze B2 via restic.
+  #
+  # CronJobs in the `backups` namespace dump every stateful target
+  # (Postgres / MySQL / Redis / Vault / hostPath PVs) on schedule
+  # and push to a single restic-encrypted repository. Operator's
+  # gitignored config (.env, config/platform.yaml, config/domains/*)
+  # backs up off-cluster via the `./tf backup-config` wrapper.
+  #
+  # Hard requirements when `enabled: true`:
+  #   - separate B2 application key from the tfstate-bucket key
+  #     (blast radius isolation)
+  #   - matching `.env` keys: TF_VAR_backup_b2_bucket /
+  #     TF_VAR_backup_b2_endpoint / TF_VAR_backup_b2_access_key_id /
+  #     TF_VAR_backup_b2_secret_access_key
+  #   - the restic passphrase (sensitive output `backup_passphrase`)
+  #     stashed in a password manager — losing it bricks every
+  #     encrypted snapshot forever
+  #
+  # Per-target lists (`postgres_databases` / `mysql_databases` /
+  # `pv_paths`) are operator-managed. Empty `postgres_databases`
+  # falls back to `pg_dumpall`; empty `pv_paths` skips the PV
+  # CronJob entirely.
+  backup:
+    enabled: false
+    postgres_databases:
+      # - platform_zitadel
+      # - platform_dash
+    mysql_databases:
+      # - tenant_a
+      # - tenant_b
+    pv_paths:
+      # - { name: stalwart-data, path: /data/vol/mail/stalwart/data }
+      # - { name: web-html,      path: /data/vol/phost-example-prod/web/usr-share-nginx-html }
+    pv_node_selector:
+      # workload-tier: stateful
+    # Schedules in UTC. Defaults stagger DB targets through 03:00–
+    # 03:45 then PV at 04:00 Sun, prune at 05:00 Sun. Override only
+    # if there's a maintenance window that conflicts.
+    # schedule_postgres: "0 3 * * *"
+    # schedule_mysql:    "15 3 * * *"
+    # schedule_redis:    "30 3 * * *"
+    # schedule_vault:    "45 3 * * *"
+    # schedule_pv:       "0 4 * * 0"
+    # schedule_prune:    "0 5 * * 0"
+    # retention_keep_daily:   7
+    # retention_keep_weekly:  4
+    # retention_keep_monthly: 6
+
   zitadel:
     enabled: false
     # Public hostname Zitadel issues OIDC tokens for. Must equal the

--- a/locals.tf
+++ b/locals.tf
@@ -57,6 +57,23 @@ locals {
       kured = {
         enabled = false
       }
+      backup = {
+        enabled                = false
+        postgres_databases     = []
+        mysql_databases        = []
+        pv_paths               = []
+        pv_node_selector       = {}
+        pv_tolerations         = []
+        schedule_postgres      = "0 3 * * *"
+        schedule_mysql         = "15 3 * * *"
+        schedule_redis         = "30 3 * * *"
+        schedule_vault         = "45 3 * * *"
+        schedule_pv            = "0 4 * * 0"
+        schedule_prune         = "0 5 * * 0"
+        retention_keep_daily   = 7
+        retention_keep_weekly  = 4
+        retention_keep_monthly = 6
+      }
       zitadel = {
         enabled              = false
         external_domain      = ""
@@ -118,6 +135,7 @@ locals {
       vault         = merge(local._platform_defaults.services.vault, try(local._platform_services.vault, {}))
       argocd        = merge(local._platform_defaults.services.argocd, try(local._platform_services.argocd, {}))
       kured         = merge(local._platform_defaults.services.kured, try(local._platform_services.kured, {}))
+      backup        = merge(local._platform_defaults.services.backup, try(local._platform_services.backup, {}))
       platform_dash = merge(local._platform_defaults.services.platform_dash, try(local._platform_services.platform_dash, {}))
     }
   }

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -605,8 +605,15 @@ resource "kubernetes_cron_job_v1" "mysql" {
             restart_policy = "OnFailure"
 
             container {
-              name  = "dump"
-              image = var.image_alpine
+              name = "dump"
+              # MariaDB 11 client speaks `caching_sha2_password` as
+              # of 10.6 — the plugin lives in
+              # /usr/lib/mysql/plugin/ in the official mariadb
+              # image and mariadb-dump auto-discovers it.
+              # Alpine's standalone mariadb-client package strips
+              # plugins, so the full mariadb:11 image is what we
+              # want. Debian-based, apt-get installs restic.
+              image = "mariadb:11"
 
               env_from {
                 secret_ref {
@@ -632,22 +639,29 @@ resource "kubernetes_cron_job_v1" "mysql" {
                 value = join(" ", var.mysql_databases)
               }
 
-              command = ["sh", "-c"]
+              command = ["bash", "-c"]
               args = [<<-EOT
-                set -e
-                apk add --no-cache restic mariadb-client >/dev/null
+                set -eo pipefail
+                apt-get update -qq
+                apt-get install -y --no-install-recommends restic >/dev/null
 
                 STAGE=$(mktemp -d)
                 trap 'rm -rf "$STAGE"' EXIT
 
+                # `mariadb-dump` (not `mysqldump`) — MariaDB 11
+                # dropped the `mysqldump` symlink. Same flags,
+                # same semantics. `--ssl=0` because in-cluster
+                # MySQL ships a self-signed cert and the client
+                # rejects untrusted chains by default; traffic
+                # stays in the pod network so plain is fine.
                 if [ -z "$DATABASES" ]; then
-                  echo "[mysql] DATABASES empty — mysqldump --all-databases"
-                  mysqldump -h "$MYSQL_HOST" -u root --single-transaction \
+                  echo "[mysql] DATABASES empty — dump --all-databases"
+                  mariadb-dump --ssl=0 -h "$MYSQL_HOST" -u root --single-transaction \
                     --quick --all-databases | gzip -9 >"$STAGE/all.sql.gz"
                 else
                   for db in $DATABASES; do
-                    echo "[mysql] mysqldump $db"
-                    mysqldump -h "$MYSQL_HOST" -u root --single-transaction \
+                    echo "[mysql] mariadb-dump $db"
+                    mariadb-dump --ssl=0 -h "$MYSQL_HOST" -u root --single-transaction \
                       --quick "$db" | gzip -9 >"$STAGE/$db.sql.gz"
                   done
                 fi
@@ -902,13 +916,12 @@ resource "kubernetes_cron_job_v1" "pv" {
                 }
               }
 
+              # `<name>:<path>` pairs joined by comma. Iterated by
+              # POSIX `sh` in the loop below (bash arrays aren't
+              # available — alpine's /bin/sh is busybox).
               env {
-                name  = "PV_NAMES"
-                value = join(",", [for p in var.pv_paths : p.name])
-              }
-              env {
-                name  = "PV_PATHS"
-                value = join(",", [for p in var.pv_paths : p.path])
+                name  = "PV_PAIRS"
+                value = join(",", [for p in var.pv_paths : "${p.name}:${p.path}"])
               }
 
               security_context {
@@ -930,20 +943,19 @@ resource "kubernetes_cron_job_v1" "pv" {
                 STAGE=$(mktemp -d)
                 trap 'rm -rf "$STAGE"' EXIT
 
-                IFS=','; set -- $PV_NAMES
-                NAMES=("$@")
-                set -- $PV_PATHS
-                PATHS=("$@")
-                IFS=' '
-
-                i=0
-                while [ $i -lt $${#NAMES[@]} ]; do
-                  name="$${NAMES[$i]}"
-                  path="$${PATHS[$i]}"
+                # POSIX iteration over comma-separated `name:path`
+                # pairs. busybox sh doesn't have bash arrays.
+                old_ifs="$IFS"
+                IFS=','
+                for entry in $PV_PAIRS; do
+                  IFS="$old_ifs"
+                  name="$${entry%%:*}"
+                  path="$${entry#*:}"
                   echo "[pv] tar $name from $path"
                   tar -czf "$STAGE/$name.tar.gz" -C "$path" .
-                  i=$((i+1))
+                  IFS=','
                 done
+                IFS="$old_ifs"
 
                 echo "[pv] restic backup"
                 restic backup --host platform-pv --tag pv "$STAGE"

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -1,0 +1,1084 @@
+# Platform backups → Backblaze B2 via restic.
+#
+# One restic repository on a dedicated B2 bucket carries every
+# backup target (Postgres dumps, MySQL dumps, Redis snapshots,
+# Vault raft snapshots, hostPath PV tarballs, operator-side
+# config/.env). Encryption is built into restic (AES-256 + a
+# single passphrase shared across targets). Retention is
+# `restic forget --prune` on a weekly cron with daily/weekly/
+# monthly slots.
+#
+# Restore scripts ship in this module's `scripts/` directory and
+# are pushed into the restic repo as a `scripts` tag on every
+# init Job run, so a complete cluster wipe + lost local repo
+# still leaves the operator with `restic restore latest --tag
+# scripts → run` as the disaster-recovery starting point.
+#
+# Three layers of secret storage make passphrase loss survivable:
+#   - Generated once via `random_password.backup_passphrase`,
+#     surfaced as a sensitive Terraform output. Operator pastes
+#     into a personal password manager — that is the only
+#     long-term source of truth.
+#   - Mounted into in-cluster CronJobs via a k8s Secret in this
+#     module's namespace.
+#   - Operator's `.env` may carry it as `TF_VAR_backup_passphrase`
+#     for the wrapper-side `./tf backup-config` invocation;
+#     gitignored, never reaches the public repo.
+#
+# B2 credentials are sourced from the same `.env` shape the
+# Terraform S3 backend already uses for tfstate
+# (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`), but pointed at
+# a dedicated `backups` bucket so a tfstate-key compromise can't
+# delete or overwrite backups.
+
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
+  }
+}
+
+# ── Inputs ─────────────────────────────────────────────────────────────────
+
+variable "enabled" {
+  description = "Whether to provision backup CronJobs + restic init Job. False collapses every resource — fresh clones stay clean."
+  type        = bool
+  default     = false
+}
+
+variable "namespace" {
+  description = "Namespace the backup CronJobs run in. Created by this module so tenant ResourceQuotas stay isolated from backup workload."
+  type        = string
+  default     = "backups"
+}
+
+variable "b2_bucket" {
+  description = "Backblaze B2 bucket name for backups. Should NOT be the same bucket the Terraform S3 backend uses for tfstate — keep blast radius separate."
+  type        = string
+}
+
+variable "b2_endpoint" {
+  description = "S3-compatible endpoint URL for the B2 bucket region (e.g. `https://s3.us-east-005.backblazeb2.com`). Same shape as `B2_ENDPOINT` in the operator's `.env` for tfstate."
+  type        = string
+}
+
+variable "b2_access_key_id" {
+  description = "B2 application key ID with write access to `b2_bucket`. Sourced from the operator's `.env`."
+  type        = string
+  sensitive   = true
+}
+
+variable "b2_secret_access_key" {
+  description = "B2 application key secret matching `b2_access_key_id`. Sensitive — lands in a k8s Secret in `var.namespace`."
+  type        = string
+  sensitive   = true
+}
+
+variable "passphrase" {
+  description = "Passphrase used to encrypt the restic repository. Empty (default) lets the module generate a random 32-char value via `random_password`; operators that prefer to manage the passphrase out-of-band can pass a non-empty value here. Either way, the passphrase MUST be stored in the operator's password manager — losing it bricks every backup forever (restic AES-256 has no recovery path)."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+# Postgres target ----------------------------------------------------------
+
+variable "postgres_enabled" {
+  description = "Whether to dump the shared Postgres on schedule. Off by default — disable when there's no Postgres in the platform OR when the operator handles dumps out-of-band."
+  type        = bool
+  default     = false
+}
+
+variable "postgres_host" {
+  description = "In-cluster hostname for `pg_dump` connections (e.g. `postgres.platform.svc.cluster.local`)."
+  type        = string
+  default     = ""
+}
+
+variable "postgres_superuser_secret" {
+  description = "Name of the Secret in `var.namespace` (created by this module via cross-namespace copy from the postgres module's superuser Secret) holding the `POSTGRES_PASSWORD` key. The CronJob mounts it for `pg_dump` auth."
+  type        = string
+  default     = ""
+}
+
+variable "postgres_databases" {
+  description = "List of database names to dump on each Postgres backup run. Empty list = uses `pg_dumpall` instead, capturing everything in one stream. Per-database mode is preferred — restic dedup works better on smaller stable streams and a per-DB restore is simpler."
+  type        = list(string)
+  default     = []
+}
+
+# MySQL target -------------------------------------------------------------
+
+variable "mysql_enabled" {
+  description = "Whether to dump the shared MySQL on schedule."
+  type        = bool
+  default     = false
+}
+
+variable "mysql_host" {
+  description = "In-cluster hostname for `mysqldump` connections."
+  type        = string
+  default     = ""
+}
+
+variable "mysql_root_secret" {
+  description = "Name of the Secret in `var.namespace` holding the MySQL root password under `MYSQL_ROOT_PASSWORD`."
+  type        = string
+  default     = ""
+}
+
+variable "mysql_databases" {
+  description = "List of MySQL database names to dump. Empty = `mysqldump --all-databases`."
+  type        = list(string)
+  default     = []
+}
+
+# Redis target -------------------------------------------------------------
+
+variable "redis_enabled" {
+  description = "Whether to snapshot Redis on schedule via `redis-cli --rdb`."
+  type        = bool
+  default     = false
+}
+
+variable "redis_host" {
+  description = "In-cluster hostname for `redis-cli`."
+  type        = string
+  default     = ""
+}
+
+variable "redis_default_secret" {
+  description = "Name of the Secret in `var.namespace` holding the Redis `default` user password under `REDIS_PASSWORD`."
+  type        = string
+  default     = ""
+}
+
+# Vault target -------------------------------------------------------------
+
+variable "vault_enabled" {
+  description = "Whether to take a `vault operator raft snapshot save` on schedule."
+  type        = bool
+  default     = false
+}
+
+variable "vault_addr" {
+  description = "In-cluster Vault URL (e.g. `http://vault.platform.svc.cluster.local:8200`)."
+  type        = string
+  default     = ""
+}
+
+variable "vault_token_secret" {
+  description = "Name of the Secret in `var.namespace` holding the Vault root token under `VAULT_TOKEN`. Phase 0 sources from the bootstrap Secret; future phases will use a dedicated backup-policy AppRole so the root token isn't day-to-day exposed."
+  type        = string
+  default     = ""
+}
+
+# PV target ----------------------------------------------------------------
+
+variable "pv_enabled" {
+  description = "Whether to tar host-path PV directories on schedule. Pod runs with `hostNetwork = false` but `hostPath` mounts for each entry in `pv_paths`. Must run on the node that owns the data — set `pv_node_selector` accordingly."
+  type        = bool
+  default     = false
+}
+
+variable "pv_paths" {
+  description = "List of host-path entries to back up. Each entry is `{ name, path }` where `name` is a stable identifier used as the restic snapshot tag (e.g. `stalwart-data`) and `path` is the absolute host directory (e.g. `/data/vol/platform/stalwart/data`)."
+  type = list(object({
+    name = string
+    path = string
+  }))
+  default = []
+}
+
+variable "pv_node_selector" {
+  description = "Node-selector for the PV backup CronJob. Required on multi-node clusters where hostPath PVs live on a single node — without it the scheduler can land the Job where the host directory is empty."
+  type        = map(string)
+  default     = {}
+}
+
+variable "pv_tolerations" {
+  description = "Tolerations for the PV backup CronJob."
+  type = list(object({
+    key                = optional(string)
+    operator           = optional(string)
+    value              = optional(string)
+    effect             = optional(string)
+    toleration_seconds = optional(string)
+  }))
+  default = []
+}
+
+# Schedule + retention -----------------------------------------------------
+
+variable "schedule_postgres" {
+  description = "Cron schedule for the Postgres dump CronJob (UTC)."
+  type        = string
+  default     = "0 3 * * *"
+}
+
+variable "schedule_mysql" {
+  description = "Cron schedule for the MySQL dump CronJob (UTC). Offset 15 min from Postgres so the two don't pile up on the network at once."
+  type        = string
+  default     = "15 3 * * *"
+}
+
+variable "schedule_redis" {
+  description = "Cron schedule for the Redis snapshot CronJob (UTC)."
+  type        = string
+  default     = "30 3 * * *"
+}
+
+variable "schedule_vault" {
+  description = "Cron schedule for the Vault raft snapshot CronJob (UTC)."
+  type        = string
+  default     = "45 3 * * *"
+}
+
+variable "schedule_pv" {
+  description = "Cron schedule for the hostPath PV tar CronJob (UTC). Weekly default — tarballs are heavier than DB dumps, restic dedup keeps the weekly cadence cheap."
+  type        = string
+  default     = "0 4 * * 0"
+}
+
+variable "schedule_prune" {
+  description = "Cron schedule for the `restic forget --prune` retention CronJob (UTC). Weekly so the prune walk happens off-peak after the heaviest backup window."
+  type        = string
+  default     = "0 5 * * 0"
+}
+
+variable "retention_keep_daily" {
+  description = "How many daily restic snapshots to keep per target."
+  type        = number
+  default     = 7
+}
+
+variable "retention_keep_weekly" {
+  description = "How many weekly restic snapshots to keep per target."
+  type        = number
+  default     = 4
+}
+
+variable "retention_keep_monthly" {
+  description = "How many monthly restic snapshots to keep per target."
+  type        = number
+  default     = 6
+}
+
+variable "image_alpine" {
+  description = "Alpine image used as the base for every backup CronJob. Each Job apk-installs the tools it needs (postgresql-client, mysql-client, redis, restic, …) at start. Pinned to keep behavior stable across applies."
+  type        = string
+  default     = "alpine:3.22"
+}
+
+# ── Locals ────────────────────────────────────────────────────────────────
+
+locals {
+  instances = var.enabled ? toset(["enabled"]) : toset([])
+
+  passphrase = var.passphrase != "" ? var.passphrase : (
+    var.enabled ? random_password.backup_passphrase[0].result : ""
+  )
+
+  # restic repo URL = `s3:<endpoint>/<bucket>`. Same encoding the
+  # tfstate backend uses for B2.
+  repository_url = "s3:${var.b2_endpoint}/${var.b2_bucket}"
+
+  postgres_set = var.enabled && var.postgres_enabled ? toset(["enabled"]) : toset([])
+  mysql_set    = var.enabled && var.mysql_enabled ? toset(["enabled"]) : toset([])
+  redis_set    = var.enabled && var.redis_enabled ? toset(["enabled"]) : toset([])
+  vault_set    = var.enabled && var.vault_enabled ? toset(["enabled"]) : toset([])
+  pv_set       = var.enabled && var.pv_enabled && length(var.pv_paths) > 0 ? toset(["enabled"]) : toset([])
+
+  # Common shell preamble all CronJob containers share. `set -e`
+  # so a failing pg_dump / restic backup propagates to the Pod
+  # status. `apk add restic` lands the binary at /usr/bin/restic.
+  # The retention CronJob only needs restic; the dump CronJobs
+  # additionally apk-install the per-target client.
+  restic_env = "RESTIC_REPOSITORY=$RESTIC_REPOSITORY RESTIC_PASSWORD=$RESTIC_PASSWORD AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY"
+
+  # Restore scripts read from `scripts/` directory and bundled
+  # into a ConfigMap. The init Job uploads them to the restic
+  # repo under the `scripts` tag so a disaster-recovery operator
+  # with only the passphrase + B2 creds can pull them back.
+  restore_scripts = {
+    "restore-postgres.sh" = file("${path.module}/scripts/restore-postgres.sh")
+    "restore-mysql.sh"    = file("${path.module}/scripts/restore-mysql.sh")
+    "restore-redis.sh"    = file("${path.module}/scripts/restore-redis.sh")
+    "restore-vault.sh"    = file("${path.module}/scripts/restore-vault.sh")
+    "restore-pv.sh"       = file("${path.module}/scripts/restore-pv.sh")
+    "restore-config.sh"   = file("${path.module}/scripts/restore-config.sh")
+    "README.md"           = file("${path.module}/scripts/README.md")
+  }
+}
+
+# ── Passphrase generation ─────────────────────────────────────────────────
+
+resource "random_password" "backup_passphrase" {
+  count = var.enabled && var.passphrase == "" ? 1 : 0
+
+  length  = 32
+  special = false
+
+  # Pin to the bucket name so a bucket rename (= a fresh restic
+  # repo) regenerates a fresh passphrase. Same-bucket re-applies
+  # keep the existing passphrase — losing it isn't a recoverable
+  # event.
+  keepers = {
+    bucket = var.b2_bucket
+  }
+}
+
+# ── Namespace + Secret ────────────────────────────────────────────────────
+
+resource "kubernetes_namespace_v1" "backup" {
+  for_each = local.instances
+
+  metadata {
+    name = var.namespace
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/component"  = "backup"
+    }
+  }
+}
+
+# All CronJobs read this Secret via `envFrom`. Holds restic repo
+# URL + passphrase + B2 creds + (optionally) per-target client
+# credentials. Per-target credentials are also written here as
+# additional keys so each Job's env is one Secret pull.
+resource "kubernetes_secret_v1" "backup_creds" {
+  for_each = local.instances
+
+  metadata {
+    name      = "backup-creds"
+    namespace = kubernetes_namespace_v1.backup["enabled"].metadata[0].name
+  }
+
+  data = {
+    RESTIC_REPOSITORY     = local.repository_url
+    RESTIC_PASSWORD       = local.passphrase
+    AWS_ACCESS_KEY_ID     = var.b2_access_key_id
+    AWS_SECRET_ACCESS_KEY = var.b2_secret_access_key
+  }
+
+  type = "Opaque"
+}
+
+# Restore-scripts ConfigMap. Mounted into the init Job so it can
+# `restic backup` them into the repo with tag `scripts`.
+resource "kubernetes_config_map_v1" "restore_scripts" {
+  for_each = local.instances
+
+  metadata {
+    name      = "backup-restore-scripts"
+    namespace = kubernetes_namespace_v1.backup["enabled"].metadata[0].name
+  }
+
+  data = local.restore_scripts
+}
+
+# ── Repo init Job ─────────────────────────────────────────────────────────
+#
+# Idempotent. `restic init` returns a non-zero exit code when the
+# repo already exists; the script ignores that specific error and
+# proceeds to upload the restore scripts under tag `scripts`.
+# Running again is harmless — restic dedup makes the script
+# upload a no-op on identical content.
+
+resource "kubernetes_job_v1" "restic_init" {
+  for_each = local.instances
+
+  metadata {
+    name      = "backup-restic-init"
+    namespace = kubernetes_namespace_v1.backup["enabled"].metadata[0].name
+    labels = {
+      "app.kubernetes.io/component" = "backup-init"
+    }
+  }
+
+  spec {
+    backoff_limit              = 4
+    ttl_seconds_after_finished = 300
+
+    template {
+      metadata {
+        labels = { "app.kubernetes.io/component" = "backup-init" }
+      }
+
+      spec {
+        restart_policy = "OnFailure"
+
+        container {
+          name  = "init"
+          image = var.image_alpine
+
+          env_from {
+            secret_ref {
+              name = kubernetes_secret_v1.backup_creds["enabled"].metadata[0].name
+            }
+          }
+
+          command = ["sh", "-c"]
+          args = [<<-EOT
+            set -e
+            apk add --no-cache restic >/dev/null
+            echo "[init] checking repository at $RESTIC_REPOSITORY"
+            if restic snapshots --no-lock >/dev/null 2>&1; then
+              echo "[init] repository already initialised — skipping init"
+            else
+              echo "[init] initialising fresh repository"
+              restic init
+            fi
+            echo "[init] uploading restore scripts as tag=scripts"
+            restic backup --tag scripts /scripts
+            echo "[init] done"
+          EOT
+          ]
+
+          volume_mount {
+            name       = "scripts"
+            mount_path = "/scripts"
+            read_only  = true
+          }
+
+          resources {
+            requests = { cpu = "10m", memory = "64Mi" }
+            limits   = { cpu = "200m", memory = "256Mi" }
+          }
+        }
+
+        volume {
+          name = "scripts"
+          config_map {
+            name = kubernetes_config_map_v1.restore_scripts["enabled"].metadata[0].name
+          }
+        }
+      }
+    }
+  }
+
+  wait_for_completion = true
+  timeouts {
+    create = "5m"
+    update = "5m"
+  }
+}
+
+# ── Postgres dump CronJob ─────────────────────────────────────────────────
+
+resource "kubernetes_cron_job_v1" "postgres" {
+  for_each = local.postgres_set
+
+  metadata {
+    name      = "backup-postgres"
+    namespace = kubernetes_namespace_v1.backup["enabled"].metadata[0].name
+  }
+
+  spec {
+    schedule                      = var.schedule_postgres
+    concurrency_policy            = "Forbid"
+    successful_jobs_history_limit = 1
+    failed_jobs_history_limit     = 3
+    starting_deadline_seconds     = 300
+
+    job_template {
+      metadata {
+        labels = { "app.kubernetes.io/component" = "backup-postgres" }
+      }
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 86400 # 1 day
+
+        template {
+          metadata {
+            labels = { "app.kubernetes.io/component" = "backup-postgres" }
+          }
+          spec {
+            restart_policy = "OnFailure"
+
+            container {
+              name  = "dump"
+              image = var.image_alpine
+
+              env_from {
+                secret_ref {
+                  name = kubernetes_secret_v1.backup_creds["enabled"].metadata[0].name
+                }
+              }
+
+              env {
+                name  = "PGHOST"
+                value = var.postgres_host
+              }
+              env {
+                name  = "PGUSER"
+                value = "postgres"
+              }
+              env {
+                name = "PGPASSWORD"
+                value_from {
+                  secret_key_ref {
+                    name = var.postgres_superuser_secret
+                    key  = "POSTGRES_PASSWORD"
+                  }
+                }
+              }
+              env {
+                name  = "DATABASES"
+                value = join(" ", var.postgres_databases)
+              }
+
+              command = ["sh", "-c"]
+              args = [<<-EOT
+                set -e
+                apk add --no-cache restic postgresql16-client >/dev/null
+
+                STAGE=$(mktemp -d)
+                trap 'rm -rf "$STAGE"' EXIT
+
+                if [ -z "$DATABASES" ]; then
+                  echo "[postgres] DATABASES empty — pg_dumpall"
+                  pg_dumpall --clean --if-exists | gzip -9 >"$STAGE/all.sql.gz"
+                else
+                  for db in $DATABASES; do
+                    echo "[postgres] pg_dump $db"
+                    pg_dump --clean --if-exists -d "$db" | gzip -9 >"$STAGE/$db.sql.gz"
+                  done
+                fi
+
+                echo "[postgres] restic backup"
+                restic backup --host platform-postgres --tag postgres "$STAGE"
+                echo "[postgres] done"
+              EOT
+              ]
+
+              resources {
+                requests = { cpu = "50m", memory = "128Mi" }
+                limits   = { cpu = "500m", memory = "512Mi" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [kubernetes_job_v1.restic_init]
+}
+
+# ── MySQL dump CronJob ────────────────────────────────────────────────────
+
+resource "kubernetes_cron_job_v1" "mysql" {
+  for_each = local.mysql_set
+
+  metadata {
+    name      = "backup-mysql"
+    namespace = kubernetes_namespace_v1.backup["enabled"].metadata[0].name
+  }
+
+  spec {
+    schedule                      = var.schedule_mysql
+    concurrency_policy            = "Forbid"
+    successful_jobs_history_limit = 1
+    failed_jobs_history_limit     = 3
+    starting_deadline_seconds     = 300
+
+    job_template {
+      metadata {
+        labels = { "app.kubernetes.io/component" = "backup-mysql" }
+      }
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 86400
+
+        template {
+          metadata {
+            labels = { "app.kubernetes.io/component" = "backup-mysql" }
+          }
+          spec {
+            restart_policy = "OnFailure"
+
+            container {
+              name  = "dump"
+              image = var.image_alpine
+
+              env_from {
+                secret_ref {
+                  name = kubernetes_secret_v1.backup_creds["enabled"].metadata[0].name
+                }
+              }
+
+              env {
+                name  = "MYSQL_HOST"
+                value = var.mysql_host
+              }
+              env {
+                name = "MYSQL_PWD"
+                value_from {
+                  secret_key_ref {
+                    name = var.mysql_root_secret
+                    key  = "MYSQL_ROOT_PASSWORD"
+                  }
+                }
+              }
+              env {
+                name  = "DATABASES"
+                value = join(" ", var.mysql_databases)
+              }
+
+              command = ["sh", "-c"]
+              args = [<<-EOT
+                set -e
+                apk add --no-cache restic mariadb-client >/dev/null
+
+                STAGE=$(mktemp -d)
+                trap 'rm -rf "$STAGE"' EXIT
+
+                if [ -z "$DATABASES" ]; then
+                  echo "[mysql] DATABASES empty — mysqldump --all-databases"
+                  mysqldump -h "$MYSQL_HOST" -u root --single-transaction \
+                    --quick --all-databases | gzip -9 >"$STAGE/all.sql.gz"
+                else
+                  for db in $DATABASES; do
+                    echo "[mysql] mysqldump $db"
+                    mysqldump -h "$MYSQL_HOST" -u root --single-transaction \
+                      --quick "$db" | gzip -9 >"$STAGE/$db.sql.gz"
+                  done
+                fi
+
+                echo "[mysql] restic backup"
+                restic backup --host platform-mysql --tag mysql "$STAGE"
+                echo "[mysql] done"
+              EOT
+              ]
+
+              resources {
+                requests = { cpu = "50m", memory = "128Mi" }
+                limits   = { cpu = "500m", memory = "512Mi" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [kubernetes_job_v1.restic_init]
+}
+
+# ── Redis snapshot CronJob ────────────────────────────────────────────────
+
+resource "kubernetes_cron_job_v1" "redis" {
+  for_each = local.redis_set
+
+  metadata {
+    name      = "backup-redis"
+    namespace = kubernetes_namespace_v1.backup["enabled"].metadata[0].name
+  }
+
+  spec {
+    schedule                      = var.schedule_redis
+    concurrency_policy            = "Forbid"
+    successful_jobs_history_limit = 1
+    failed_jobs_history_limit     = 3
+    starting_deadline_seconds     = 300
+
+    job_template {
+      metadata {
+        labels = { "app.kubernetes.io/component" = "backup-redis" }
+      }
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 86400
+
+        template {
+          metadata {
+            labels = { "app.kubernetes.io/component" = "backup-redis" }
+          }
+          spec {
+            restart_policy = "OnFailure"
+
+            container {
+              name  = "snapshot"
+              image = var.image_alpine
+
+              env_from {
+                secret_ref {
+                  name = kubernetes_secret_v1.backup_creds["enabled"].metadata[0].name
+                }
+              }
+
+              env {
+                name  = "REDIS_HOST"
+                value = var.redis_host
+              }
+              env {
+                name = "REDIS_PASSWORD"
+                value_from {
+                  secret_key_ref {
+                    name = var.redis_default_secret
+                    key  = "REDIS_PASSWORD"
+                  }
+                }
+              }
+
+              command = ["sh", "-c"]
+              args = [<<-EOT
+                set -e
+                apk add --no-cache restic redis >/dev/null
+
+                STAGE=$(mktemp -d)
+                trap 'rm -rf "$STAGE"' EXIT
+
+                echo "[redis] redis-cli --rdb"
+                redis-cli -h "$REDIS_HOST" -a "$REDIS_PASSWORD" --no-auth-warning \
+                  --rdb "$STAGE/dump.rdb"
+
+                echo "[redis] restic backup"
+                restic backup --host platform-redis --tag redis "$STAGE"
+                echo "[redis] done"
+              EOT
+              ]
+
+              resources {
+                requests = { cpu = "50m", memory = "128Mi" }
+                limits   = { cpu = "500m", memory = "512Mi" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [kubernetes_job_v1.restic_init]
+}
+
+# ── Vault raft snapshot CronJob ───────────────────────────────────────────
+
+resource "kubernetes_cron_job_v1" "vault" {
+  for_each = local.vault_set
+
+  metadata {
+    name      = "backup-vault"
+    namespace = kubernetes_namespace_v1.backup["enabled"].metadata[0].name
+  }
+
+  spec {
+    schedule                      = var.schedule_vault
+    concurrency_policy            = "Forbid"
+    successful_jobs_history_limit = 1
+    failed_jobs_history_limit     = 3
+    starting_deadline_seconds     = 300
+
+    job_template {
+      metadata {
+        labels = { "app.kubernetes.io/component" = "backup-vault" }
+      }
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 86400
+
+        template {
+          metadata {
+            labels = { "app.kubernetes.io/component" = "backup-vault" }
+          }
+          spec {
+            restart_policy = "OnFailure"
+
+            container {
+              name  = "snapshot"
+              image = "hashicorp/vault:1.18.4"
+
+              env_from {
+                secret_ref {
+                  name = kubernetes_secret_v1.backup_creds["enabled"].metadata[0].name
+                }
+              }
+
+              env {
+                name  = "VAULT_ADDR"
+                value = var.vault_addr
+              }
+              env {
+                name = "VAULT_TOKEN"
+                value_from {
+                  secret_key_ref {
+                    name = var.vault_token_secret
+                    key  = "root-token"
+                  }
+                }
+              }
+
+              command = ["sh", "-c"]
+              args = [<<-EOT
+                set -e
+                # vault image is alpine-based; apk works.
+                apk add --no-cache restic >/dev/null
+
+                STAGE=$(mktemp -d)
+                trap 'rm -rf "$STAGE"' EXIT
+
+                echo "[vault] operator raft snapshot save"
+                vault operator raft snapshot save "$STAGE/vault.snap"
+
+                echo "[vault] restic backup"
+                restic backup --host platform-vault --tag vault "$STAGE"
+                echo "[vault] done"
+              EOT
+              ]
+
+              resources {
+                requests = { cpu = "50m", memory = "128Mi" }
+                limits   = { cpu = "500m", memory = "512Mi" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [kubernetes_job_v1.restic_init]
+}
+
+# ── PV tar CronJob ────────────────────────────────────────────────────────
+
+resource "kubernetes_cron_job_v1" "pv" {
+  for_each = local.pv_set
+
+  metadata {
+    name      = "backup-pv"
+    namespace = kubernetes_namespace_v1.backup["enabled"].metadata[0].name
+  }
+
+  spec {
+    schedule                      = var.schedule_pv
+    concurrency_policy            = "Forbid"
+    successful_jobs_history_limit = 1
+    failed_jobs_history_limit     = 3
+    starting_deadline_seconds     = 600
+
+    job_template {
+      metadata {
+        labels = { "app.kubernetes.io/component" = "backup-pv" }
+      }
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 86400
+
+        template {
+          metadata {
+            labels = { "app.kubernetes.io/component" = "backup-pv" }
+          }
+          spec {
+            restart_policy = "OnFailure"
+            node_selector  = length(var.pv_node_selector) > 0 ? var.pv_node_selector : null
+
+            dynamic "toleration" {
+              for_each = var.pv_tolerations
+              content {
+                key                = toleration.value.key
+                operator           = toleration.value.operator
+                value              = toleration.value.value
+                effect             = toleration.value.effect
+                toleration_seconds = toleration.value.toleration_seconds
+              }
+            }
+
+            container {
+              name  = "tar"
+              image = var.image_alpine
+
+              env_from {
+                secret_ref {
+                  name = kubernetes_secret_v1.backup_creds["enabled"].metadata[0].name
+                }
+              }
+
+              env {
+                name  = "PV_NAMES"
+                value = join(",", [for p in var.pv_paths : p.name])
+              }
+              env {
+                name  = "PV_PATHS"
+                value = join(",", [for p in var.pv_paths : p.path])
+              }
+
+              security_context {
+                # Tar of host-mount paths needs root to read every
+                # file regardless of UIDs the apps run as.
+                run_as_user                = 0
+                allow_privilege_escalation = false
+                capabilities {
+                  drop = ["ALL"]
+                  add  = ["DAC_READ_SEARCH"]
+                }
+              }
+
+              command = ["sh", "-c"]
+              args = [<<-EOT
+                set -e
+                apk add --no-cache restic >/dev/null
+
+                STAGE=$(mktemp -d)
+                trap 'rm -rf "$STAGE"' EXIT
+
+                IFS=','; set -- $PV_NAMES
+                NAMES=("$@")
+                set -- $PV_PATHS
+                PATHS=("$@")
+                IFS=' '
+
+                i=0
+                while [ $i -lt $${#NAMES[@]} ]; do
+                  name="$${NAMES[$i]}"
+                  path="$${PATHS[$i]}"
+                  echo "[pv] tar $name from $path"
+                  tar -czf "$STAGE/$name.tar.gz" -C "$path" .
+                  i=$((i+1))
+                done
+
+                echo "[pv] restic backup"
+                restic backup --host platform-pv --tag pv "$STAGE"
+                echo "[pv] done"
+              EOT
+              ]
+
+              dynamic "volume_mount" {
+                for_each = var.pv_paths
+                content {
+                  name       = "pv-${replace(volume_mount.value.name, "/", "-")}"
+                  mount_path = volume_mount.value.path
+                  read_only  = true
+                }
+              }
+
+              resources {
+                requests = { cpu = "50m", memory = "128Mi" }
+                limits   = { cpu = "500m", memory = "512Mi" }
+              }
+            }
+
+            dynamic "volume" {
+              for_each = var.pv_paths
+              content {
+                name = "pv-${replace(volume.value.name, "/", "-")}"
+                host_path {
+                  path = volume.value.path
+                  type = "Directory"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [kubernetes_job_v1.restic_init]
+}
+
+# ── Retention CronJob ─────────────────────────────────────────────────────
+
+resource "kubernetes_cron_job_v1" "prune" {
+  for_each = local.instances
+
+  metadata {
+    name      = "backup-prune"
+    namespace = kubernetes_namespace_v1.backup["enabled"].metadata[0].name
+  }
+
+  spec {
+    schedule                      = var.schedule_prune
+    concurrency_policy            = "Forbid"
+    successful_jobs_history_limit = 1
+    failed_jobs_history_limit     = 3
+    starting_deadline_seconds     = 600
+
+    job_template {
+      metadata {
+        labels = { "app.kubernetes.io/component" = "backup-prune" }
+      }
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 86400
+
+        template {
+          metadata {
+            labels = { "app.kubernetes.io/component" = "backup-prune" }
+          }
+          spec {
+            restart_policy = "OnFailure"
+
+            container {
+              name  = "prune"
+              image = var.image_alpine
+
+              env_from {
+                secret_ref {
+                  name = kubernetes_secret_v1.backup_creds["enabled"].metadata[0].name
+                }
+              }
+
+              env {
+                name  = "KEEP_DAILY"
+                value = tostring(var.retention_keep_daily)
+              }
+              env {
+                name  = "KEEP_WEEKLY"
+                value = tostring(var.retention_keep_weekly)
+              }
+              env {
+                name  = "KEEP_MONTHLY"
+                value = tostring(var.retention_keep_monthly)
+              }
+
+              command = ["sh", "-c"]
+              args = [<<-EOT
+                set -e
+                apk add --no-cache restic >/dev/null
+                echo "[prune] forget --keep-daily=$KEEP_DAILY --keep-weekly=$KEEP_WEEKLY --keep-monthly=$KEEP_MONTHLY"
+                restic forget --group-by host,tags --keep-daily "$KEEP_DAILY" \
+                  --keep-weekly "$KEEP_WEEKLY" --keep-monthly "$KEEP_MONTHLY" --prune
+                echo "[prune] done"
+              EOT
+              ]
+
+              resources {
+                requests = { cpu = "50m", memory = "128Mi" }
+                limits   = { cpu = "500m", memory = "512Mi" }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [kubernetes_job_v1.restic_init]
+}
+
+# ── Outputs ───────────────────────────────────────────────────────────────
+
+output "namespace" {
+  value       = var.enabled ? var.namespace : null
+  description = "Backups namespace, or null when disabled."
+}
+
+output "passphrase" {
+  value       = local.passphrase
+  sensitive   = true
+  description = "restic repository passphrase. Pull with `terraform output -raw backup_passphrase` (root output) and stash in a password manager — losing it bricks every backup."
+}
+
+output "repository_url" {
+  value       = var.enabled ? local.repository_url : null
+  description = "restic repository URL (`s3:<endpoint>/<bucket>`). Used by the wrapper-side `./tf backup-config` command and by every restore-script."
+}

--- a/modules/backup/scripts/README.md
+++ b/modules/backup/scripts/README.md
@@ -1,41 +1,239 @@
-# Restore scripts
+# Platform backups — operator manual
 
-These ride along inside the restic repository under tag `scripts`. A
-disaster-recovery operator with the passphrase + B2 credentials can
-pull them back with:
+Backups + restore for the platform's stateful tier. One restic
+repository on a dedicated B2 bucket carries every backup target;
+encryption is built in (AES-256 + Poly1305 with a passphrase).
+This document is the canonical operator guide; it ships in the
+restic repo under tag `scripts` so disaster-recovery operators
+can `restic restore` it back even after losing the local repo
+clone.
 
-```
-restic -r s3:<endpoint>/<bucket> -p <passphrase> restore latest \
-  --tag scripts --target /tmp/restore
-ls /tmp/restore/scripts/
-```
+## What gets backed up and when
 
-Each script wraps a `restic restore` invocation for a specific target
-plus the post-restore steps (psql import, vault snapshot apply, kubectl
-cp into a running pod, etc). Run after a fresh `./tf bootstrap-k3s` +
-`./tf apply` brings the cluster back up empty.
+Default schedules in UTC. Tweak via `services.backup.schedule_*`
+in `config/platform.yaml`. Each CronJob runs in the `backups`
+namespace and pushes to one shared restic repo, with a
+distinguishing `--tag` and `--host`.
 
-| Script | Restores |
-| --- | --- |
-| `restore-postgres.sh <db> <snapshot-id>` | One Postgres database from `pg_dump` output |
-| `restore-mysql.sh <db> <snapshot-id>` | One MySQL database from `mysqldump` output |
-| `restore-redis.sh <snapshot-id>` | Redis RDB snapshot via `kubectl cp` + restart |
-| `restore-vault.sh <snapshot-id>` | Vault raft state via `vault operator raft snapshot restore` |
-| `restore-pv.sh <pv-name> <snapshot-id>` | One hostPath PV directory by name |
-| `restore-config.sh <snapshot-id>` | Operator's gitignored `.env` + `config/` to local disk |
+| Target          | Default cron         | Tag               | Source                                          |
+| ---             | ---                  | ---               | ---                                             |
+| Postgres dumps  | `0 3 * * *`  daily   | `postgres`        | per-DB `pg_dump` (or `pg_dumpall` if list empty) |
+| MySQL dumps     | `15 3 * * *` daily   | `mysql`           | per-DB `mariadb-dump` (or `--all-databases`)     |
+| Redis snapshot  | `30 3 * * *` daily   | `redis`           | `redis-cli --rdb`                                |
+| Vault raft      | `45 3 * * *` daily   | `vault`           | `vault operator raft snapshot save`              |
+| hostPath PVs    | `0 4 * * 0`  weekly  | `pv`              | `tar -czf` per `services.backup.pv_paths` entry  |
+| Retention prune | `0 5 * * 0`  weekly  | —                 | `restic forget --prune`                          |
+| Operator config | `0 2 * * *`  daily   | `operator-config` | `./tf backup-config` from operator's machine     |
+| Restore scripts | one-shot, on apply   | `scripts`         | this directory                                   |
 
-`<snapshot-id>` defaults to `latest` for each tag if omitted. Use
-`restic snapshots --tag <tag>` to list what's available.
+Retention defaults: `--keep-daily 7 --keep-weekly 4
+--keep-monthly 6` per (host, tag). The prune CronJob applies it
+weekly.
 
-## Bootstrap order after total loss
+## Initial setup
 
-1. Fresh cluster — `./tf bootstrap-k3s`
-2. Pull operator config: `restore-config.sh latest`
-3. `./tf apply` (with restored `.env` + `config/`)
-4. Once Postgres/MySQL/Vault pods are Ready:
-   - `restore-postgres.sh <db> latest` for each DB
-   - `restore-mysql.sh <db> latest` for each DB
-   - `restore-vault.sh latest`
-5. Once mail/wordpress pods exist:
-   - Stop pod (scale to 0), `restore-pv.sh <name> latest`, scale back up
-6. Verify with smoke tests
+1. Create a B2 bucket dedicated to backups. **Must be a different
+   bucket from the one the Terraform S3 backend uses for
+   tfstate** — a tfstate-key compromise must not delete or
+   overwrite encrypted backups.
+2. Create a B2 application key scoped to that single bucket. The
+   key needs `listBuckets`, `listFiles`, `readFiles`,
+   `writeFiles` at minimum. Skip `deleteFiles` if you want
+   write-once immutability — but then `restic forget --prune`
+   won't be able to expire old snapshots and the bucket grows
+   forever.
+3. Add to the operator's gitignored `.env`:
+
+       TF_VAR_backup_b2_bucket=<bucket-name>
+       TF_VAR_backup_b2_endpoint=https://s3.<region>.backblazeb2.com
+       TF_VAR_backup_b2_access_key_id=<key-id>
+       TF_VAR_backup_b2_secret_access_key=<key-secret>
+
+4. Flip on in `config/platform.yaml`:
+
+       services:
+         backup:
+           enabled: true
+           postgres_databases: [<db1>, <db2>, ...]
+           mysql_databases: []                  # empty = all
+           pv_paths:
+             - { name: <stable-id>, path: <absolute-host-path> }
+           pv_node_selector:
+             <key>: <value>                     # for hostPath PV node-pinning
+
+5. `./tf apply` — creates the namespace, restic init Job (uploads
+   restore scripts as `tag=scripts`), 6 CronJobs (5 backup + 1
+   prune).
+
+6. **Stash the passphrase in a password manager:**
+
+       ./tf output -raw backup_passphrase
+
+   Losing it bricks every encrypted snapshot forever; restic
+   AES-256 has no recovery path.
+
+7. Install `restic` locally so the operator-side
+   `./tf backup-config` works (uses your distro's package
+   manager, no special build needed).
+
+8. Add a host-side cron entry to capture operator config nightly.
+   Absolute path matters when cron runs without an interactive
+   shell:
+
+       0 2 * * * /home/<user>/platform/tf backup-config >> \
+         /home/<user>/platform/.backup-config.log 2>&1
+
+## Health checks
+
+| Want to know                   | Command                                                                                       |
+| ---                            | ---                                                                                           |
+| Is each CronJob succeeding?    | `kubectl -n backups get jobs --sort-by=.metadata.creationTimestamp | tail -10`               |
+| Last successful run per target | `kubectl -n backups get cronjobs`                                                              |
+| Any in-flight failure logs     | `kubectl -n backups logs -l app.kubernetes.io/component=backup-postgres --tail=30`            |
+| List snapshots in restic       | `RESTIC_REPOSITORY=$(./tf output -raw backup_repository_url \| tail -1) restic snapshots`     |
+| Total bytes stored             | `restic stats --mode raw-data`                                                                 |
+
+The wrapper writes `Loading variables…` to stdout, so `./tf
+output -raw …` needs `| tail -1` when piping into another tool.
+
+## Manual one-shot run (skip the schedule)
+
+Trigger any CronJob immediately by spawning a one-off Job:
+
+    kubectl -n backups create job manual-postgres --from=cronjob/backup-postgres
+    kubectl -n backups logs -l job-name=manual-postgres -f
+
+Same shape for `backup-mysql` / `backup-redis` / `backup-vault` /
+`backup-pv` / `backup-prune`. Useful to verify a config change
+without waiting until next scheduled fire.
+
+## Restoring from a snapshot
+
+Every restore script reads `RESTIC_REPOSITORY`, `RESTIC_PASSWORD`,
+`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` from the environment.
+Set them once at the top of the operator's session:
+
+    export RESTIC_REPOSITORY=$(./tf output -raw backup_repository_url | tail -1)
+    export RESTIC_PASSWORD=$(./tf output -raw backup_passphrase | tail -1)
+    source .env
+    export AWS_ACCESS_KEY_ID=$TF_VAR_backup_b2_access_key_id
+    export AWS_SECRET_ACCESS_KEY=$TF_VAR_backup_b2_secret_access_key
+
+| Script                                  | Restores                                                  |
+| ---                                     | ---                                                       |
+| `restore-postgres.sh <db> [snapshot]`   | One Postgres database from `pg_dump` output              |
+| `restore-mysql.sh <db> [snapshot]`      | One MySQL database from `mariadb-dump` output            |
+| `restore-redis.sh [snapshot]`           | Redis RDB via `kubectl cp` + `rollout restart sts/redis` |
+| `restore-vault.sh [snapshot]`           | Vault raft via `vault operator raft snapshot restore`    |
+| `restore-pv.sh <name> [snapshot]`       | One hostPath PV directory by name                        |
+| `restore-config.sh [snapshot] [target]` | Operator's `.env` + `config/` to local disk              |
+
+`<snapshot>` defaults to `latest` for each tag. `restic snapshots
+--tag <tag>` lists what's available; `restic snapshots --tag <tag>
+--latest 1` shows just the most recent.
+
+For `restore-pv.sh`, scale the consuming workload to 0 first to
+avoid corruption from a live untar:
+
+    kubectl -n <ns> scale deploy/<workload> --replicas=0
+    PV_TARGET_PATH=<absolute-host-path> restore-pv.sh <name> latest
+    kubectl -n <ns> scale deploy/<workload> --replicas=1
+
+## Sanity-check a snapshot without touching anything live
+
+Restore to a tmp dir, inspect, throw away. Never imports
+anything; the live cluster never sees the restored bytes.
+
+    mkdir -p /tmp/r
+    for tag in postgres mysql redis vault pv operator-config; do
+      rm -rf /tmp/r/$tag; mkdir -p /tmp/r/$tag
+      restic restore latest --tag $tag --target /tmp/r/$tag
+      echo "--- $tag ---"
+      find /tmp/r/$tag -type f -printf '%s %p\n' | sort -nr | head -8
+    done
+    rm -rf /tmp/r
+
+Empty / absurdly tiny output for any target ⇒ that target's
+backup is broken; check the most recent CronJob log.
+
+## Total-loss disaster recovery
+
+Cluster + node disk + local repo clone all gone. You have:
+
+  - the restic passphrase (from your password manager)
+  - the B2 access key id + secret (from your password manager
+    or B2 console)
+  - the bucket name + endpoint (from B2 console)
+
+Steps:
+
+1. Pull the restore scripts back.
+
+       export RESTIC_REPOSITORY=s3:<endpoint>/<bucket>
+       export RESTIC_PASSWORD=<passphrase>
+       export AWS_ACCESS_KEY_ID=<key-id>
+       export AWS_SECRET_ACCESS_KEY=<key-secret>
+       restic snapshots --tag scripts          # confirm repo opens
+       mkdir -p /tmp/scripts
+       restic restore latest --tag scripts --target /tmp/scripts
+
+   `/tmp/scripts/` now has every `restore-*.sh` plus this README.
+   No git clone needed.
+
+2. Pull operator config back. Lands `.env`, `config/`, and the
+   most recent `terraform.tfstate.snapshot.json` into the target
+   directory.
+
+       /tmp/scripts/restore-config.sh latest ~/platform-restored
+
+   `git clone <repo>` to the same target if the platform git
+   tree is also gone — operator config goes on top, no
+   conflicts (the gitignored files don't overlap with the
+   tracked ones).
+
+3. Bring up a fresh cluster.
+
+       cd ~/platform-restored
+       ./tf bootstrap-k3s
+
+4. `./tf apply` — recreates the empty Postgres / MySQL / Redis /
+   Vault / Stalwart shells.
+
+5. Restore database data into the new pods, in order:
+
+       /tmp/scripts/restore-postgres.sh <db> latest    # for each
+       /tmp/scripts/restore-mysql.sh <db> latest       # for each
+       /tmp/scripts/restore-redis.sh latest
+       /tmp/scripts/restore-vault.sh latest
+
+6. For each PV target listed in `services.backup.pv_paths`, scale
+   its consumer to 0, restore the tarball, scale back up:
+
+       kubectl -n <ns> scale deploy/<workload> --replicas=0
+       PV_TARGET_PATH=<path> /tmp/scripts/restore-pv.sh <name> latest
+       kubectl -n <ns> scale deploy/<workload> --replicas=1
+
+7. Smoke-test the public surface (sign in, send a test email,
+   open one tenant site). Verify `kubectl -n backups get
+   cronjobs` is healthy so future backups land in the recreated
+   repository.
+
+## Things to know
+
+- **Live-tar of stateful PV directories** trades a tiny window
+  of in-flight writes against zero downtime on the source
+  workload. RocksDB / SQLite / etc. that ship a write-ahead log
+  recover cleanly to the most recent fsync; cooperative apps
+  with a snapshot API (Vault) are backed up via that API
+  instead.
+- **`./tf backup-config` runs `terraform state pull` first** and
+  bundles the JSON snapshot into the `operator-config` tag. Same
+  encryption, separate B2 key. Disaster recovery doesn't have to
+  assume the tfstate bucket survived.
+- **Single passphrase** for the whole repo — losing it is total
+  loss. Per-target passphrases are an option restic supports but
+  this platform doesn't use; the trade-off is operator
+  convenience over leak blast radius.
+- **No automatic restore drill.** Verify periodically with the
+  sanity-check section above; "not tested" backups are the
+  classic failure mode.

--- a/modules/backup/scripts/README.md
+++ b/modules/backup/scripts/README.md
@@ -1,0 +1,41 @@
+# Restore scripts
+
+These ride along inside the restic repository under tag `scripts`. A
+disaster-recovery operator with the passphrase + B2 credentials can
+pull them back with:
+
+```
+restic -r s3:<endpoint>/<bucket> -p <passphrase> restore latest \
+  --tag scripts --target /tmp/restore
+ls /tmp/restore/scripts/
+```
+
+Each script wraps a `restic restore` invocation for a specific target
+plus the post-restore steps (psql import, vault snapshot apply, kubectl
+cp into a running pod, etc). Run after a fresh `./tf bootstrap-k3s` +
+`./tf apply` brings the cluster back up empty.
+
+| Script | Restores |
+| --- | --- |
+| `restore-postgres.sh <db> <snapshot-id>` | One Postgres database from `pg_dump` output |
+| `restore-mysql.sh <db> <snapshot-id>` | One MySQL database from `mysqldump` output |
+| `restore-redis.sh <snapshot-id>` | Redis RDB snapshot via `kubectl cp` + restart |
+| `restore-vault.sh <snapshot-id>` | Vault raft state via `vault operator raft snapshot restore` |
+| `restore-pv.sh <pv-name> <snapshot-id>` | One hostPath PV directory by name |
+| `restore-config.sh <snapshot-id>` | Operator's gitignored `.env` + `config/` to local disk |
+
+`<snapshot-id>` defaults to `latest` for each tag if omitted. Use
+`restic snapshots --tag <tag>` to list what's available.
+
+## Bootstrap order after total loss
+
+1. Fresh cluster — `./tf bootstrap-k3s`
+2. Pull operator config: `restore-config.sh latest`
+3. `./tf apply` (with restored `.env` + `config/`)
+4. Once Postgres/MySQL/Vault pods are Ready:
+   - `restore-postgres.sh <db> latest` for each DB
+   - `restore-mysql.sh <db> latest` for each DB
+   - `restore-vault.sh latest`
+5. Once mail/wordpress pods exist:
+   - Stop pod (scale to 0), `restore-pv.sh <name> latest`, scale back up
+6. Verify with smoke tests

--- a/modules/backup/scripts/restore-config.sh
+++ b/modules/backup/scripts/restore-config.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Restore the operator's gitignored configuration to the local
+# disk after a clone-from-scratch / disaster recovery.
+#
+# Usage: restore-config.sh [snapshot_id] [target_dir]
+#
+# Env:
+#   RESTIC_REPOSITORY / RESTIC_PASSWORD / AWS_ACCESS_KEY_ID /
+#   AWS_SECRET_ACCESS_KEY — restic + B2 creds
+#
+# Pulls every file uploaded under `tag=operator-config` (i.e.
+# `.env`, `config/platform.yaml`, `config/domains/*.yaml`,
+# anything else the operator chose to capture via
+# `./tf backup-config`). Default target is the current working
+# directory; pass `~/platform` (or wherever) explicitly to land
+# the files in the right repo clone.
+set -euo pipefail
+
+SNAP="${1:-latest}"
+TARGET="${2:-.}"
+
+echo "[config] restic restore $SNAP --tag operator-config -> $TARGET"
+restic restore "$SNAP" --tag operator-config --target "$TARGET"
+
+echo "[config] done — review files in $TARGET before running ./tf apply"

--- a/modules/backup/scripts/restore-mysql.sh
+++ b/modules/backup/scripts/restore-mysql.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Restore one MySQL database from a restic snapshot.
+#
+# Usage: restore-mysql.sh <db_name> [snapshot_id]
+#
+# Env:
+#   RESTIC_REPOSITORY / RESTIC_PASSWORD / AWS_ACCESS_KEY_ID /
+#   AWS_SECRET_ACCESS_KEY — restic + B2 creds
+#   MYSQL_HOST            — in-cluster MySQL host
+#   MYSQL_PWD             — root password (env name `mysql` reads)
+set -euo pipefail
+
+DB="${1:?usage: restore-mysql.sh <db_name> [snapshot_id]}"
+SNAP="${2:-latest}"
+
+STAGE=$(mktemp -d)
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "[mysql] restic restore $SNAP --tag mysql"
+restic restore "$SNAP" --tag mysql --target "$STAGE" \
+  --include "*/$DB.sql.gz"
+
+DUMP=$(find "$STAGE" -name "$DB.sql.gz" | head -1)
+if [ -z "$DUMP" ]; then
+  echo "[mysql] no dump found for db=$DB in snapshot $SNAP" >&2
+  exit 2
+fi
+
+echo "[mysql] piping dump into mysql"
+gunzip -c "$DUMP" | mysql -h "$MYSQL_HOST" -u root "$DB"
+
+echo "[mysql] restored $DB from $SNAP"

--- a/modules/backup/scripts/restore-postgres.sh
+++ b/modules/backup/scripts/restore-postgres.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Restore one Postgres database from a restic snapshot.
+#
+# Usage: restore-postgres.sh <db_name> [snapshot_id]
+#
+# Env (set on caller side, NOT hardcoded):
+#   RESTIC_REPOSITORY     — s3:<endpoint>/<bucket>
+#   RESTIC_PASSWORD       — repo passphrase
+#   AWS_ACCESS_KEY_ID     — B2 key id
+#   AWS_SECRET_ACCESS_KEY — B2 key secret
+#   PGHOST                — in-cluster Postgres host (e.g. via kubectl port-forward)
+#   PGUSER                — postgres
+#   PGPASSWORD            — superuser password
+#
+# Flow:
+#   1. Pull the named DB's `.sql.gz` from the latest (or named)
+#      `tag=postgres` snapshot.
+#   2. `psql --set ON_ERROR_STOP=1` the dump back. The dump uses
+#      `--clean --if-exists`, so it's safe to run against a DB
+#      that already has the schema.
+set -euo pipefail
+
+DB="${1:?usage: restore-postgres.sh <db_name> [snapshot_id]}"
+SNAP="${2:-latest}"
+
+STAGE=$(mktemp -d)
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "[postgres] restic restore $SNAP --tag postgres"
+restic restore "$SNAP" --tag postgres --target "$STAGE" \
+  --include "*/$DB.sql.gz"
+
+DUMP=$(find "$STAGE" -name "$DB.sql.gz" | head -1)
+if [ -z "$DUMP" ]; then
+  echo "[postgres] no dump found for db=$DB in snapshot $SNAP" >&2
+  exit 2
+fi
+
+echo "[postgres] piping dump into psql"
+gunzip -c "$DUMP" | psql --set ON_ERROR_STOP=1 -d postgres
+
+echo "[postgres] restored $DB from $SNAP"

--- a/modules/backup/scripts/restore-pv.sh
+++ b/modules/backup/scripts/restore-pv.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Restore one hostPath PV directory from a restic snapshot.
+#
+# Usage: restore-pv.sh <pv_name> [snapshot_id]
+#
+# Env:
+#   RESTIC_REPOSITORY / RESTIC_PASSWORD / AWS_ACCESS_KEY_ID /
+#   AWS_SECRET_ACCESS_KEY — restic + B2 creds
+#   PV_TARGET_PATH        — absolute host directory to extract into
+#                           (e.g. /data/vol/platform/stalwart/data)
+#
+# The host path MUST already exist (TF re-creates it on apply via
+# the matching `kubernetes_persistent_volume_v1.<name>` resource).
+# This script ASSUMES the consuming pod is scaled to 0 — running
+# Stalwart / WordPress / etc on top of an in-progress untar will
+# corrupt the new state. Operator should:
+#
+#   kubectl -n <ns> scale deploy/<workload> --replicas=0
+#   restore-pv.sh <name> <snapshot>
+#   kubectl -n <ns> scale deploy/<workload> --replicas=1
+set -euo pipefail
+
+NAME="${1:?usage: restore-pv.sh <pv_name> [snapshot_id]}"
+SNAP="${2:-latest}"
+TARGET="${PV_TARGET_PATH:?PV_TARGET_PATH must be set to the host directory}"
+
+STAGE=$(mktemp -d)
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "[pv] restic restore $SNAP --tag pv"
+restic restore "$SNAP" --tag pv --target "$STAGE" \
+  --include "*/$NAME.tar.gz"
+
+TARBALL=$(find "$STAGE" -name "$NAME.tar.gz" | head -1)
+if [ -z "$TARBALL" ]; then
+  echo "[pv] no $NAME.tar.gz in snapshot $SNAP" >&2
+  exit 2
+fi
+
+echo "[pv] wiping $TARGET and untarring"
+rm -rf "$TARGET"/*
+tar -xzf "$TARBALL" -C "$TARGET"
+
+echo "[pv] restored $NAME into $TARGET"

--- a/modules/backup/scripts/restore-redis.sh
+++ b/modules/backup/scripts/restore-redis.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Restore Redis state from a restic snapshot.
+#
+# Usage: restore-redis.sh [snapshot_id]
+#
+# Env:
+#   RESTIC_REPOSITORY / RESTIC_PASSWORD / AWS_ACCESS_KEY_ID /
+#   AWS_SECRET_ACCESS_KEY — restic + B2 creds
+#   REDIS_NS    — namespace where the redis StatefulSet lives (default: platform)
+#   REDIS_POD   — pod name (default: redis-0)
+#
+# Redis loads its RDB at startup. The flow is:
+#   1. Pull `dump.rdb` from the snapshot.
+#   2. `kubectl cp` the file into the redis pod's data dir,
+#      replacing whatever is there.
+#   3. `kubectl rollout restart` the StatefulSet so redis re-reads
+#      the RDB on next boot.
+#
+# That implies the operator is OK with whatever in-memory state
+# the running redis has (sessions, BullMQ queues, …) being
+# overwritten by the RDB content.
+set -euo pipefail
+
+SNAP="${1:-latest}"
+NS="${REDIS_NS:-platform}"
+POD="${REDIS_POD:-redis-0}"
+
+STAGE=$(mktemp -d)
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "[redis] restic restore $SNAP --tag redis"
+restic restore "$SNAP" --tag redis --target "$STAGE"
+RDB=$(find "$STAGE" -name dump.rdb | head -1)
+if [ -z "$RDB" ]; then
+  echo "[redis] no dump.rdb in snapshot $SNAP" >&2
+  exit 2
+fi
+
+echo "[redis] kubectl cp -> $NS/$POD:/data/dump.rdb"
+kubectl -n "$NS" cp "$RDB" "$POD:/data/dump.rdb"
+
+echo "[redis] kubectl rollout restart sts/redis"
+kubectl -n "$NS" rollout restart sts/redis
+kubectl -n "$NS" rollout status sts/redis --timeout=180s
+
+echo "[redis] restored from $SNAP"

--- a/modules/backup/scripts/restore-vault.sh
+++ b/modules/backup/scripts/restore-vault.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Restore Vault raft state from a restic snapshot.
+#
+# Usage: restore-vault.sh [snapshot_id]
+#
+# Env:
+#   RESTIC_REPOSITORY / RESTIC_PASSWORD / AWS_ACCESS_KEY_ID /
+#   AWS_SECRET_ACCESS_KEY — restic + B2 creds
+#   VAULT_ADDR  — public Vault URL (https://secrets.<domain>)
+#   VAULT_TOKEN — root token
+#
+# The destination Vault must be initialised + unsealed. After
+# `vault operator raft snapshot restore`, the recovered raft state
+# REPLACES whatever the running Vault had — every secret + auth
+# method + policy + token reverts to the snapshot point. That
+# usually means re-pasting the root token from the password
+# manager or the bootstrap Secret.
+set -euo pipefail
+
+SNAP="${1:-latest}"
+
+STAGE=$(mktemp -d)
+trap 'rm -rf "$STAGE"' EXIT
+
+echo "[vault] restic restore $SNAP --tag vault"
+restic restore "$SNAP" --tag vault --target "$STAGE"
+SNAP_FILE=$(find "$STAGE" -name vault.snap | head -1)
+if [ -z "$SNAP_FILE" ]; then
+  echo "[vault] no vault.snap in snapshot $SNAP" >&2
+  exit 2
+fi
+
+echo "[vault] operator raft snapshot restore (force)"
+vault operator raft snapshot restore -force "$SNAP_FILE"
+
+echo "[vault] restored from $SNAP — re-paste root token if it changed"

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -303,3 +303,8 @@ output "root_password" {
   sensitive   = true
   description = "MySQL root password (also in the mysql-root Secret), or null if the module is disabled."
 }
+
+output "root_secret_name" {
+  value       = one([for s in kubernetes_secret_v1.mysql_root : s.metadata[0].name])
+  description = "Name of the Secret carrying MYSQL_ROOT_PASSWORD. Consumed by the backup module's cross-namespace mirror Secret. Null when disabled."
+}

--- a/tf
+++ b/tf
@@ -527,6 +527,45 @@ case "${SUBCOMMAND}" in
     purge_cloudflare_tunnel "${CLOUDFLARE_TUNNEL_NAME}"
     ;;
 
+  backup-config)
+    # Push the operator's gitignored configuration (.env, the
+    # config/ directory) to the same restic repository the
+    # in-cluster CronJobs use, under tag `operator-config`. The
+    # repo URL + passphrase + B2 credentials are sourced from
+    # `terraform output` (which already has them after the first
+    # apply that brought the backup module up). Idempotent —
+    # restic dedup makes a no-op push when nothing changed.
+    set +x
+    : "${TF_VAR_backup_b2_access_key_id:?TF_VAR_backup_b2_access_key_id must be set in .env}"
+    : "${TF_VAR_backup_b2_secret_access_key:?TF_VAR_backup_b2_secret_access_key must be set in .env}"
+    if ! command -v restic >/dev/null 2>&1; then
+      echo "tf: restic CLI not found — install via your distro's package manager (apt-get install restic / brew install restic)" >&2
+      exit 1
+    fi
+    REPO_URL="$(terraform output -raw backup_repository_url 2>/dev/null)"
+    PASSPHRASE="$(terraform output -raw backup_passphrase 2>/dev/null)"
+    if [[ -z "${REPO_URL}" || -z "${PASSPHRASE}" ]]; then
+      echo "tf: backup outputs not populated — run ./tf apply with services.backup.enabled = true first" >&2
+      exit 1
+    fi
+    export RESTIC_REPOSITORY="${REPO_URL}"
+    export RESTIC_PASSWORD="${PASSPHRASE}"
+    export AWS_ACCESS_KEY_ID="${TF_VAR_backup_b2_access_key_id}"
+    export AWS_SECRET_ACCESS_KEY="${TF_VAR_backup_b2_secret_access_key}"
+    cd "${SCRIPT_DIR}"
+    TARGETS=(.env config)
+    EXISTING=()
+    for t in "${TARGETS[@]}"; do
+      if [[ -e "$t" ]]; then EXISTING+=("$t"); fi
+    done
+    if [[ ${#EXISTING[@]} -eq 0 ]]; then
+      echo "tf: nothing to back up (.env / config absent)" >&2
+      exit 1
+    fi
+    echo "tf: restic backup --tag operator-config ${EXISTING[*]}"
+    restic backup --tag operator-config --host platform-operator-config "${EXISTING[@]}"
+    ;;
+
   bootstrap-minikube)
     shift
     preflight_config_files

--- a/tf
+++ b/tf
@@ -542,24 +542,46 @@ case "${SUBCOMMAND}" in
       echo "tf: restic CLI not found — install via your distro's package manager (apt-get install restic / brew install restic)" >&2
       exit 1
     fi
+    cd "${SCRIPT_DIR}"
+    # Step 1: pull TF state with the existing tfstate-bucket
+    # credentials (whichever AWS_ACCESS_KEY_ID / SECRET the
+    # operator's `.env` is loading for the S3 backend). The state
+    # already lives in the B2 tfstate bucket, but backing the JSON
+    # dump up via restic into the *backup* bucket gives a third
+    # copy under a separate B2 key — full disaster recovery
+    # doesn't have to assume the tfstate key/bucket survived.
+    SNAPSHOT="${SCRIPT_DIR}/terraform.tfstate.snapshot.json"
+    cleanup_snapshot() { rm -f "${SNAPSHOT}"; }
+    trap cleanup_snapshot EXIT
+    echo "tf: terraform state pull -> $(basename "${SNAPSHOT}")"
+    terraform state pull > "${SNAPSHOT}"
+
+    # Step 2: pull restic repo URL + passphrase from outputs.
     REPO_URL="$(terraform output -raw backup_repository_url 2>/dev/null)"
     PASSPHRASE="$(terraform output -raw backup_passphrase 2>/dev/null)"
     if [[ -z "${REPO_URL}" || -z "${PASSPHRASE}" ]]; then
       echo "tf: backup outputs not populated — run ./tf apply with services.backup.enabled = true first" >&2
       exit 1
     fi
+
+    # Step 3: switch AWS_* env to the backup-bucket key for the
+    # restic push. Done AFTER `terraform state pull` so the state
+    # call still uses the tfstate-bucket key. Per the
+    # `services.backup` design, the two keys are intentionally
+    # separate — a tfstate-key compromise must not delete or
+    # overwrite encrypted backups.
     export RESTIC_REPOSITORY="${REPO_URL}"
     export RESTIC_PASSWORD="${PASSPHRASE}"
     export AWS_ACCESS_KEY_ID="${TF_VAR_backup_b2_access_key_id}"
     export AWS_SECRET_ACCESS_KEY="${TF_VAR_backup_b2_secret_access_key}"
-    cd "${SCRIPT_DIR}"
-    TARGETS=(.env config)
+
+    TARGETS=(.env config "$(basename "${SNAPSHOT}")")
     EXISTING=()
     for t in "${TARGETS[@]}"; do
       if [[ -e "$t" ]]; then EXISTING+=("$t"); fi
     done
     if [[ ${#EXISTING[@]} -eq 0 ]]; then
-      echo "tf: nothing to back up (.env / config absent)" >&2
+      echo "tf: nothing to back up (.env / config / state absent)" >&2
       exit 1
     fi
     echo "tf: restic backup --tag operator-config ${EXISTING[*]}"


### PR DESCRIPTION
Foundation for cluster + operator-side backups. Off by default; flip on via `services.backup.enabled: true` plus `TF_VAR_backup_b2_*` keys in the gitignored `.env`.

See commit message for the full architecture write-up. Highlights:

- Single restic repo on a dedicated B2 bucket (separate from tfstate bucket — blast radius isolation)
- Single passphrase, surfaced as a sensitive output for the operator to stash in a password manager
- 6 CronJobs (postgres / mysql / redis / vault / pv / retention) on UTC-staggered schedules
- 6 restore scripts riding inside the restic repo under tag `scripts` so disaster-recovery operators with the passphrase + B2 creds can pull them back
- `./tf backup-config` wrapper subcommand for off-cluster operator config (.env + config/) backup
- Cross-namespace Secret mirroring so CronJobs can `secret_key_ref` the per-target credentials locally
- Live-tar Stalwart trade-off: 0 mail downtime, RocksDB WAL recovers torn snapshots

Plan with `services.backup.enabled = false` (default): no resources change. The whole module is dormant until the operator opts in.