### PR TITLE
feat(engine): operator secrets schema + Redis ACL channels

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -203,7 +203,17 @@ locals {
           # TF-emitted but still need platform shared-service
           # credentials in their namespace.
           shared_services = try(env_spec.shared_services, {})
-          limits          = try(env_spec.limits, cfg.limits, null)
+          # Generic operator-defined Secrets — engine emits a
+          # `kubernetes_secret_v1` per entry in the project namespace.
+          # Use for app-specific shared-secrets (e.g. an apikey a
+          # chart's `existingSecret` references). Each entry's `keys`
+          # list defines data keys; a single random_password per
+          # entry seeds the value across every key. Sharing one
+          # value across keys lets an operator point a chart's
+          # multi-env-var Secret consumer at one Secret without
+          # rotating multiple downstream registrations.
+          secrets = try(env_spec.secrets, {})
+          limits  = try(env_spec.limits, cfg.limits, null)
           # Optional per-project component overrides. Top-level keys here
           # win over the matching keys in `config/components/<name>.yaml`
           # via shallow merge — provide a full replacement value for any

--- a/main.tf
+++ b/main.tf
@@ -142,6 +142,7 @@ module "project" {
   argocd_hostnames = try(each.value.argocd_hostnames, {})
   argocd_bootstrap = try(each.value.argocd_bootstrap, null)
   shared_services  = try(each.value.shared_services, {})
+  secrets          = try(each.value.secrets, {})
 
   # Shared-service endpoints. Each module's outputs collapse to null
   # when its own `enabled` flag is off, so the preconditions in

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -159,6 +159,12 @@ variable "shared_services" {
   default     = {}
 }
 
+variable "secrets" {
+  description = "Per-env `secrets:` map from the domain yaml — operator-defined random-value Secrets emitted in the project namespace. Each entry: `keys` (list of data-key names — every listed key receives the same random value, lets a chart's `envFrom` pull every variable from one Secret), `length` (optional, default 48). Use when an Argo CD-managed chart's `existingSecret` references an operator-named Secret that platform engine should pre-create with a random value the chart consumes via env. Engine creates `kubernetes_secret_v1` per entry; rotation = `tf taint random_password.<...>` + apply."
+  type        = any
+  default     = {}
+}
+
 # ── Locals ────────────────────────────────────────────────────────────────────
 
 locals {
@@ -767,6 +773,22 @@ resource "kubernetes_job_v1" "redis_setup" {
               "\\>${random_password.redis[0].result}",
               "resetkeys",
               "~${local.redis_key_prefix}*",
+              # Reset + scope pub/sub channels to the same prefix.
+              # Default `resetchannels` denies every channel; without
+              # this the user holds `+@pubsub` commands but can't
+              # subscribe to anything (NOPERM at SUBSCRIBE time).
+              # Two patterns: `<ns>:*` covers the keyspace-style
+              # channel naming (e.g. `<ns>:notifications`); `<ns>::*`
+              # covers the double-colon namespace separator some
+              # apps use (e.g. `<ns>::dialog_actions`). Both whitelisted
+              # so either convention works without per-app schema.
+              "resetchannels",
+              # `&` is a literal Redis ACL channel-pattern prefix; in
+              # `sh -c` it's also the background-job operator. Escape
+              # so the shell passes `&pattern*` through verbatim
+              # instead of interpreting as `&` + glob.
+              "\\&${local.redis_key_prefix}*",
+              "\\&${local.namespace}::*",
               "+@all",
               "-@dangerous",
               # Object-cache plugins (WP redis-cache, Drupal Redis, …)
@@ -835,6 +857,47 @@ resource "kubernetes_secret_v1" "ollama_endpoint" {
     OLLAMA_HOST     = var.ollama_url
     OLLAMA_BASE_URL = var.ollama_url
     OLLAMA_API_BASE = var.ollama_url
+  }
+}
+
+# ── Operator-defined Secrets (per-env `secrets:` block) ───────────────────────
+#
+# Generic Secret-emission machinery: operator declares a map of
+# `<secret-name>` → `{ keys: [...], length: 48 }` in the domain
+# yaml's per-env block; engine generates one random value per
+# entry and emits a `kubernetes_secret_v1` in the project
+# namespace with every listed `keys` populated by that same
+# random value. Lets an Argo CD-managed chart's `existingSecret`
+# pin reference an operator-named Secret that platform pre-creates
+# without involving any per-app TF code.
+#
+# Same value across keys is intentional — most charts that emit
+# multi-key Secrets (chart proxy + chart server pulling from the
+# same Secret via different env-var names) want one shared secret
+# bytes. If an operator needs different randoms per key, declare
+# multiple top-level entries.
+resource "random_password" "operator_secret" {
+  for_each = var.secrets
+
+  length  = try(each.value.length, 48)
+  special = false
+}
+
+resource "kubernetes_secret_v1" "operator_secret" {
+  for_each = var.secrets
+
+  metadata {
+    name      = each.key
+    namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/part-of"    = local.namespace
+    }
+  }
+
+  data = {
+    for k in try(each.value.keys, []) :
+    k => random_password.operator_secret[each.key].result
   }
 }
 


### PR DESCRIPTION
## Summary

- New per-env `secrets:` block in the domain yaml — engine emits one `kubernetes_secret_v1` per entry in the project namespace, seeded by a `random_password`. Every listed `keys` data-key receives the same random value so a chart's `envFrom: secretRef` pulls every variable from one Secret. Closes the gap where an Argo CD-managed chart's `existingSecret` pins an operator-named Secret that the platform must pre-create without click-ops `kubectl create secret`.
- Redis ACL setup Job now grants pub/sub channel access. Without `resetchannels` + scoped `&` patterns, ACL users with `+@pubsub` commands still hit `NOPERM` at SUBSCRIBE time. Two patterns whitelisted (`<ns>:*` and `<ns>::*`) so either single- or double-colon namespace convention works.
- `&` is escaped (`\\&`) in the redis-cli ACL args — `sh -c` interprets bare `&` as the background-job operator and silently truncates the rule.

## Schema

```yaml
envs:
  dev:
    secrets:
      sipmesh-apikey:
        keys:   [SIPMESH_API_KEY]
        length: 48           # optional, default 48
```

Engine then materialises a `Secret/sipmesh-apikey` in the project namespace with `data.SIPMESH_API_KEY` set to a random 48-char value. Add more `keys` to share the same value across multiple env vars in one chart Secret consumer.

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform validate` (run by CI)
- [ ] Verified live in dev: `secrets.sipmesh-apikey` materialises, chart `existingSecret: sipmesh-apikey` resolves, sipmesh proxy/server load API key from envFrom
- [ ] Redis ACL channels: chart client subscribes to `<ns>:*` channel without `NOPERM`

🤖 Generated with [Claude Code](https://claude.com/claude-code)