### PR TITLE
feat(metallb): add MetalLB module with L2 mode for bare-metal LoadBalancer

### DIFF
--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -161,6 +161,56 @@ services:
   #   systemctl enable --now iscsid
   # Without these, Longhorn instance-managers crash at startup
   # and no PVC ever binds.
+  # MetalLB — bare-metal LoadBalancer for `Service type:
+  # LoadBalancer` on a self-hosted / VPS cluster.
+  #
+  # L2 mode only: one node per VIP announces via gratuitous ARP.
+  # The announcing node MUST be reachable from the network the
+  # client lives on (real public IP for Internet traffic, or
+  # private IP if the cluster only serves intranet).
+  #
+  # Source-IP preservation requires the consuming Service to set
+  # `externalTrafficPolicy: Local` AND its backend pod to land on
+  # the announcing node — kube-proxy with Local does NOT forward
+  # across nodes; it drops if no local backend exists. Multi-pod
+  # horizontal scale on L2 = DaemonSet pattern (one pod per
+  # speaker-eligible node). True multi-active fronting one VIP
+  # needs BGP mode + an upstream router that speaks BGP.
+  #
+  # Pool layout is per-operator. Each pool's `l2_node_selectors`
+  # restricts which nodes announce its VIPs; without it, every
+  # speaker would ARP for the IP and the upstream switch picks
+  # whichever speaker won the race (split-brain; flapping).
+  metallb:
+    enabled: false
+    # Controller node selector — controller is stateless, just
+    # picks IPs from pools. Pin to a stable tier to avoid flap.
+    # controller_node_selector:
+    #   workload-tier: general
+    # Speaker node selector — restricts the speaker DaemonSet to
+    # the nodes that should announce VIPs (i.e. the nodes whose
+    # NICs the LB IPs live on). Empty = speaker on every
+    # un-tainted node, which is rarely what you want.
+    # speaker_node_selector:
+    #   kubernetes.io/hostname: edge-node
+    # Speaker tolerations — needed if the announcing node carries
+    # an app-specific taint (e.g. a VPS that's both an LB ingress
+    # and an app-pinned node).
+    # speaker_tolerations:
+    #   - { key: app, operator: Equal, value: matrix, effect: NoSchedule }
+    # Pools — map of pool name → addresses + L2 advertisement.
+    # `addresses` is a list of CIDRs or `start-end` ranges in
+    # MetalLB's native syntax. `auto_assign: false` makes Services
+    # opt in by name (`spec.loadBalancerIP: <addr>`).
+    # `l2_node_selectors` is a list of label-selector maps that
+    # becomes the L2Advertisement.spec.nodeSelectors field.
+    # pools:
+    #   public:
+    #     addresses:
+    #       - 192.0.2.10/32
+    #     l2_node_selectors:
+    #       - { kubernetes.io/hostname: edge-node }
+
   longhorn:
     enabled: false
     # `replica_count` — how many copies of each volume Longhorn

--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -195,9 +195,9 @@ services:
     #   kubernetes.io/hostname: edge-node
     # Speaker tolerations — needed if the announcing node carries
     # an app-specific taint (e.g. a VPS that's both an LB ingress
-    # and an app-pinned node).
+    # and a dedicated-app node).
     # speaker_tolerations:
-    #   - { key: app, operator: Equal, value: matrix, effect: NoSchedule }
+    #   - { key: app, operator: Equal, value: <app-name>, effect: NoSchedule }
     # Pools — map of pool name → addresses + L2 advertisement.
     # `addresses` is a list of CIDRs or `start-end` ranges in
     # MetalLB's native syntax. `auto_assign: false` makes Services

--- a/locals.tf
+++ b/locals.tf
@@ -66,6 +66,14 @@ locals {
         tolerations      = []
         tag_pools        = {}
       }
+      metallb = {
+        enabled                  = false
+        controller_node_selector = {}
+        controller_tolerations   = []
+        speaker_node_selector    = {}
+        speaker_tolerations      = []
+        pools                    = {}
+      }
       backup = {
         enabled                = false
         postgres_databases     = []
@@ -145,6 +153,7 @@ locals {
       argocd        = merge(local._platform_defaults.services.argocd, try(local._platform_services.argocd, {}))
       kured         = merge(local._platform_defaults.services.kured, try(local._platform_services.kured, {}))
       longhorn      = merge(local._platform_defaults.services.longhorn, try(local._platform_services.longhorn, {}))
+      metallb       = merge(local._platform_defaults.services.metallb, try(local._platform_services.metallb, {}))
       backup        = merge(local._platform_defaults.services.backup, try(local._platform_services.backup, {}))
       platform_dash = merge(local._platform_defaults.services.platform_dash, try(local._platform_services.platform_dash, {}))
     }

--- a/metallb.tf
+++ b/metallb.tf
@@ -1,0 +1,32 @@
+# MetalLB — bare-metal LoadBalancer.
+#
+# Enables real-IP allocation for `Service type: LoadBalancer` on a
+# self-hosted / VPS cluster. L2 mode only (gratuitous ARP); BGP is
+# out of scope until the platform spans multi-rack / multi-DC.
+#
+# Pool layout is operator-driven via `services.metallb.pools` —
+# the engine knows nothing about which node owns which IP. Each
+# pool's `l2_node_selectors` restricts the speakers that announce
+# its VIPs (avoids ARP split-brain when multiple speakers run).
+#
+# Source-IP preservation requires the consuming Service to set
+# `externalTrafficPolicy: Local` AND its backend pod to land on
+# the announcing node — see modules/metallb/main.tf for the full
+# rationale.
+
+module "metallb" {
+  source     = "./modules/metallb"
+  depends_on = [module.addons]
+
+  enabled                  = local.platform.services.metallb.enabled
+  controller_node_selector = local.platform.services.metallb.controller_node_selector
+  controller_tolerations   = local.platform.services.metallb.controller_tolerations
+  speaker_node_selector    = local.platform.services.metallb.speaker_node_selector
+  speaker_tolerations      = local.platform.services.metallb.speaker_tolerations
+  pools                    = local.platform.services.metallb.pools
+}
+
+output "metallb_pools" {
+  description = "Map of pool name → list of addresses, mirroring the operator-configured pools. Empty when MetalLB is disabled."
+  value       = module.metallb.pools
+}

--- a/modules/metallb/main.tf
+++ b/modules/metallb/main.tf
@@ -1,0 +1,222 @@
+# MetalLB — bare-metal LoadBalancer for k8s on a self-hosted /
+# VPS cluster. Enables `Service type: LoadBalancer` to allocate
+# real on-network IPs (instead of the cloud-controller no-op
+# that leaves them stuck in <pending>).
+#
+# L2 mode only — no BGP. One node per VIP announces via
+# gratuitous ARP. Source-IP preservation requires the consuming
+# Service to set `externalTrafficPolicy: Local` AND the backend
+# pod to land on the announcing node (kube-proxy does not
+# forward traffic across nodes when Local is set; it drops if
+# no local backend exists). Multi-replica horizontal scale on
+# L2 = DaemonSet pattern (pod on every node that has a speaker)
+# or multiple Services with distinct VIPs. True multi-active
+# fronting one VIP needs BGP mode + an upstream router that
+# speaks BGP — out of scope for this module.
+#
+# The chart's controller picks IPs from configured pools; speaker
+# DaemonSet does the L2 announcement. Pools and L2Advertisements
+# are CRDs the operator config defines per intent.
+
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.14"
+    }
+  }
+}
+
+# ── Inputs ─────────────────────────────────────────────────────────────────
+
+variable "enabled" {
+  description = "Whether to deploy MetalLB. False collapses every resource."
+  type        = bool
+  default     = false
+}
+
+variable "namespace" {
+  description = "Namespace MetalLB lives in. Convention is `metallb-system`; the chart's controller and speaker reference each other via in-namespace Services and the CRD validating webhook is namespace-bound, so override only if a fleet-wide policy requires a different one."
+  type        = string
+  default     = "metallb-system"
+}
+
+variable "version_pin" {
+  description = "Helm chart version for metallb/metallb. Pinned so an upstream re-tag doesn't change CRD shape or defaults across applies."
+  type        = string
+  default     = "0.14.9"
+}
+
+variable "controller_node_selector" {
+  description = "Node selector for the MetalLB controller Deployment. Controller is stateless and picks IPs from pools — it can run anywhere with cluster API access. Empty map = land wherever k8s schedules. Set to a stable tier (e.g. `{ workload-tier: general }`) to avoid the controller bouncing onto edge / tainted nodes."
+  type        = map(string)
+  default     = {}
+}
+
+variable "controller_tolerations" {
+  description = "Tolerations for the MetalLB controller. Standard k8s toleration shape. Empty = controller lands only on un-tainted nodes."
+  type = list(object({
+    key                = optional(string)
+    operator           = optional(string, "Exists")
+    value              = optional(string)
+    effect             = optional(string)
+    toleration_seconds = optional(string)
+  }))
+  default = []
+}
+
+variable "speaker_node_selector" {
+  description = "Node selector for the speaker DaemonSet. The speaker MUST land on the node(s) that should announce VIPs via L2 ARP — the IP physically arrives on that node's NIC. Restricting via nodeSelector keeps speaker pods off nodes that have no business announcing (e.g. home nodes that aren't on the public network). Empty map = speaker DaemonSet lands on every (un-tainted) node, which is the chart default but rarely what you want for a multi-tier cluster."
+  type        = map(string)
+  default     = {}
+}
+
+variable "speaker_tolerations" {
+  description = "Tolerations for the speaker DaemonSet. If the announcing node is tainted (e.g. dedicated-app taint on a VPS that also serves as the LB ingress node), the speaker must tolerate the taint to land there. Standard k8s toleration shape. Empty = speaker lands only on un-tainted nodes."
+  type = list(object({
+    key                = optional(string)
+    operator           = optional(string, "Exists")
+    value              = optional(string)
+    effect             = optional(string)
+    toleration_seconds = optional(string)
+  }))
+  default = []
+}
+
+variable "pools" {
+  description = "IP address pools MetalLB allocates from. Each entry produces one `IPAddressPool` CRD plus, when `l2_node_selectors` is non-empty, one `L2Advertisement` CRD restricting which nodes announce the pool's IPs via ARP (avoids split-brain ARP from multiple speakers offering the same VIP). Map key is the pool name (also used as CRD object name). `addresses` is a list of CIDRs or `start-end` ranges in MetalLB's native syntax. `auto_assign` controls whether unallocated IPs in the pool can be auto-picked for `Service type: LoadBalancer` without an explicit `loadBalancerIP` request — set false for tightly-controlled pools where every Service must opt in by name. `l2_node_selectors` is a list of label-selector maps that becomes the `L2Advertisement.spec.nodeSelectors` field; restricts which nodes announce these IPs (defaults to all nodes with a speaker if empty). Empty `pools` map = MetalLB installed but inert."
+  type = map(object({
+    addresses         = list(string)
+    auto_assign       = optional(bool, true)
+    l2_node_selectors = optional(list(map(string)), [])
+  }))
+  default = {}
+}
+
+# ── Locals ─────────────────────────────────────────────────────────────────
+
+locals {
+  instances = var.enabled ? toset(["enabled"]) : toset([])
+}
+
+# ── Namespace ──────────────────────────────────────────────────────────────
+
+resource "kubernetes_namespace_v1" "metallb" {
+  for_each = local.instances
+
+  metadata {
+    name = var.namespace
+    labels = {
+      # MetalLB's webhook expects this label so its ValidatingAdmissionWebhook
+      # can scope CRD validation correctly. Skipping it makes IPAddressPool /
+      # L2Advertisement creates fail with "namespace not found by webhook".
+      "pod-security.kubernetes.io/enforce" = "privileged"
+    }
+  }
+}
+
+# ── Helm chart ─────────────────────────────────────────────────────────────
+
+resource "helm_release" "metallb" {
+  for_each = local.instances
+
+  name             = "metallb"
+  repository       = "https://metallb.github.io/metallb"
+  chart            = "metallb"
+  version          = var.version_pin
+  namespace        = kubernetes_namespace_v1.metallb["enabled"].metadata[0].name
+  create_namespace = false
+  wait             = true
+  timeout          = 600
+
+  values = [yamlencode({
+    controller = {
+      nodeSelector = var.controller_node_selector
+      tolerations  = var.controller_tolerations
+    }
+    speaker = {
+      nodeSelector = var.speaker_node_selector
+      tolerations  = var.speaker_tolerations
+      # L2 mode does not need BGP daemon; chart bundles FRR as
+      # opt-in for BGP. Keep it disabled — fewer moving parts,
+      # smaller speaker pod footprint.
+      frr = {
+        enabled = false
+      }
+    }
+  })]
+}
+
+# ── Pools + L2 advertisements ──────────────────────────────────────────────
+#
+# Both CRDs live under metallb.io/v1beta1. Created via raw manifest
+# because the kubernetes provider's `kubernetes_manifest` resource
+# requires the cluster-side CRD to exist at plan time, which fails
+# on a fresh apply where the chart installs the CRD in the same
+# run. `kubectl_manifest` defers the read until apply, sidestepping
+# the chicken-and-egg.
+
+resource "kubectl_manifest" "ip_pool" {
+  for_each = var.enabled ? var.pools : {}
+
+  depends_on = [helm_release.metallb]
+
+  yaml_body = yamlencode({
+    apiVersion = "metallb.io/v1beta1"
+    kind       = "IPAddressPool"
+    metadata = {
+      name      = each.key
+      namespace = var.namespace
+    }
+    spec = {
+      addresses  = each.value.addresses
+      autoAssign = each.value.auto_assign
+    }
+  })
+}
+
+resource "kubectl_manifest" "l2_advertisement" {
+  for_each = var.enabled ? {
+    for k, v in var.pools : k => v
+    if length(v.l2_node_selectors) > 0
+  } : {}
+
+  depends_on = [kubectl_manifest.ip_pool]
+
+  yaml_body = yamlencode({
+    apiVersion = "metallb.io/v1beta1"
+    kind       = "L2Advertisement"
+    metadata = {
+      name      = each.key
+      namespace = var.namespace
+    }
+    spec = {
+      ipAddressPools = [each.key]
+      nodeSelectors = [
+        for sel in each.value.l2_node_selectors : {
+          matchLabels = sel
+        }
+      ]
+    }
+  })
+}
+
+# ── Outputs ────────────────────────────────────────────────────────────────
+
+output "namespace" {
+  description = "Namespace MetalLB is installed in. Empty when `enabled = false`."
+  value       = var.enabled ? var.namespace : ""
+}
+
+output "pools" {
+  description = "Map of pool name → addresses, mirroring the input. Useful for downstream modules that want to assert a pool exists before requesting `loadBalancerIP` from it."
+  value       = var.enabled ? { for k, v in var.pools : k => v.addresses } : {}
+}


### PR DESCRIPTION
## Summary

- New `modules/metallb/` installs MetalLB v0.14.9 (L2 mode only, BGP deferred), opt-in via `services.metallb` in operator config
- Engine generic — operator config defines pools / node selectors / tolerations; the engine carries no app, tenant, hostname, or address literals
- `auto_assign: false` is the recommended pool default — Services request the IP explicitly via `spec.loadBalancerIP`, preventing MetalLB from auto-claiming for unrelated `type: LoadBalancer` Services

## Why MetalLB

Unblocks cluster-native scaling for source-IP-preserving L4 services (SIP/UDP being the immediate driver from the agent inbox handoff). Source-IP preservation requires `externalTrafficPolicy: Local` on a real LoadBalancer; Traefik's UDP entrypoint forwards via a fresh socket and loses the source. MetalLB plus `Local` keeps the original client IP intact.

This PR ships only the platform-side primitive; consumers refactor their charts to `type: LoadBalancer` + `externalTrafficPolicy: Local` separately.

## Architecture notes

- **L2 mode constraints**: one node per VIP announces via gratuitous ARP; source-IP preservation requires the consuming Service to set `externalTrafficPolicy: Local` AND its backend pod to land on the announcing node (kube-proxy with \`Local\` does NOT forward across nodes — drops if no local backend exists). Horizontal scale on L2 = DaemonSet pattern (pod-per-node) or multiple Services with distinct VIPs. True multi-active fronting one VIP needs BGP, deferred.
- **Pool opt-in (\`auto_assign: false\`)**: prevents MetalLB from auto-claiming the pool's IPs for any pre-existing \`type: LoadBalancer\` Service in the cluster.

## Testing

- ✅ \`./tf apply\` — module applies clean, no destroys / replaces
- ✅ Controller lands on the configured tier
- ✅ Speaker DaemonSet lands on the configured node (taint tolerated, single-node nodeSelector match)
- ✅ \`IPAddressPool\` + \`L2Advertisement\` CRDs created with the expected spec
- ✅ End-to-end reachability verified from a different VPS (truly external network, no shared L2 with the announcing node): \`curl http://<VIP>:80/\` returns \`HTTP 200\`, ICMP reaches the VIP — proves ARP announce + ingress forwarding flow

## Operator note — pre-existing tech debt surfaced

The platform's ingress controller Service is \`type: LoadBalancer\` (chart default leftover) and was stuck at \`<pending>\` for ~18 days because no LB allocator existed. MetalLB picked it up on first install (auto-assign was true initially); this PR's \`auto_assign: false\` fix landed AFTER, but MetalLB does not rebalance existing allocations.

**Net effect**: the ingress controller now actually serves on the VIP directly, partially bypassing the Cloudflare Tunnel chain. Functionally fine (DNS still points at CF Tunnel), but architecturally wrong — Traefik should never need a public IP under a CF-Tunnel design.

**Suggested follow-up (separate PR, not blocking this one)**: change the ingress controller's Service to \`ClusterIP\` in the addons repo. Once it releases the VIP, future opt-in Services with explicit \`loadBalancerIP\` can claim it.

## Out of scope

- Consumer-side chart refactor — separate PR per consumer
- Ingress controller Service type cleanup — separate addons-repo PR
- BGP mode (single-DC platform doesn't need multi-active LB)
- CNI swap (Cilium is the bigger-lift alternative; MetalLB solves the immediate need)

## Test plan

- [x] \`./tf apply\` — verified no destroy / replace
- [x] MetalLB pods running on intended nodes
- [x] CRDs created with correct spec
- [x] External HTTP reach to the pool VIP from a non-cluster network
- [ ] Source-IP preservation E2E test (deferred to consumer-side refactor)
- [ ] Ingress controller → ClusterIP follow-up (separate PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)