### PR TITLE
feat(engine): argocd bootstrap + hostnames + shared_services schema

### DIFF
--- a/argocd_repos.tf
+++ b/argocd_repos.tf
@@ -1,0 +1,81 @@
+# Argo CD repo credential Secrets.
+#
+# Generic mechanism: operator supplies SSH private keys via
+# `var.argocd_repo_ssh_keys` (map of `<id>` => PEM-encoded key).
+# Components with `kind: argocd_app` reference an entry by `id`
+# through the `repo_ssh_key_id:` field in their gitignored yaml. TF
+# collects unique (repo_url, ssh_key_id) pairs across all such
+# components and emits one Secret per pair in the Argo CD namespace,
+# shaped per Argo CD's repository-secret convention (label
+# `argocd.argoproj.io/secret-type: repository` + data {type, url,
+# sshPrivateKey}). Multiple components pointing at the same repo with
+# the same key reuse one Secret; different keys for the same URL get
+# distinct Secrets — Argo CD's match-by-URL semantics tolerate either.
+#
+# Mirrors the existing `git_deploy_keys` mechanism (per-namespace
+# git-sync key Secrets) — same private key value can serve both if
+# the operator adds it as a deploy key on every consuming repo, but
+# the maps are separate so an operator can scope keys narrowly.
+
+variable "argocd_repo_ssh_keys" {
+  description = "Operator-supplied map of `<id>` => SSH private key (PEM string). Components reference an entry by `repo_ssh_key_id:` in the domain yaml's `argocd_bootstrap:` block. Empty map = no private repo support; bootstrap repo must be public. NOT marked sensitive at the variable level so `for_each` over keys works; the rendered Secret's `data` block is sensitive in state."
+  type        = map(string)
+  default     = {}
+}
+
+locals {
+  # (url, ssh_key_id) pairs across every project that declares an
+  # `argocd_bootstrap:` block with a private-repo auth hint. Iterates
+  # per-project from `local.projects[*].argocd_bootstrap`. `distinct()`
+  # collapses duplicates so multiple envs sharing a deploy repo produce
+  # one Secret.
+  _argocd_app_repo_pairs = distinct([
+    for _, project in local.projects : {
+      url        = try(project.argocd_bootstrap.repo_url, "")
+      ssh_key_id = try(project.argocd_bootstrap.repo_ssh_key_id, "")
+    }
+    if try(project.argocd_bootstrap, null) != null
+    && try(project.argocd_bootstrap.repo_ssh_key_id, "") != ""
+    && try(project.argocd_bootstrap.repo_url, "") != ""
+  ])
+
+  # Stable for_each key. Key id first so Secret names group by operator
+  # intent (one key spans many repos → all those Secrets share a prefix);
+  # url-hash suffix disambiguates.
+  argocd_repo_creds = {
+    for pair in local._argocd_app_repo_pairs :
+    "${pair.ssh_key_id}-${substr(md5(pair.url), 0, 8)}" => pair
+  }
+}
+
+# Precondition: every referenced ssh_key_id resolves in the operator's
+# var.argocd_repo_ssh_keys map. Surfaces as a clear plan-time error
+# instead of a sync-time `permission denied` from Argo CD's repo pull.
+check "argocd_repo_ssh_keys_resolved" {
+  assert {
+    condition = alltrue([
+      for pair in local._argocd_app_repo_pairs :
+      contains(keys(var.argocd_repo_ssh_keys), pair.ssh_key_id)
+    ])
+    error_message = "argocd_bootstrap entry references a `repo_ssh_key_id` not present in `var.argocd_repo_ssh_keys`. Referenced ids: ${jsonencode([for p in local._argocd_app_repo_pairs : p.ssh_key_id])}. Available ids: ${jsonencode(keys(var.argocd_repo_ssh_keys))}. Add the missing entry to `terraform.tfvars` (`argocd_repo_ssh_keys = { ... }`) or remove the `repo_ssh_key_id:` field from the domain yaml's argocd_bootstrap block if the repo is public."
+  }
+}
+
+resource "kubernetes_secret_v1" "argocd_repo" {
+  for_each = local.platform.services.argocd.enabled ? local.argocd_repo_creds : {}
+
+  metadata {
+    name      = "repo-${each.key}"
+    namespace = local.platform.services.argocd.namespace
+    labels = {
+      "argocd.argoproj.io/secret-type" = "repository"
+      "app.kubernetes.io/managed-by"   = "terraform"
+    }
+  }
+
+  data = {
+    type          = "git"
+    url           = each.value.url
+    sshPrivateKey = var.argocd_repo_ssh_keys[each.value.ssh_key_id]
+  }
+}

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -10,6 +10,35 @@ locals {
   all_hostnames = merge([
     for _, proj in module.project : proj.hostnames
   ]...)
+
+  # Argo CD-managed hostnames pulled from `envs.<env>.argocd_hostnames`
+  # in each project's domain yaml. Two flavours:
+  #   - cf_tunnel=true: hostname routes through the existing Cloudflare
+  #     Tunnel + Traefik chain. Treat exactly like a legacy `routes:`
+  #     entry — emit a CNAME to the tunnel + a tunnel ingress rule
+  #     pointing at Traefik. The IngressRoute itself is owned by the
+  #     operator's deploy repo and applied via Argo CD.
+  #   - cf_tunnel=false: hostname binds directly to the node's real
+  #     public IP (`node_ip`). Emit an unproxied A record; do NOT add
+  #     a tunnel ingress rule. The cluster service must be reachable
+  #     on that IP independently (hostNetwork pod, NodePort, etc.).
+  all_argocd_hostnames = merge([
+    for _, proj in module.project : proj.argocd_hostnames
+  ]...)
+
+  # Subset routed through the tunnel — folded into the tunnel + CNAME
+  # generators below alongside legacy hostnames.
+  tunnel_argocd_hostnames = {
+    for host, h in local.all_argocd_hostnames :
+    host => h if h.cf_tunnel
+  }
+
+  # Subset bound directly to a node IP. Drives unproxied A records;
+  # NOT included in the tunnel ingress rules.
+  direct_argocd_hostnames = {
+    for host, h in local.all_argocd_hostnames :
+    host => h if !h.cf_tunnel
+  }
 }
 
 # ── Cloudflare Zero Trust Tunnel ─────────────────────────────────────────────
@@ -117,6 +146,18 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "main" {
           }
         }
       ],
+      # Argo CD-managed hostnames opted into the tunnel. Same shape
+      # as legacy entries above; backend always Traefik on `web`.
+      [
+        for hostname, cfg in local.tunnel_argocd_hostnames : {
+          hostname = hostname
+          service  = cfg.service
+          origin_request = {
+            origin_server_name = hostname
+            http2_origin       = false
+          }
+        }
+      ],
       # Catch-all (required by Cloudflare — must be the last entry,
       # match-anything by omitting `hostname`).
       [{
@@ -130,7 +171,8 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "main" {
 
 resource "cloudflare_dns_record" "tunnel" {
   for_each = {
-    for hostname, cfg in local.all_hostnames : hostname => cfg
+    for hostname, cfg in merge(local.all_hostnames, local.tunnel_argocd_hostnames) :
+    hostname => cfg
     if cfg.zone_id != null
   }
 
@@ -143,6 +185,26 @@ resource "cloudflare_dns_record" "tunnel" {
   type    = "CNAME"
   proxied = true
   ttl     = 1
+}
+
+# Direct A records for argocd_hostnames opted out of the tunnel
+# (`cf_tunnel: false`). Unproxied so DNS resolves to the literal
+# node IP — the operator's workload terminates the connection there
+# (hostNetwork pod / NodePort with the firewall opened up). No
+# Cloudflare features in front; raw exposure.
+resource "cloudflare_dns_record" "argocd_direct" {
+  for_each = {
+    for hostname, cfg in local.direct_argocd_hostnames :
+    hostname => cfg
+    if cfg.zone_id != null && cfg.node_ip != ""
+  }
+
+  zone_id = each.value.zone_id
+  name    = each.key
+  content = each.value.node_ip
+  type    = "A"
+  proxied = false
+  ttl     = 60
 }
 
 # ── Manual DNS records — declared per-domain in YAML ─────────────────────────

--- a/locals.tf
+++ b/locals.tf
@@ -180,7 +180,30 @@ locals {
           namespace          = "${var.namespace_prefix}${cfg.slug}-${env_name}"
           cloudflare_zone_id = try(cfg.cloudflare_zone_id, null)
           routes             = try(env_spec.routes, {})
-          limits             = try(env_spec.limits, cfg.limits, null)
+          # Argo CD-managed hostnames declared per-env. Keyed by host
+          # prefix (resolves to `<prefix>.<domain>`); each entry sets
+          # `cf_tunnel: bool` (default true) and optional `node_ip:` for
+          # the no-tunnel A-record path. TF only plumbs DNS + tunnel
+          # rule — IngressRoute / Service live in the operator's deploy
+          # repo, applied by Argo CD.
+          argocd_hostnames = try(env_spec.argocd_hostnames, {})
+          # Argo CD bootstrap App-of-Apps root for this env. When set,
+          # TF emits a single root Application + AppProject; sub-apps
+          # live in the deploy repo and reconcile through Argo CD.
+          # Null = no Argo CD bootstrap (project has no Argo footprint
+          # unless `argocd_hostnames` is set).
+          argocd_bootstrap = try(env_spec.argocd_bootstrap, null)
+          # Per-env shared-service provisioning flags. Same shape as
+          # the per-component `postgres: true` / `redis: true` /
+          # `ollama: true` knobs but applied at the project layer —
+          # engine emits per-namespace ACL credentials (Postgres role
+          # + DB, Redis ACL user, Ollama Service URL Secret) WITHOUT
+          # requiring a `kind: deployment/app` component to opt in.
+          # Use for Argo CD-managed workloads whose pods aren't
+          # TF-emitted but still need platform shared-service
+          # credentials in their namespace.
+          shared_services = try(env_spec.shared_services, {})
+          limits          = try(env_spec.limits, cfg.limits, null)
           # Optional per-project component overrides. Top-level keys here
           # win over the matching keys in `config/components/<name>.yaml`
           # via shallow merge — provide a full replacement value for any

--- a/main.tf
+++ b/main.tf
@@ -121,10 +121,27 @@ module "project" {
   source     = "./modules/project"
   depends_on = [module.addons, kubernetes_namespace_v1.platform, module.mysql, module.postgres, module.redis, module.ollama]
 
+  providers = {
+    kubernetes = kubernetes
+    kubectl    = kubectl
+    random     = random
+    zitadel    = zitadel
+  }
+
   project_config   = each.value
   components       = local.components
   default_limits   = local.default_limits
   volume_base_path = var.host_volume_path
+
+  # Argo CD wiring — the project module emits an AppProject + bootstrap
+  # Application when `argocd_bootstrap:` is declared in the domain yaml,
+  # plus DNS+tunnel records per `argocd_hostnames:` entry. All three
+  # propagate from the per-env block in the domain yaml; null/empty
+  # values short-circuit the resources.
+  argocd_namespace = local.platform.services.argocd.enabled ? local.platform.services.argocd.namespace : ""
+  argocd_hostnames = try(each.value.argocd_hostnames, {})
+  argocd_bootstrap = try(each.value.argocd_bootstrap, null)
+  shared_services  = try(each.value.shared_services, {})
 
   # Shared-service endpoints. Each module's outputs collapse to null
   # when its own `enabled` flag is off, so the preconditions in

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -135,6 +135,30 @@ variable "volume_base_path" {
   type        = string
 }
 
+variable "argocd_namespace" {
+  description = "Namespace where the Argo CD chart is installed. Argo CD AppProject + bootstrap Application CRDs land here when this project's domain yaml declares an `argocd_bootstrap:` block. Empty disables Argo CD wiring entirely in this project (caller fails the precondition below if anything Argo-related is declared)."
+  type        = string
+  default     = ""
+}
+
+variable "argocd_hostnames" {
+  description = "Map of Argo-managed hostnames declared under `envs.<env>.argocd_hostnames:` in the domain yaml. Keyed by host prefix (resolves to `<prefix>.<domain>`); value carries `cf_tunnel` (bool, default true — emit a Cloudflare Tunnel ingress rule routing the hostname through cloudflared → Traefik) and optional `node_ip` (string, required when `cf_tunnel = false` — TF emits an unproxied A record pointing at the node's real public IP, bypassing Cloudflare entirely). The IngressRoute itself for these hostnames is owned by the operator's deploy repo via Argo CD — TF only plumbs DNS + tunnel rule. Consumed by the root `cloudflare.tf` / `cloudflared.tf` for hostname registration."
+  type        = any
+  default     = {}
+}
+
+variable "argocd_bootstrap" {
+  description = "Optional `argocd_bootstrap:` block declared under `envs.<env>:` in the domain yaml. Carries `repo_url`, `path`, `target_revision`, and optional `repo_ssh_key_id` (looked up in the root `argocd_repo_ssh_keys` map). When set, TF emits one root Application in the Argo CD namespace pointing at this repo+path; sub-Application manifests living there are recursively synced by Argo CD (App-of-Apps pattern). Application + workload manifests are operator-owned; TF only stands up the bootstrap entrypoint + the AppProject scoping it. Null disables Argo CD wiring for this project/env."
+  type        = any
+  default     = null
+}
+
+variable "shared_services" {
+  description = "Per-env `shared_services:` map from the domain yaml — flags telling the engine to provision per-namespace shared-service credentials (Postgres DB + role + Secret, Redis ACL user + Secret, Ollama Service URL Secret) WITHOUT requiring a `kind: deployment/app` component to opt in. Use for Argo CD-managed apps whose pods aren't TF-emitted but still need platform-shared backing services. Keys: `db` / `postgres` / `redis` / `ollama` (bool, default false). Provisioned credentials end up in standard Secret names the chart can consume via `envFrom` — `db-credentials`, `postgres-credentials`, `redis-credentials`, `ollama-endpoint`."
+  type        = any
+  default     = {}
+}
+
 # ── Locals ────────────────────────────────────────────────────────────────────
 
 locals {
@@ -324,19 +348,19 @@ locals {
 
   needs_db = anytrue([
     for _, c in local.normalized_components : try(c.db, false)
-  ])
+  ]) || try(var.shared_services.db, false)
 
   needs_postgres = anytrue([
     for _, c in local.normalized_components : try(c.postgres, false)
-  ])
+  ]) || try(var.shared_services.postgres, false)
 
   needs_redis = anytrue([
     for _, c in local.normalized_components : try(c.redis, false)
-  ])
+  ]) || try(var.shared_services.redis, false)
 
   needs_ollama = anytrue([
     for _, c in local.normalized_components : try(c.ollama, false)
-  ])
+  ]) || try(var.shared_services.ollama, false)
 
   db_name = replace(local.namespace, "-", "_")
   db_user = replace(local.namespace, "-", "_")
@@ -820,8 +844,8 @@ resource "kubernetes_secret_v1" "ollama_endpoint" {
 # Project name defaults to the component name (v1: one project per
 # app); roles default to `[platform_admin, tenant_admin, user]` so a
 # bare `oidc.enabled: true` already buys a usable role tree. Override
-# both via the component yaml — see config/components/sipmesh-frontend.yaml
-# for the worked shape.
+# both via the component yaml — see any `kind: app` example for the
+# worked shape.
 
 check "zitadel_issuer_set_when_app_oidc_used" {
   assert {
@@ -1059,6 +1083,164 @@ resource "kubernetes_secret_v1" "env_random" {
   }
 }
 
+# ── ArgoCD wiring (per project) ──────────────────────────────────────────────
+#
+# Two ways the project intersects with Argo CD:
+#
+#   1. `argocd_hostnames:` map in the domain yaml — hostnames the
+#      operator wants Argo CD-managed services reachable on. TF only
+#      plumbs DNS + (optional) Cloudflare Tunnel ingress rule. The
+#      IngressRoute itself + the Service it targets live in the
+#      operator's deploy repo (chart-rendered, Argo CD-applied).
+#
+#   2. `argocd_bootstrap:` block in the domain yaml — repo URL +
+#      path + branch the operator's deploy repo lives at. TF emits
+#      ONE root Application in the Argo CD namespace + an AppProject
+#      scoping every Application synced under it to this project's
+#      namespace. Sub-Applications and AppProject overrides land in
+#      the deploy repo itself, not here.
+#
+# When neither is declared, the project has zero Argo CD footprint.
+
+check "argocd_bootstrap_requires_argocd_ns" {
+  assert {
+    condition     = var.argocd_bootstrap == null || var.argocd_namespace != ""
+    error_message = "project '${local.namespace}' declares an `argocd_bootstrap:` block but `argocd_namespace` is empty. Enable `services.argocd.enabled = true` in `config/platform.yaml` and re-apply."
+  }
+}
+
+check "argocd_hostnames_node_ip_set_when_no_tunnel" {
+  assert {
+    condition = alltrue([
+      for _, h in var.argocd_hostnames :
+      try(h.cf_tunnel, true) || try(h.node_ip, "") != ""
+    ])
+    error_message = "every `argocd_hostnames` entry with `cf_tunnel: false` must set `node_ip:` to the node's real public IP — TF emits an unproxied A record there, bypassing the Cloudflare Tunnel. Project '${local.namespace}'."
+  }
+}
+
+# AppProject — RBAC scope. One per (project, env) when the project
+# has any Argo CD wiring (bootstrap declared OR argocd_hostnames
+# non-empty). Destinations pin strictly to this project's namespace;
+# sourceRepos pin to the bootstrap deploy repo (sub-Applications
+# inherit via `spec.project = <project-name>`). Cluster-scoped
+# resources are entirely denied — the platform owns CRDs, ClusterRoles,
+# Namespaces.
+resource "kubectl_manifest" "argocd_app_project" {
+  count = (var.argocd_bootstrap != null || length(var.argocd_hostnames) > 0) ? 1 : 0
+
+  yaml_body = yamlencode({
+    apiVersion = "argoproj.io/v1alpha1"
+    kind       = "AppProject"
+    metadata = {
+      name      = local.namespace
+      namespace = var.argocd_namespace
+      labels = {
+        "app.kubernetes.io/managed-by" = "terraform"
+        "platform.tenant"              = local.namespace
+      }
+    }
+    spec = {
+      description = "Auto-managed AppProject for TF project ${local.namespace}. Pins Application destinations to this namespace and source repos to the operator's deploy repo declared in `argocd_bootstrap:`."
+
+      sourceRepos = compact([
+        try(var.argocd_bootstrap.repo_url, ""),
+      ])
+
+      destinations = [
+        # Workload destination — every chart-rendered resource the
+        # sub-Applications spawn lands here.
+        {
+          server    = "https://kubernetes.default.svc"
+          namespace = local.namespace
+        },
+        # Argo CD's own namespace — App-of-Apps materialises sub-
+        # Application CRDs here. Without this entry the bootstrap
+        # Application fails its own destination check ("destination
+        # server ... and namespace 'argocd' do not match allowed
+        # destinations") and never even reaches sync.
+        {
+          server    = "https://kubernetes.default.svc"
+          namespace = var.argocd_namespace
+        },
+      ]
+
+      namespaceResourceWhitelist = [
+        { group = "*", kind = "*" },
+      ]
+      clusterResourceWhitelist = []
+    }
+  })
+}
+
+# Bootstrap Application — App-of-Apps root. Points at the operator's
+# deploy repo path; Argo CD recursively syncs every Application
+# manifest found there. Sub-Applications must declare
+# `spec.project: <project-name>` to land workloads (AppProject above
+# refuses anything else).
+resource "kubectl_manifest" "argocd_bootstrap" {
+  count = var.argocd_bootstrap == null ? 0 : 1
+
+  depends_on = [kubectl_manifest.argocd_app_project]
+
+  yaml_body = yamlencode({
+    apiVersion = "argoproj.io/v1alpha1"
+    kind       = "Application"
+    metadata = {
+      name      = "${local.namespace}-bootstrap"
+      namespace = var.argocd_namespace
+      finalizers = [
+        "resources-finalizer.argocd.argoproj.io",
+      ]
+      labels = {
+        "app.kubernetes.io/managed-by" = "terraform"
+        "platform.tenant"              = local.namespace
+        "platform.role"                = "bootstrap"
+      }
+    }
+    spec = {
+      project = local.namespace
+
+      source = {
+        repoURL        = var.argocd_bootstrap.repo_url
+        path           = try(var.argocd_bootstrap.path, ".")
+        targetRevision = try(var.argocd_bootstrap.target_revision, "HEAD")
+        # Bootstrap directory contains plain Application yaml manifests —
+        # no Helm rendering at the bootstrap layer. directory.recurse
+        # picks up nested folders so the operator can group apps
+        # however they like.
+        directory = {
+          recurse = true
+        }
+      }
+
+      destination = {
+        server    = "https://kubernetes.default.svc"
+        namespace = var.argocd_namespace
+      }
+
+      syncPolicy = {
+        automated = {
+          prune    = true
+          selfHeal = true
+        }
+        syncOptions = [
+          "CreateNamespace=false",
+          "ServerSideApply=true",
+        ]
+        retry = {
+          limit = 3
+          backoff = {
+            duration    = "30s"
+            factor      = 2
+            maxDuration = "5m"
+          }
+        }
+      }
+    }
+  })
+}
+
 # ── IngressRoutes ─────────────────────────────────────────────────────────────
 #
 # One IngressRoute per component, carrying every route that points at it.
@@ -1158,6 +1340,30 @@ output "hostnames" {
 
 output "components" {
   value = keys(local.normalized_components)
+}
+
+# Argo CD-managed hostnames for this project. Resolved per-prefix
+# against the project's domain. Each entry carries the cf_tunnel
+# toggle + (when toggle is false) the node_ip the operator wants the
+# A record pointing at. Consumed by the root `cloudflare.tf` to emit
+# either a tunnel-routed CNAME + ingress rule (cf_tunnel=true) or an
+# unproxied A record bypassing CF entirely (cf_tunnel=false).
+output "argocd_hostnames" {
+  value = {
+    for prefix, h in var.argocd_hostnames :
+    (prefix == "" ? local.domain : "${prefix}.${local.domain}") => {
+      cf_tunnel = try(h.cf_tunnel, true)
+      node_ip   = try(h.node_ip, "")
+      zone_id   = try(var.project_config.cloudflare_zone_id, null)
+      # Tunnel-routed argocd hostnames terminate at Traefik on the
+      # `web` entrypoint, identical to the legacy routes pipeline.
+      # Traefik then matches the Host header against an IngressRoute
+      # the operator's chart applies into the project namespace via
+      # Argo CD. The A-record path (cf_tunnel=false) ignores `service`
+      # — the consumer skips the tunnel rule entirely.
+      service = "http://traefik.ingress-controller.svc.cluster.local:80"
+    }
+  }
 }
 
 output "has_db" {


### PR DESCRIPTION
## Summary
Engine refactor splitting deployment ownership cleanly:

- **`argocd_bootstrap:` block** (per-env in domain yaml) — TF emits one root Application + AppProject; sub-app manifests live in operator's deploy repo, ArgoCD recursively syncs (App-of-Apps).
- **`argocd_hostnames:` map** (per-env) — DNS + (toggleable) Cloudflare Tunnel ingress rule per hostname. `cf_tunnel: false` emits an unproxied A record straight to the operator-supplied node IP, bypassing CF entirely (for SIP/RTP traffic CF can't carry).
- **`shared_services:` block** (per-env) — flips Redis ACL / Postgres DB / Ollama Service URL Secret provisioning at the project level WITHOUT requiring a `kind: deployment/app` component to opt in. ArgoCD-managed apps' pods get platform-shared backing services through the existing `<service>-credentials` Secret machinery via `envFrom`.
- **`argocd_repos.tf`** — repo credential Secrets (SSH key, ArgoCD repository-shape) emitted in argocd ns from operator's `argocd_repo_ssh_keys` map. One Secret per (url, key_id) pair.
- **AppProject** — strict allowlist (destinations pin to project namespace + argocd ns; sourceRepos = bootstrap.repo_url; cluster-scoped resources denied). Sub-Apps must `spec.project: <project-name>` to land workloads.
- Drops the per-app `kind: argocd_app` mechanism that lived briefly today — superseded by this cleaner domain-layer split.

## Why
Operator's architecture call: TF only owns the domain layer (DNS, tunnel, namespace, AppProject, repo creds, bootstrap App). Workload deployment + IngressRoutes + Secrets-the-chart-needs all flow from operator's deploy repo, applied by ArgoCD. Image bumps land via git commit to the deploy repo, no `tf apply` needed for routine deploys.

## Test plan
- [x] Live: bootstrap Application syncs sub-Application manifests from chart repo's `deploy/argocd/apps/` via SSH cred
- [x] Live: AppProject refuses sub-App with `spec.project: default` (forces operator discipline on RBAC scope)
- [x] Live: `cf_tunnel: false` argocd_hostname emits A record to node IP, NOT a CNAME to tunnel
- [x] Live: `shared_services.redis: true` (after operator opt-in) emits per-namespace ACL user + Secret with REDIS_HOST/USER/PASSWORD/KEY_PREFIX/PORT keys
- [ ] Pending: chart-side migration to `envFrom` Secret consumption (handed off to sipmesh agent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)