### PR TITLE
feat(zitadel): namespace_phost-*-{admin,sre} roles for platform-dash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `platform_dash` Zitadel application gains 12 new `namespace_phost-<slug>-<env>_admin` / `_sre` role keys (6 tenant `phost-*` namespaces × admin/sre). Mirrors the existing `cluster_<name>_admin/sre` family but scoped to a single tenant namespace. Consumed by the dashboard's namespace-scoped authorization (PR #52 in `platform-dash`). System namespaces (`platform`, `mail`, `ops`, `monitoring`, `ingress-controller`) are intentionally NOT delegable — they hold shared platform infra and stay cluster-admin only.
+
 ### Removed
 - Untracked `.claude/` skill cache from version control (4 markdown files: `SKILL.md`, `architecture.md`, `operating.md`, `troubleshooting.md`). The directory was already covered by `.gitignore`, but the files were committed before the gitignore line landed and remained tracked. Active skill content lives in operator's home at `~/.claude/skills/platform/`.
 

--- a/platform_dash.tf
+++ b/platform_dash.tf
@@ -60,14 +60,33 @@ module "platform_dash_oidc" {
   secret_namespace = kubernetes_namespace_v1.platform.metadata[0].name
 
   # Role keys mirror what the dashboard's authz code checks for —
-  # global admin/sre + per-cluster overrides. Add cluster_<name>_*
-  # entries as more clusters land in DASH_CLUSTERS_JSON.
+  # global admin/sre + per-cluster overrides + per-tenant-namespace
+  # delegations. Add cluster_<name>_* entries as more clusters land
+  # in DASH_CLUSTERS_JSON. Add namespace_phost-<slug>-<env>_*
+  # entries as more tenant namespaces become delegable. System
+  # namespaces (`platform`, `mail`, `ops`, `monitoring`,
+  # `ingress-controller`) are intentionally NOT delegable — they
+  # hold shared platform infra (Vault, Postgres, MySQL, Redis,
+  # Zitadel, Stalwart, Roundcube, cloudflared, Traefik). Only
+  # `phost-<slug>-<env>` tenant namespaces are listed here.
   roles = [
     { key = "platform_admin", display_name = "Platform Admin" },
     { key = "platform_sre", display_name = "Platform SRE" },
     { key = "user", display_name = "User" },
     { key = "cluster_local_admin", display_name = "Cluster local Admin" },
-    { key = "cluster_local_sre", display_name = "Cluster local SRE" }
+    { key = "cluster_local_sre", display_name = "Cluster local SRE" },
+    { key = "namespace_phost-ipsupport-us-dev_admin", display_name = "Namespace phost-ipsupport-us-dev Admin" },
+    { key = "namespace_phost-ipsupport-us-dev_sre", display_name = "Namespace phost-ipsupport-us-dev SRE" },
+    { key = "namespace_phost-ipsupport-us-prod_admin", display_name = "Namespace phost-ipsupport-us-prod Admin" },
+    { key = "namespace_phost-ipsupport-us-prod_sre", display_name = "Namespace phost-ipsupport-us-prod SRE" },
+    { key = "namespace_phost-jagdterrier-club-prod_admin", display_name = "Namespace phost-jagdterrier-club-prod Admin" },
+    { key = "namespace_phost-jagdterrier-club-prod_sre", display_name = "Namespace phost-jagdterrier-club-prod SRE" },
+    { key = "namespace_phost-paseka-co-dev_admin", display_name = "Namespace phost-paseka-co-dev Admin" },
+    { key = "namespace_phost-paseka-co-dev_sre", display_name = "Namespace phost-paseka-co-dev SRE" },
+    { key = "namespace_phost-paseka-co-prod_admin", display_name = "Namespace phost-paseka-co-prod Admin" },
+    { key = "namespace_phost-paseka-co-prod_sre", display_name = "Namespace phost-paseka-co-prod SRE" },
+    { key = "namespace_phost-priroda-kharkov-ua-prod_admin", display_name = "Namespace phost-priroda-kharkov-ua-prod Admin" },
+    { key = "namespace_phost-priroda-kharkov-ua-prod_sre", display_name = "Namespace phost-priroda-kharkov-ua-prod SRE" }
   ]
 }
 


### PR DESCRIPTION
## Summary
- Adds 12 namespace-scoped role keys to platform-dash Zitadel app — 6 phost-* tenant namespaces × admin/sre
- Consumed by platform-dash PR #52 (namespace-scoped authorization in the dashboard)
- System namespaces (platform/mail/ops/monitoring/ingress-controller) intentionally omitted — they stay cluster-admin only

## Scope
- `platform_dash.tf` — extends `roles = [...]` list with new entries
- `CHANGELOG.md` — entry under Unreleased / Added

## State
- Already applied to live cluster ahead of this commit (Zitadel events2_pkey race forced two-stage apply on first run; second `./tf apply` finished the remaining 2 roles cleanly)
- `./tf plan` post-apply: \`No changes. Your infrastructure matches the configuration.\`
- This PR brings repo HEAD in sync with cluster state

## Test plan
- [ ] PR review confirms the 12 new keys correspond to the 6 phost-* namespaces × admin/sre
- [ ] platform-dash UI surfaces the new roles in role-assignment screens
- [ ] Operator with `namespace_phost-X_admin` can write inside that namespace and gets 403 elsewhere

🤖 Generated with [Claude Code](https://claude.com/claude-code)