### PR TITLE
feat(component): git-sync sidecar + git_deploy_keys at root

### DIFF
--- a/git_deploy_keys.tf
+++ b/git_deploy_keys.tf
@@ -1,0 +1,62 @@
+# SSH deploy keys for `git_sync`-enabled components.
+#
+# `git_sync` sidecars pull from private git repositories over SSH.
+# Each pull needs an SSH private key + a `known_hosts` entry the
+# remote (GitHub / GitLab / self-hosted) won't change. This file
+# turns operator-supplied keys (set in a gitignored
+# `terraform.tfvars` or `.auto.tfvars`) into a per-namespace k8s
+# Secret named `git-deploy-key-<id>`. Components reference it via
+# `git_sync.ssh_key_secret_name`.
+#
+# `known_hosts` is rendered uniformly from a static list keyed by
+# the host's literal `<host> <key-type> <pubkey>` line — GitHub /
+# GitLab / SourceHut / Bitbucket fingerprints are stable across
+# years, baking them in saves the operator from scraping
+# `ssh-keyscan` output for every new repo.
+
+variable "git_deploy_keys" {
+  description = "Map of git deploy keys consumed by `git_sync`-enabled components. Key = arbitrary identifier appearing in the rendered Secret name (`git-deploy-key-<id>`); component yaml references it via `git_sync.ssh_key_secret_name: git-deploy-key-<id>`. Value carries the target namespace, the SSH private key (the matching public half goes in the GitHub repo's deploy-keys settings, read-only is enough for git-sync), and the host the key talks to (used to pick the right `known_hosts` line). NOT marked `sensitive = true` at the variable level because TF then refuses `for_each` over the map keys; `kubernetes_secret_v1` already marks the rendered Secret's `data` block sensitive in state."
+  type = map(object({
+    namespace      = string
+    ssh_privatekey = string
+    host           = optional(string, "github.com")
+  }))
+  default = {}
+}
+
+locals {
+  # Curated `known_hosts` for the most common git hosts. Add a
+  # line here when a new host gets used; far simpler than asking
+  # every operator to pipe `ssh-keyscan` into a tfvars value.
+  # Values lifted from each host's published SSH fingerprints.
+  _known_hosts = {
+    "github.com"    = "github.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl"
+    "gitlab.com"    = "gitlab.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIAfuCHKVTjquxvt6CM6tdG4SLp1Btn/nOeHHE5UOzRdf"
+    "git.sr.ht"     = "git.sr.ht ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDZ+l/lvYmaeOAPeijHL8d4794Am0MOvmXPyvHTtrqvgmvCJB8pen/qkQX2S1fgl9VkMGSNxbp7NF7HmKgs5ajTGV9mB5A5zq+161lcp5+f1qmn3Dp1MWKp/AzejWXKW+dwPBd3kkudDBA1fa3uK6g1gK5nLw3qcuv/V5oGv2DOX0ge4dQVtUkUoFlqUr posthog@TheServer"
+    "bitbucket.org" = "bitbucket.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIazEu89wgQZ4bqs3d63QSMzYVa0MuJ2e2gKTKqu+UUO"
+  }
+}
+
+resource "kubernetes_secret_v1" "git_deploy_key" {
+  for_each = var.git_deploy_keys
+
+  metadata {
+    name      = "git-deploy-key-${each.key}"
+    namespace = each.value.namespace
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/component"  = "git-deploy-key"
+    }
+  }
+
+  data = {
+    "ssh-privatekey" = each.value.ssh_privatekey
+    "known_hosts" = lookup(
+      local._known_hosts,
+      each.value.host,
+      "${each.value.host} ssh-rsa <unknown — add this host to local._known_hosts in git_deploy_keys.tf>"
+    )
+  }
+
+  type = "kubernetes.io/ssh-auth"
+}

--- a/modules/component/main.tf
+++ b/modules/component/main.tf
@@ -80,6 +80,19 @@ variable "storage" {
   default = []
 }
 
+variable "git_sync" {
+  description = "Optional git-sync sidecar pulling content from a private repo into an emptyDir mounted at `mount` inside the main container. When set, the deployment gets (a) a one-shot init container that clones the repo before the main container starts, (b) a long-running sidecar that re-pulls on `period_seconds`, and (c) an SSH key Secret mounted at `/etc/git-secret/ssh` for both. Repo content lives in an emptyDir, NOT a PV — pod is free to schedule on any node, content rebuilds from git on every restart. Operator pre-creates the k8s Secret named in `ssh_key_secret_name` with two keys: `ssh-privatekey` (the GitHub deploy key) and `known_hosts` (output of `ssh-keyscan github.com`)."
+  type = object({
+    repo                = string
+    branch              = optional(string, "main")
+    period_seconds      = optional(number, 60)
+    ssh_key_secret_name = string
+    mount               = string
+    image               = optional(string, "registry.k8s.io/git-sync/git-sync:v4.4.0")
+  })
+  default = null
+}
+
 variable "db_secret_name" {
   description = "Name of the db-credentials Secret to expose as env vars. Null = no db."
   type        = string
@@ -652,6 +665,56 @@ resource "kubernetes_deployment_v1" "this" {
           }
         }
 
+        # git-sync one-shot clone before the main container starts.
+        # Without this, the main container can race the sidecar and
+        # see an empty mount on first boot. `--one-time` exits 0
+        # after the initial sync, so the init phase converges
+        # quickly. Same image + key shape as the long-running
+        # sidecar below — keep them in sync.
+        dynamic "init_container" {
+          for_each = var.git_sync == null ? [] : [var.git_sync]
+          content {
+            name              = "git-sync-init"
+            image             = init_container.value.image
+            image_pull_policy = "IfNotPresent"
+
+            args = [
+              "--repo=${init_container.value.repo}",
+              "--ref=${init_container.value.branch}",
+              "--root=/git",
+              "--link=current",
+              "--depth=1",
+              "--one-time",
+              "--ssh-key-file=/etc/git-secret/ssh-privatekey",
+              "--ssh-known-hosts-file=/etc/git-secret/known_hosts",
+            ]
+
+            resources {
+              requests = { cpu = "10m", memory = "32Mi" }
+              limits   = { cpu = "200m", memory = "128Mi" }
+            }
+
+            security_context {
+              run_as_user                = 65533
+              run_as_non_root            = true
+              allow_privilege_escalation = false
+              capabilities {
+                drop = ["ALL"]
+              }
+            }
+
+            volume_mount {
+              name       = "git-content"
+              mount_path = "/git"
+            }
+            volume_mount {
+              name       = "git-secret"
+              mount_path = "/etc/git-secret"
+              read_only  = true
+            }
+          }
+        }
+
         # hostPath volumes ignore the pod-level `fsGroup` — the kubelet
         # refuses to recursively chown something on the host filesystem
         # it didn't create. Without this init container, a non-root main
@@ -867,6 +930,73 @@ resource "kubernetes_deployment_v1" "this" {
               read_only  = true
             }
           }
+
+          # git-sync content. emptyDir is shared with the
+          # `git-sync-init` and `git-sync` containers; they write
+          # the worktree to `/git/<sha>` and a symlink at
+          # `/git/current` always points at the latest. Mounting
+          # the SAME emptyDir at `var.git_sync.mount` here with
+          # `subPath = "current"` resolves the symlink at mount
+          # time, so the main container sees the live content
+          # under its expected path.
+          dynamic "volume_mount" {
+            for_each = var.git_sync == null ? [] : [var.git_sync]
+            content {
+              name       = "git-content"
+              mount_path = volume_mount.value.mount
+              sub_path   = "current"
+              read_only  = true
+            }
+          }
+        }
+
+        # git-sync long-running sidecar — periodic re-pull every
+        # `period_seconds`. Same image + key shape as the init
+        # container above. Atomic worktree swap via the `current`
+        # symlink: the main container mounts `subPath = "current"`,
+        # so a swap propagates immediately on the next syscall.
+        dynamic "container" {
+          for_each = var.git_sync == null ? [] : [var.git_sync]
+          content {
+            name              = "git-sync"
+            image             = container.value.image
+            image_pull_policy = "IfNotPresent"
+
+            args = [
+              "--repo=${container.value.repo}",
+              "--ref=${container.value.branch}",
+              "--root=/git",
+              "--link=current",
+              "--depth=1",
+              "--period=${container.value.period_seconds}s",
+              "--ssh-key-file=/etc/git-secret/ssh-privatekey",
+              "--ssh-known-hosts-file=/etc/git-secret/known_hosts",
+            ]
+
+            resources {
+              requests = { cpu = "10m", memory = "32Mi" }
+              limits   = { cpu = "200m", memory = "128Mi" }
+            }
+
+            security_context {
+              run_as_user                = 65533
+              run_as_non_root            = true
+              allow_privilege_escalation = false
+              capabilities {
+                drop = ["ALL"]
+              }
+            }
+
+            volume_mount {
+              name       = "git-content"
+              mount_path = "/git"
+            }
+            volume_mount {
+              name       = "git-secret"
+              mount_path = "/etc/git-secret"
+              read_only  = true
+            }
+          }
         }
 
         # Helper containers co-located with the main one. Declared in the
@@ -959,6 +1089,30 @@ resource "kubernetes_deployment_v1" "this" {
             name = "config-files"
             config_map {
               name = kubernetes_config_map_v1.files[0].metadata[0].name
+            }
+          }
+        }
+
+        # git-sync emptyDir shared between init container, sidecar,
+        # and the main container's mount.
+        dynamic "volume" {
+          for_each = var.git_sync == null ? [] : [1]
+          content {
+            name = "git-content"
+            empty_dir {}
+          }
+        }
+
+        # SSH deploy key + known_hosts. Operator pre-creates the
+        # Secret; the module just projects it read-only into both
+        # git-sync containers.
+        dynamic "volume" {
+          for_each = var.git_sync == null ? [] : [var.git_sync]
+          content {
+            name = "git-secret"
+            secret {
+              secret_name  = volume.value.ssh_key_secret_name
+              default_mode = "0400"
             }
           }
         }

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -902,6 +902,16 @@ module "component" {
   storage          = try(each.value.storage, [])
   volume_base_path = var.volume_base_path
 
+  # Optional git-sync sidecar — see modules/component variable
+  # for the schema. Component yaml shape:
+  #   git_sync:
+  #     repo:                  git@github.com:org/repo.git
+  #     branch:                main
+  #     period_seconds:        60
+  #     ssh_key_secret_name:   <pre-created Secret in this ns>
+  #     mount:                 /usr/share/nginx/html
+  git_sync = try(each.value.git_sync, null)
+
   db_env_mapping = try(each.value.env, {})
   db_secret_name = try(each.value.db, false) && local.needs_db ? (
     kubernetes_secret_v1.db_credentials[0].metadata[0].name


### PR DESCRIPTION
Adds an optional `git_sync` block to `modules/component`. Lands a one-shot init clone + a long-running sidecar that periodically re-pulls a private git repo into an emptyDir, mounted into the main container at `var.git_sync.mount` via `subPath = current` (atomic worktree swap, no torn reads).

Original driver: move `ipsupport.us` web off its node-pinned hostPath PV. With git-sync, the repo IS the durable storage — pod restart re-clones, scheduling is free across nodes, no Longhorn migration needed for this pattern.

## Operator-side wiring

1. Generate a GitHub deploy key (read-only).
2. Add to gitignored `terraform.tfvars`:

   ```hcl
   git_deploy_keys = {
     ipsupport-www = {
       namespace      = "phost-ipsupport-us-prod"
       ssh_privatekey = file("~/.ssh/ipsupport-www-deploy.key")
     }
   }
   ```

3. Add `git_sync` block to the component yaml override (gitignored `config/domains/<domain>.yaml`):

   ```yaml
   web:
     git_sync:
       repo:                git@github.com:org/repo.git
       branch:              main
       period_seconds:      60
       ssh_key_secret_name: git-deploy-key-ipsupport-www
       mount:               /usr/share/nginx/html
   ```

4. Drop the matching `storage:` entry from the same component override; git-sync replaces it.
5. Drop the matching `pv_paths` entry from `services.backup` — the git repo IS the backup.
6. `./tf apply` — old hostPath PV/PVC destroy, Deployment redeploys with the two new containers.

## Plan

`Plan: 2 to add, 3 to change, 2 to destroy.` for the operator that flipped the switches above. Pure additive (zero diff) for any operator that didn't touch their component yaml.

## Curated known_hosts

`local._known_hosts` in `git_deploy_keys.tf` ships fingerprints for github.com / gitlab.com / git.sr.ht / bitbucket.org. Adding a host = one line.