### PR TITLE
feat(engine)!: argocd_bootstrap → argocd_bootstraps map (multi-repo per ns)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **BREAKING** `modules/project` input renamed `argocd_bootstrap` (single object) → `argocd_bootstraps` (map of objects keyed by short name). Engine emits one root Application per entry as `<namespace>-<key>-bootstrap`; AppProject `sourceRepos` aggregates every entry's `repo_url` so sub-Applications cross-referencing peer repos pass the allowlist. Domain-yaml input renamed under `envs.<env>.argocd_bootstrap:` → `envs.<env>.argocd_bootstraps:`. **Migration:** wrap the old singular block as a map under any key — the key becomes the Application-name suffix, so the first apply destroys the legacy `<ns>-bootstrap` and re-creates `<ns>-<key>-bootstrap`. Apply requires operator OK because the bootstrap Application is destroy-replaced; sub-Applications themselves keep their own names and re-attach automatically once the new bootstrap App syncs.
+  ```yaml
+  # before
+  argocd_bootstrap:
+    repo_url: git@github.com:org/deploy.git
+    path: deploy/argocd/apps
+    target_revision: main
+    repo_ssh_key_id: deploy
+
+  # after
+  argocd_bootstraps:
+    deploy:                                # any key — becomes the Application name suffix
+      repo_url: git@github.com:org/deploy.git
+      path: deploy/argocd/apps
+      target_revision: main
+      repo_ssh_key_id: deploy
+  ```
+
+### Added
+- Multiple `argocd_bootstraps:` entries per project/env are now supported — primary use case is a single project namespace served by independent chart repos (e.g. a backend chart at `git@github.com:org/backend.git` and a frontend chart at `git@github.com:org/frontend.git`, both deploying into the same `phost-…` namespace with their own `deploy/argocd/apps/application-<env>.yaml`). One AppProject still scopes the entire namespace; its `sourceRepos` list is the union of every entry's `repo_url`.
+
 ### Fixed
 - `modules/redis` and `modules/project` switch Redis from `--requirepass` to `--aclfile /data/users.acl` so per-tenant ACL users survive `redis-0` restarts. Pre-fix every tenant lost its Redis login on the next pod bounce because `ACL SETUSER` only persisted in memory; now the tenant setup Job runs `ACL SAVE` after each `SETUSER`, and a `seed-users-acl` initContainer in the Redis StatefulSet writes the `default` user line on first boot from `$REDIS_PASSWORD` so the platform-root password keeps working too. `requirepass` and `aclfile` are mutually exclusive in Redis (server refuses to start with both); the migration is invisible from a fresh-volume bootstrap and self-heals on first restart for existing volumes (initContainer sees missing/empty `users.acl` and seeds it; tenant Jobs re-apply `SETUSER` + `SAVE`)
 

--- a/argocd_repos.tf
+++ b/argocd_repos.tf
@@ -18,26 +18,25 @@
 # the maps are separate so an operator can scope keys narrowly.
 
 variable "argocd_repo_ssh_keys" {
-  description = "Operator-supplied map of `<id>` => SSH private key (PEM string). Components reference an entry by `repo_ssh_key_id:` in the domain yaml's `argocd_bootstrap:` block. Empty map = no private repo support; bootstrap repo must be public. NOT marked sensitive at the variable level so `for_each` over keys works; the rendered Secret's `data` block is sensitive in state."
+  description = "Operator-supplied map of `<id>` => SSH private key (PEM string). Bootstrap entries reference an id by `repo_ssh_key_id:` under the domain yaml's `argocd_bootstraps:` map. Empty map = no private repo support; bootstrap repos must be public. NOT marked sensitive at the variable level so `for_each` over keys works; the rendered Secret's `data` block is sensitive in state."
   type        = map(string)
   default     = {}
 }
 
 locals {
-  # (url, ssh_key_id) pairs across every project that declares an
-  # `argocd_bootstrap:` block with a private-repo auth hint. Iterates
-  # per-project from `local.projects[*].argocd_bootstrap`. `distinct()`
-  # collapses duplicates so multiple envs sharing a deploy repo produce
-  # one Secret.
-  _argocd_app_repo_pairs = distinct([
-    for _, project in local.projects : {
-      url        = try(project.argocd_bootstrap.repo_url, "")
-      ssh_key_id = try(project.argocd_bootstrap.repo_ssh_key_id, "")
-    }
-    if try(project.argocd_bootstrap, null) != null
-    && try(project.argocd_bootstrap.repo_ssh_key_id, "") != ""
-    && try(project.argocd_bootstrap.repo_url, "") != ""
-  ])
+  # (url, ssh_key_id) pairs across every project's `argocd_bootstraps:`
+  # map. Flattens project × bootstrap-entry; `distinct()` collapses
+  # duplicates so multiple envs / multiple bootstrap entries sharing
+  # one deploy repo produce one Secret.
+  _argocd_app_repo_pairs = distinct(flatten([
+    for _, project in local.projects : [
+      for _, entry in try(project.argocd_bootstraps, {}) : {
+        url        = try(entry.repo_url, "")
+        ssh_key_id = try(entry.repo_ssh_key_id, "")
+      }
+      if try(entry.repo_ssh_key_id, "") != "" && try(entry.repo_url, "") != ""
+    ]
+  ]))
 
   # Stable for_each key. Key id first so Secret names group by operator
   # intent (one key spans many repos → all those Secrets share a prefix);
@@ -57,7 +56,7 @@ check "argocd_repo_ssh_keys_resolved" {
       for pair in local._argocd_app_repo_pairs :
       contains(keys(var.argocd_repo_ssh_keys), pair.ssh_key_id)
     ])
-    error_message = "argocd_bootstrap entry references a `repo_ssh_key_id` not present in `var.argocd_repo_ssh_keys`. Referenced ids: ${jsonencode([for p in local._argocd_app_repo_pairs : p.ssh_key_id])}. Available ids: ${jsonencode(keys(var.argocd_repo_ssh_keys))}. Add the missing entry to `terraform.tfvars` (`argocd_repo_ssh_keys = { ... }`) or remove the `repo_ssh_key_id:` field from the domain yaml's argocd_bootstrap block if the repo is public."
+    error_message = "argocd_bootstraps entry references a `repo_ssh_key_id` not present in `var.argocd_repo_ssh_keys`. Referenced ids: ${jsonencode([for p in local._argocd_app_repo_pairs : p.ssh_key_id])}. Available ids: ${jsonencode(keys(var.argocd_repo_ssh_keys))}. Add the missing entry to `terraform.tfvars` (`argocd_repo_ssh_keys = { ... }`) or remove the `repo_ssh_key_id:` field from the domain yaml's argocd_bootstraps entry if the repo is public."
   }
 }
 

--- a/locals.tf
+++ b/locals.tf
@@ -192,10 +192,10 @@ locals {
           # (`<ns>-<key>-bootstrap`) + sub-apps recursing under it.
           # AppProject sourceRepos is the union across entries, so
           # multi-repo sub-Applications cross-referencing peer repos
-          # pass the allowlist (e.g. `sipmesh` + `sipmesh-frontend`
-          # both deploying into the same project namespace). Empty
-          # map = no Argo CD bootstrap (project has no Argo footprint
-          # unless `argocd_hostnames` is set).
+          # pass the allowlist (e.g. a backend chart and a frontend
+          # chart living in separate repos but sharing one project
+          # namespace). Empty map = no Argo CD bootstrap (project
+          # has no Argo footprint unless `argocd_hostnames` is set).
           argocd_bootstraps = try(env_spec.argocd_bootstraps, {})
           # Per-env shared-service provisioning flags. Same shape as
           # the per-component `postgres: true` / `redis: true` /

--- a/locals.tf
+++ b/locals.tf
@@ -187,12 +187,16 @@ locals {
           # rule — IngressRoute / Service live in the operator's deploy
           # repo, applied by Argo CD.
           argocd_hostnames = try(env_spec.argocd_hostnames, {})
-          # Argo CD bootstrap App-of-Apps root for this env. When set,
-          # TF emits a single root Application + AppProject; sub-apps
-          # live in the deploy repo and reconcile through Argo CD.
-          # Null = no Argo CD bootstrap (project has no Argo footprint
+          # Argo CD bootstrap App-of-Apps roots for this env, keyed by
+          # short name. Each entry → one root Application
+          # (`<ns>-<key>-bootstrap`) + sub-apps recursing under it.
+          # AppProject sourceRepos is the union across entries, so
+          # multi-repo sub-Applications cross-referencing peer repos
+          # pass the allowlist (e.g. `sipmesh` + `sipmesh-frontend`
+          # both deploying into the same project namespace). Empty
+          # map = no Argo CD bootstrap (project has no Argo footprint
           # unless `argocd_hostnames` is set).
-          argocd_bootstrap = try(env_spec.argocd_bootstrap, null)
+          argocd_bootstraps = try(env_spec.argocd_bootstraps, {})
           # Per-env shared-service provisioning flags. Same shape as
           # the per-component `postgres: true` / `redis: true` /
           # `ollama: true` knobs but applied at the project layer —

--- a/main.tf
+++ b/main.tf
@@ -133,16 +133,19 @@ module "project" {
   default_limits   = local.default_limits
   volume_base_path = var.host_volume_path
 
-  # Argo CD wiring — the project module emits an AppProject + bootstrap
-  # Application when `argocd_bootstrap:` is declared in the domain yaml,
-  # plus DNS+tunnel records per `argocd_hostnames:` entry. All three
-  # propagate from the per-env block in the domain yaml; null/empty
-  # values short-circuit the resources.
-  argocd_namespace = local.platform.services.argocd.enabled ? local.platform.services.argocd.namespace : ""
-  argocd_hostnames = try(each.value.argocd_hostnames, {})
-  argocd_bootstrap = try(each.value.argocd_bootstrap, null)
-  shared_services  = try(each.value.shared_services, {})
-  secrets          = try(each.value.secrets, {})
+  # Argo CD wiring — the project module emits an AppProject + one
+  # bootstrap Application per `argocd_bootstraps:` entry in the domain
+  # yaml, plus DNS+tunnel records per `argocd_hostnames:` entry. All
+  # three propagate from the per-env block in the domain yaml; empty
+  # values short-circuit the resources. Multi-entry bootstraps let
+  # multiple chart repos share one project namespace (e.g. a backend
+  # chart + a frontend chart deployed via separate Applications into
+  # the same `phost-…` namespace).
+  argocd_namespace  = local.platform.services.argocd.enabled ? local.platform.services.argocd.namespace : ""
+  argocd_hostnames  = try(each.value.argocd_hostnames, {})
+  argocd_bootstraps = try(each.value.argocd_bootstraps, {})
+  shared_services   = try(each.value.shared_services, {})
+  secrets           = try(each.value.secrets, {})
 
   # Shared-service endpoints. Each module's outputs collapse to null
   # when its own `enabled` flag is off, so the preconditions in

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -136,7 +136,7 @@ variable "volume_base_path" {
 }
 
 variable "argocd_namespace" {
-  description = "Namespace where the Argo CD chart is installed. Argo CD AppProject + bootstrap Application CRDs land here when this project's domain yaml declares an `argocd_bootstrap:` block. Empty disables Argo CD wiring entirely in this project (caller fails the precondition below if anything Argo-related is declared)."
+  description = "Namespace where the Argo CD chart is installed. Argo CD AppProject + bootstrap Application CRDs land here when this project's domain yaml declares any `argocd_bootstraps:` entries. Empty disables Argo CD wiring entirely in this project (caller fails the precondition below if anything Argo-related is declared)."
   type        = string
   default     = ""
 }
@@ -147,10 +147,10 @@ variable "argocd_hostnames" {
   default     = {}
 }
 
-variable "argocd_bootstrap" {
-  description = "Optional `argocd_bootstrap:` block declared under `envs.<env>:` in the domain yaml. Carries `repo_url`, `path`, `target_revision`, and optional `repo_ssh_key_id` (looked up in the root `argocd_repo_ssh_keys` map). When set, TF emits one root Application in the Argo CD namespace pointing at this repo+path; sub-Application manifests living there are recursively synced by Argo CD (App-of-Apps pattern). Application + workload manifests are operator-owned; TF only stands up the bootstrap entrypoint + the AppProject scoping it. Null disables Argo CD wiring for this project/env."
+variable "argocd_bootstraps" {
+  description = "Map of Argo CD bootstrap App-of-Apps roots declared under `envs.<env>.argocd_bootstraps:` in the domain yaml. Keyed by short name (engine emits `<namespace>-<key>-bootstrap` Application per entry). Each entry: `repo_url` (git remote URL — SSH form when `repo_ssh_key_id` is set), `path` (default `.`), `target_revision` (default `HEAD`), `repo_ssh_key_id` (optional — looked up in root `argocd_repo_ssh_keys` map). Sub-Applications under `path` are recursively synced by Argo CD; their `spec.project` must equal this project's namespace to clear the AppProject allowlist. AppProject `sourceRepos` aggregates every entry's `repo_url`, so sub-Applications cross-referencing peer repos pass the allowlist. Empty map disables Argo CD bootstrap (project still gets an AppProject when `argocd_hostnames` is non-empty)."
   type        = any
-  default     = null
+  default     = {}
 }
 
 variable "shared_services" {
@@ -1156,19 +1156,22 @@ resource "kubernetes_secret_v1" "env_random" {
 #      IngressRoute itself + the Service it targets live in the
 #      operator's deploy repo (chart-rendered, Argo CD-applied).
 #
-#   2. `argocd_bootstrap:` block in the domain yaml — repo URL +
-#      path + branch the operator's deploy repo lives at. TF emits
-#      ONE root Application in the Argo CD namespace + an AppProject
-#      scoping every Application synced under it to this project's
+#   2. `argocd_bootstraps:` map in the domain yaml — keyed by short
+#      name, each entry carries the repo URL + path + branch of one
+#      operator deploy repo. TF emits ONE root Application per entry
+#      (`<ns>-<key>-bootstrap`) plus a single AppProject scoping every
+#      Application synced under any of them to this project's
 #      namespace. Sub-Applications and AppProject overrides land in
-#      the deploy repo itself, not here.
+#      the deploy repos themselves, not here. Multi-entry use case:
+#      one chart per repo deployed into the same namespace (e.g.
+#      `sipmesh` + `sipmesh-frontend`).
 #
 # When neither is declared, the project has zero Argo CD footprint.
 
-check "argocd_bootstrap_requires_argocd_ns" {
+check "argocd_bootstraps_require_argocd_ns" {
   assert {
-    condition     = var.argocd_bootstrap == null || var.argocd_namespace != ""
-    error_message = "project '${local.namespace}' declares an `argocd_bootstrap:` block but `argocd_namespace` is empty. Enable `services.argocd.enabled = true` in `config/platform.yaml` and re-apply."
+    condition     = length(var.argocd_bootstraps) == 0 || var.argocd_namespace != ""
+    error_message = "project '${local.namespace}' declares `argocd_bootstraps:` entries but `argocd_namespace` is empty. Enable `services.argocd.enabled = true` in `config/platform.yaml` and re-apply."
   }
 }
 
@@ -1190,7 +1193,7 @@ check "argocd_hostnames_node_ip_set_when_no_tunnel" {
 # resources are entirely denied — the platform owns CRDs, ClusterRoles,
 # Namespaces.
 resource "kubectl_manifest" "argocd_app_project" {
-  count = (var.argocd_bootstrap != null || length(var.argocd_hostnames) > 0) ? 1 : 0
+  for_each = (length(var.argocd_bootstraps) > 0 || length(var.argocd_hostnames) > 0) ? toset(["enabled"]) : toset([])
 
   yaml_body = yamlencode({
     apiVersion = "argoproj.io/v1alpha1"
@@ -1204,11 +1207,11 @@ resource "kubectl_manifest" "argocd_app_project" {
       }
     }
     spec = {
-      description = "Auto-managed AppProject for TF project ${local.namespace}. Pins Application destinations to this namespace and source repos to the operator's deploy repo declared in `argocd_bootstrap:`."
+      description = "Auto-managed AppProject for TF project ${local.namespace}. Pins Application destinations to this namespace and source repos to every operator deploy repo declared under `argocd_bootstraps:`."
 
-      sourceRepos = compact([
-        try(var.argocd_bootstrap.repo_url, ""),
-      ])
+      sourceRepos = distinct(compact([
+        for _, b in var.argocd_bootstraps : try(b.repo_url, "")
+      ]))
 
       destinations = [
         # Workload destination — every chart-rendered resource the
@@ -1242,7 +1245,7 @@ resource "kubectl_manifest" "argocd_app_project" {
 # `spec.project: <project-name>` to land workloads (AppProject above
 # refuses anything else).
 resource "kubectl_manifest" "argocd_bootstrap" {
-  count = var.argocd_bootstrap == null ? 0 : 1
+  for_each = var.argocd_bootstraps
 
   depends_on = [kubectl_manifest.argocd_app_project]
 
@@ -1250,7 +1253,7 @@ resource "kubectl_manifest" "argocd_bootstrap" {
     apiVersion = "argoproj.io/v1alpha1"
     kind       = "Application"
     metadata = {
-      name      = "${local.namespace}-bootstrap"
+      name      = "${local.namespace}-${each.key}-bootstrap"
       namespace = var.argocd_namespace
       finalizers = [
         "resources-finalizer.argocd.argoproj.io",
@@ -1259,15 +1262,16 @@ resource "kubectl_manifest" "argocd_bootstrap" {
         "app.kubernetes.io/managed-by" = "terraform"
         "platform.tenant"              = local.namespace
         "platform.role"                = "bootstrap"
+        "platform.bootstrap.key"       = each.key
       }
     }
     spec = {
       project = local.namespace
 
       source = {
-        repoURL        = var.argocd_bootstrap.repo_url
-        path           = try(var.argocd_bootstrap.path, ".")
-        targetRevision = try(var.argocd_bootstrap.target_revision, "HEAD")
+        repoURL        = each.value.repo_url
+        path           = try(each.value.path, ".")
+        targetRevision = try(each.value.target_revision, "HEAD")
         # Bootstrap directory contains plain Application yaml manifests —
         # no Helm rendering at the bootstrap layer. directory.recurse
         # picks up nested folders so the operator can group apps

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -1163,8 +1163,9 @@ resource "kubernetes_secret_v1" "env_random" {
 #      Application synced under any of them to this project's
 #      namespace. Sub-Applications and AppProject overrides land in
 #      the deploy repos themselves, not here. Multi-entry use case:
-#      one chart per repo deployed into the same namespace (e.g.
-#      `sipmesh` + `sipmesh-frontend`).
+#      one chart per repo deployed into the same namespace (a backend
+#      chart and a frontend chart in separate repos sharing one
+#      project namespace, each owning its own Application manifest).
 #
 # When neither is declared, the project has zero Argo CD footprint.
 


### PR DESCRIPTION
## Summary

- Renames per-env Argo CD bootstrap input `argocd_bootstrap:` (single object) → `argocd_bootstraps:` (map of objects keyed by short name) at the domain-yaml layer and at `modules/project`.
- Engine emits one root Application per entry: `<namespace>-<key>-bootstrap`. AppProject `sourceRepos` aggregates every entry's `repo_url` so sub-Applications cross-referencing peer repos pass the allowlist.
- `kubectl_manifest.argocd_app_project` switched from `count` to `for_each = ... ? toset(["enabled"]) : toset([])` per AGENT.md "prefer for_each over count".
- `argocd_repos.tf` follow-fix: `_argocd_app_repo_pairs` now flattens `project.argocd_bootstraps` (map) instead of reading the removed singular `project.argocd_bootstrap`.

## Motivation

Multiple independent chart repos sharing one project namespace. With the old singular shape, a project namespace could only be served by one App-of-Apps repo — sister charts had to either share that repo's `deploy/argocd/apps/` directory (cross-repo coupling) or land in separate namespaces. The map form lets each chart repo own its own bootstrap entry, its own Application manifest, and its own deploy key, while the engine emits a single AppProject scoping everything to the same namespace.

## Migration

**BREAKING** for callers using the singular form. Yaml-only edit on the operator side:

```yaml
# before
argocd_bootstrap:
  repo_url: git@github.com:org/deploy.git
  path: deploy/argocd/apps
  target_revision: main
  repo_ssh_key_id: deploy

# after — wrap under any key (becomes Application name suffix)
argocd_bootstraps:
  deploy:
    repo_url: git@github.com:org/deploy.git
    path: deploy/argocd/apps
    target_revision: main
    repo_ssh_key_id: deploy
```

First apply destroy-replaces the bootstrap Application (legacy `<ns>-bootstrap` → new `<ns>-<key>-bootstrap`). Sub-Applications keep their own names + reattach automatically once the new bootstrap App syncs. Operator OK required because of the destroy-replace.

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform validate` ok
- [x] Applied against a dev project with two `argocd_bootstraps` entries — both bootstraps materialise, both `Synced/Healthy`, AppProject `sourceRepos` lists both repos, sub-Apps under each pass the allowlist
- [x] Legacy singular Application destroy-replaced cleanly: existing sub-App re-attached on next reconcile, no manifest drift in chart-rendered resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)
