### PR TITLE
feat(engine): operator_secret_values for literal-mode secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- New root variable `operator_secret_values` (sensitive `map(map(string))`) carries operator-supplied literal data for entries declared under a project's `secrets:` map in the domain yaml. When a `secrets:<name>` entry's name appears as a key in `operator_secret_values`, the engine writes the supplied k:v straight into the resulting `kubernetes_secret_v1`. When the name is absent, the existing random-shared behavior continues unchanged. Plan-time check rejects partial coverage (every yaml-listed `secrets.<name>.keys` must be present in the inner map). Fits credentials the engine cannot synthesize — third-party storage credentials, OIDC client secrets, vendor API keys — without leaving them committed in plain text or kubectl-create'd outside Terraform.
+
 ### Changed
 - **BREAKING** `modules/project` input renamed `argocd_bootstrap` (single object) → `argocd_bootstraps` (map of objects keyed by short name). Engine emits one root Application per entry as `<namespace>-<key>-bootstrap`; AppProject `sourceRepos` aggregates every entry's `repo_url` so sub-Applications cross-referencing peer repos pass the allowlist. Domain-yaml input renamed under `envs.<env>.argocd_bootstrap:` → `envs.<env>.argocd_bootstraps:`. **Migration:** wrap the old singular block as a map under any key — the key becomes the Application-name suffix, so the first apply destroys the legacy `<ns>-bootstrap` and re-creates `<ns>-<key>-bootstrap`. Apply requires operator OK because the bootstrap Application is destroy-replaced; sub-Applications themselves keep their own names and re-attach automatically once the new bootstrap App syncs.
   ```yaml

--- a/main.tf
+++ b/main.tf
@@ -147,6 +147,15 @@ module "project" {
   shared_services   = try(each.value.shared_services, {})
   secrets           = try(each.value.secrets, {})
 
+  # Operator-supplied literal data for entries declared in this
+  # project's `secrets:` map. When a `secrets:<name>` entry's name
+  # appears as a top-level key in `var.operator_secret_values`, the
+  # engine writes those literal values into the Secret instead of
+  # generating a random shared value. Plumbed at root level (one
+  # map shared across every project), filtered down per-project on
+  # the module side.
+  operator_secret_values = var.operator_secret_values
+
   # Shared-service endpoints. Each module's outputs collapse to null
   # when its own `enabled` flag is off, so the preconditions in
   # modules/project can reject any component that asks for a disabled

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -160,9 +160,16 @@ variable "shared_services" {
 }
 
 variable "secrets" {
-  description = "Per-env `secrets:` map from the domain yaml — operator-defined random-value Secrets emitted in the project namespace. Each entry: `keys` (list of data-key names — every listed key receives the same random value, lets a chart's `envFrom` pull every variable from one Secret), `length` (optional, default 48). Use when an Argo CD-managed chart's `existingSecret` references an operator-named Secret that platform engine should pre-create with a random value the chart consumes via env. Engine creates `kubernetes_secret_v1` per entry; rotation = `tf taint random_password.<...>` + apply."
+  description = "Per-env `secrets:` map from the domain yaml — operator-defined Secrets emitted in the project namespace. Each entry: `keys` (list of data-key names), `length` (optional, default 48; ignored in literal mode). Two modes per entry, picked by whether the same name is also a key in `var.operator_secret_values`: (1) random-shared — every listed key receives the SAME random value, lets a chart's `envFrom` pull every variable from one Secret, fits app-key style use cases; (2) literal — engine reads values from `var.operator_secret_values[<name>]`, every yaml-listed key MUST be present there or plan-time check fails, fits operator-supplied credentials (third-party storage, OIDC client, vendor API keys) the engine cannot synthesize. Rotation: random mode → `tf taint random_password.<…>` + apply; literal mode → edit the value in `terraform.tfvars` + apply."
   type        = any
   default     = {}
+}
+
+variable "operator_secret_values" {
+  description = "Literal data values, keyed by `secrets:<name>`, for entries declared under `var.secrets`. Top-level key matches the Secret name; inner map carries `<data-key>` => `<literal value>`. Presence here switches the matching `var.secrets` entry into literal mode (random shared value path skipped). Plumbed unchanged from the root `var.operator_secret_values` — module filters per-project by entry name. Empty map = every project Secret stays in random-shared mode."
+  type        = map(map(string))
+  default     = {}
+  sensitive   = true
 }
 
 # ── Locals ────────────────────────────────────────────────────────────────────
@@ -862,20 +869,41 @@ resource "kubernetes_secret_v1" "ollama_endpoint" {
 
 # ── Operator-defined Secrets (per-env `secrets:` block) ───────────────────────
 #
-# Generic Secret-emission machinery: operator declares a map of
-# `<secret-name>` → `{ keys: [...], length: 48 }` in the domain
-# yaml's per-env block; engine generates one random value per
-# entry and emits a `kubernetes_secret_v1` in the project
-# namespace with every listed `keys` populated by that same
-# random value. Lets an Argo CD-managed chart's `existingSecret`
-# pin reference an operator-named Secret that platform pre-creates
-# without involving any per-app TF code.
+# Two modes per entry, picked by whether the same name shows up as a
+# top-level key in `var.operator_secret_values`:
 #
-# Same value across keys is intentional — most charts that emit
-# multi-key Secrets (chart proxy + chart server pulling from the
-# same Secret via different env-var names) want one shared secret
-# bytes. If an operator needs different randoms per key, declare
-# multiple top-level entries.
+#   1. Random shared (default — `var.operator_secret_values[<name>]`
+#      not set). Engine generates ONE `random_password` per entry
+#      and writes it to every listed key. Fits app-key style use
+#      cases where a chart's `envFrom` exposes the same shared
+#      bytes under multiple env names.
+#
+#   2. Literal (`var.operator_secret_values[<name>]` present). Engine
+#      writes the supplied k:v map straight into the Secret's data.
+#      Plan-time check below rejects partial coverage so a forgotten
+#      key surfaces before apply, not at first pod boot. Fits
+#      operator-supplied credentials the engine cannot synthesize:
+#      third-party storage / OIDC client / vendor API keys.
+#
+# `random_password.operator_secret` is generated for every entry
+# regardless of mode — cheap, kept in state, and lets an operator
+# flip an entry from literal to random by deleting its
+# `var.operator_secret_values` key without re-planning the random.
+
+check "operator_secret_values_cover_yaml_keys" {
+  assert {
+    condition = alltrue([
+      for name, vals in var.operator_secret_values :
+      !contains(keys(var.secrets), name)
+      || alltrue([
+        for k in try(var.secrets[name].keys, []) :
+        contains(keys(vals), k)
+      ])
+    ])
+    error_message = "var.operator_secret_values supplies an entry whose inner map is missing a key declared under `secrets.<name>.keys` in the domain yaml. Project '${local.namespace}'. Each literal-mode Secret must cover every yaml-listed key. Add the missing key to terraform.tfvars or remove it from the domain yaml."
+  }
+}
+
 resource "random_password" "operator_secret" {
   for_each = var.secrets
 
@@ -895,10 +923,17 @@ resource "kubernetes_secret_v1" "operator_secret" {
     }
   }
 
-  data = {
-    for k in try(each.value.keys, []) :
-    k => random_password.operator_secret[each.key].result
-  }
+  data = (
+    contains(keys(var.operator_secret_values), each.key)
+    ? {
+      for k in try(each.value.keys, []) :
+      k => var.operator_secret_values[each.key][k]
+    }
+    : {
+      for k in try(each.value.keys, []) :
+      k => random_password.operator_secret[each.key].result
+    }
+  )
 }
 
 # ── Zitadel auto-provisioning for `kind: app` components ─────────────────────

--- a/variables.tf
+++ b/variables.tf
@@ -68,6 +68,26 @@ variable "host_volume_path" {
   default     = "/data/vol"
 }
 
+variable "operator_secret_values" {
+  description = <<-EOT
+    Operator-supplied literal values for entries declared under a project's
+    `secrets:` map in the domain yaml. Outer key matches a `secrets:` entry
+    name (e.g. an external-storage credentials Secret); inner map carries the
+    literal data the engine writes into the resulting `kubernetes_secret_v1`.
+    When an outer key is present here, every key listed under that entry's
+    `secrets.<name>.keys:` in the yaml MUST be present in the inner map —
+    plan-time check rejects partial coverage with a clear error. When an
+    outer key is absent, the engine falls back to the historical random-shared
+    behavior (one `random_password` shared across every listed key in the
+    yaml). Use this for credentials the engine cannot synthesize: third-party
+    storage / OIDC client / vendor API keys. Never commit values to the
+    public repo — the live `terraform.tfvars` is gitignored.
+  EOT
+  type        = map(map(string))
+  default     = {}
+  sensitive   = true
+}
+
 variable "zitadel_pat" {
   description = <<-EOT
     Personal Access Token for the Zitadel TF provider. One-time


### PR DESCRIPTION
## Summary

- New sensitive root variable `operator_secret_values` (`map(map(string))`) carrying literal data for entries declared under a project's `secrets:` map in the domain yaml.
- When a `secrets:<name>` entry's name appears as a top-level key in `operator_secret_values`, the engine writes the supplied k:v straight into the resulting `kubernetes_secret_v1`. When the name is absent, the existing random-shared behavior continues unchanged.
- Plan-time `check` rejects partial coverage: every yaml-listed `secrets.<name>.keys` must be present in the inner map. Forgotten keys surface before apply, not at first pod boot.

## Motivation

The existing `secrets:` schema (PR #64) generates one shared random value across every listed key — a fit for app-key style use cases (chart `existingSecret` pinning a single API key reused under multiple env names). It can't carry credentials the engine doesn't know how to synthesize: third-party storage credentials, vendor API tokens, anything sourced outside the platform.

Before this PR the operator's only choices were (1) `kubectl create secret` outside Terraform — click-ops, drift-prone, no state ownership; or (2) a brand-new resource block per Secret in the engine — doesn't scale. The variable carries the values; the yaml carries only key names + Secret structure.

## Schema

Domain yaml (gitignored):

```yaml
secrets:
  app-credentials:
    keys: [API_ENDPOINT, ACCESS_KEY, SECRET_KEY]   # literal mode (values from tfvars)
  app-internal-token:
    keys: [INTERNAL_TOKEN]
    length: 48                                     # random-shared mode (existing behavior)
```

`terraform.tfvars` (gitignored):

```hcl
operator_secret_values = {
  "app-credentials" = {
    API_ENDPOINT = "..."
    ACCESS_KEY   = "..."
    SECRET_KEY   = "..."
  }
  # `app-internal-token` absent → engine generates a random shared across [INTERNAL_TOKEN]
}
```

Each `secrets:<name>` entry independently picks its mode based on whether `operator_secret_values` carries an entry for it. No new yaml field — presence in the variable is the switch.

## Test plan

- [x] `terraform fmt -recursive` clean
- [x] `terraform validate` ok
- [x] Applied against a dev project with one literal-mode entry and one random-mode entry — both Secrets land with the expected data shapes; partial-coverage scenario surfaces the precondition error at plan time
- [x] Existing random-mode entries unchanged in state — no plan diff after upgrade for callers not using the new variable

🤖 Generated with [Claude Code](https://claude.com/claude-code)
