### PR TITLE
chore(tf): TCP listener probe for Zitadel port-forward readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `platform_dash` Zitadel application gains 12 new `namespace_phost-<slug>-<env>_admin` / `_sre` role keys (6 tenant `phost-*` namespaces × admin/sre). Mirrors the existing `cluster_<name>_admin/sre` family but scoped to a single tenant namespace. Consumed by the dashboard's namespace-scoped authorization (PR #52 in `platform-dash`). System namespaces (`platform`, `mail`, `ops`, `monitoring`, `ingress-controller`) are intentionally NOT delegable — they hold shared platform infra and stay cluster-admin only.
 
+### Changed
+- `./tf` wrapper's Zitadel port-forward readiness probe switched from HTTP `GET /.well-known/openid-configuration` (with curl) to a TCP listener probe via bash `/dev/tcp/127.0.0.1/8080`. The wrapper only needs to wait for kubectl's local listener to be open — Zitadel's own readiness behind the listener is the provider's concern (errors cleanly if not). Earlier curl probe false-warned on cold-start Zitadel pods. Loop now polls every 250ms × 60 attempts (was 500ms × 30) — same 15s overall budget but TCP connect typically completes in <1s on warm pods.
+
 ### Removed
 - Untracked `.claude/` skill cache from version control (4 markdown files: `SKILL.md`, `architecture.md`, `operating.md`, `troubleshooting.md`). The directory was already covered by `.gitignore`, but the files were committed before the gitignore line landed and remained tracked. Active skill content lives in operator's home at `~/.claude/skills/platform/`.
 

--- a/tf
+++ b/tf
@@ -189,11 +189,18 @@ start_zitadel_port_forward() {
   echo "tf: kubectl port-forward svc/zitadel 8080:8080 (provider transport, bypasses Cloudflare gRPC trailer-strip)"
   kubectl port-forward -n platform svc/zitadel 8080:8080 >/dev/null 2>&1 &
   ZITADEL_PF_PID=$!
-  for _ in $(seq 1 30); do
-    if curl -fsS -o /dev/null --max-time 1 "http://localhost:8080/.well-known/openid-configuration" 2>/dev/null; then
+  # Probe the local TCP listener only — that's all the wrapper has to wait for.
+  # Whether Zitadel itself is ready behind the listener is the provider's
+  # concern (it'll error cleanly if not). Earlier versions waited on
+  # `/.well-known/openid-configuration` and false-warned on cold-start
+  # Zitadel; bash's `<>` open against the listener probes only the
+  # kubectl-side TCP, completes in <1s on a warm pod.
+  for _ in $(seq 1 60); do
+    if (exec 3<>/dev/tcp/127.0.0.1/8080) 2>/dev/null; then
+      exec 3<&- 3>&-
       return 0
     fi
-    sleep 0.5
+    sleep 0.25
   done
   echo "tf: port-forward never became ready, continuing anyway (Zitadel may not be up yet)" >&2
 }


### PR DESCRIPTION
## Summary
- `./tf` wrapper's Zitadel port-forward readiness probe switched from HTTP `GET /.well-known/openid-configuration` (curl) to a TCP listener probe via bash `/dev/tcp/127.0.0.1/8080`
- Removes the spurious \"port-forward never became ready, continuing anyway\" warning that fired on every `./tf` invocation when Zitadel was cold-starting (the warning was cosmetic — apply still worked because PF was actually up by the time the provider hit it)
- Loop polls every 250ms × 60 attempts (was 500ms × 30) — same 15s overall budget, finer granularity

## Scope
- `tf` script — `start_zitadel_port_forward` body only
- `CHANGELOG.md` — entry under Unreleased / Changed

## Test plan
- [ ] `./tf plan` on a warm cluster — no \"port-forward never became ready\" warning
- [ ] `./tf plan` immediately after restarting `zitadel` pod (cold-start scenario) — still works without false warning
- [ ] Provider behaviour unchanged (no Zitadel resource diffs from the probe change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)