### PR TITLE
fix(component,chat): deep-merge env_static + uvicorn trust forwarded proto

### DIFF
--- a/config/components/chat.yaml
+++ b/config/components/chat.yaml
@@ -50,6 +50,16 @@ env_random:
 oidc_secret_ref: chat-oidc
 
 env_static:
+  # Open WebUI runs under uvicorn — trust the forwarded proto from
+  # the cluster's ingress chain (cloudflared → Traefik → pod). TLS
+  # terminates at the Cloudflare edge; the hop into the pod is
+  # plain HTTP, so without this uvicorn falls back to scheme=http
+  # when building absolute URLs (in particular the OAuth callback
+  # `redirect_uri`, which Zitadel then rejects against the
+  # registered HTTPS URL). `*` is fine inside a single-trust-boundary
+  # cluster; tighten only if multi-tenant ingress lands here.
+  FORWARDED_ALLOW_IPS:  "*"
+
   RAG_EMBEDDING_ENGINE: ollama
   RAG_OLLAMA_BASE_URL:  http://ollama.platform.svc.cluster.local:11434
   RAG_EMBEDDING_MODEL:  all-minilm:latest
@@ -78,9 +88,15 @@ env_static:
   # stay visible so the user can A/B them side-by-side. Tiny qwen3.5
   # variants (0.8b + 2b) ride along for snappy single-shot prompts where
   # the bigger 4b/9b/14b round-trip latency feels heavy.
-  DEFAULT_MODELS:      qwen3.5:9b
-  ENABLE_MODEL_FILTER: "True"
-  MODEL_FILTER_LIST:   qwen3.5:0.8b,qwen3.5:2b,qwen3.5:4b,qwen3.5:9b,qwen3:14b,gemma4:e2b,gemma4:e4b
+  DEFAULT_MODELS: qwen3.5:9b
+  # NOTE: `ENABLE_MODEL_FILTER` + `MODEL_FILTER_LIST` are no-ops in
+  # Open WebUI v0.9.x — model visibility is purely per-model ACL
+  # in the local SQLite (`model.access_control` + AccessGrants).
+  # Operator currently sets visibility manually via Admin Panel
+  # after a one-time login as the pre-OIDC local admin account.
+  # Engine extension to auto-upsert via admin API is in
+  # `~/.claude/.../memory/project_platform_ops_todo.md` —
+  # "Open WebUI per-model config automation".
 
   # Pre-register the co-located mcp-weather sidecar as a native MCP tool
   # server so the chat model can call `get_current_weather`, `get_forecast`

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -224,8 +224,18 @@ locals {
   #   4. per-project overrides from the domain yaml
   #      (`project_config.components[name]`) — top-level keys here win
   #      over the same keys in the component yaml. Lists/nested maps
-  #      are REPLACED wholesale (Terraform merge() is shallow), which
-  #      keeps the override semantics predictable.
+  #      are REPLACED wholesale (Terraform merge() is shallow), with
+  #      one named exception below.
+  #
+  # `env_static` is specifically deep-merged: the operator's override
+  # ADDS to (and wins per-key over) the component template's
+  # `env_static`. Reason — `env_static` is the natural place to drop
+  # per-tenant environment knobs (canonical URL, hostname-derived
+  # OAuth callback, feature flags) without owning the whole envvar
+  # surface area of a third-party chart. Without this exception, the
+  # operator would have to copy every template env in to keep the
+  # template working — an immediate footgun when chart upstreams
+  # bump their env contract.
   normalized_components = {
     for name in local._component_names :
     name => merge(
@@ -233,6 +243,12 @@ locals {
       local.component_defaults,
       try(var.components[name], {}),
       try(var.project_config.components[name], {}),
+      {
+        env_static = merge(
+          try(var.components[name].env_static, {}),
+          try(var.project_config.components[name].env_static, {}),
+        )
+      },
     )
   }
 


### PR DESCRIPTION
## Summary

Two coupled fixes that surfaced shipping chat OIDC (PR #75):

1. **`modules/project`** — `env_static` is now deep-merged across the four-step component override stack instead of shallow-replacing the whole map. Per-tenant overrides ADD per-key (override wins on conflict); other top-level fields keep the existing shallow-replacement semantics. Documented inline next to the existing merge comment.

2. **`config/components/chat.yaml`** — set `FORWARDED_ALLOW_IPS=*` so uvicorn trusts the cluster ingress chain (cloudflared → Traefik → pod). Without it, Open WebUI builds OAuth callback URLs as `http://...` (TLS terminates at the Cloudflare edge; the hop into the pod is plain HTTP), Zitadel then rejects against the registered HTTPS redirect_uri. Same change drops the no-op `ENABLE_MODEL_FILTER` + `MODEL_FILTER_LIST` envs — Open WebUI v0.9.x ignores both; visibility is per-model ACL in the pod's local SQLite.

## Why

PR #75 wired chat to Zitadel via `oidc_secret_ref` + `chart_oidc_apps`. First sign-in lit up the SSO button but threw `redirect_uri missing` at Zitadel because Open WebUI's auto-derived callback was `http://chat.ipsupport.us/...`. Easy to fix on chat.yaml's side. Adding the `WEBUI_URL` / `OPENID_REDIRECT_URI` per-tenant override on the project's `chat:` block then revealed the second bug: the override silently dropped every other env var the chat template carried (RAG, OAuth flags, model defaults, MCP / open-terminal sidecar config). Chat lit up but with no models registered and the wrong sign-in label.

The deep-merge fix keeps the override's intent (add canonical URL + callback) without forcing the operator to copy the entire chart template into every per-tenant override — which would be an immediate footgun whenever the upstream chart bumps its env contract.

## Compatibility

- Existing components without per-tenant `env_static` overrides — no change (deep-merge of {} into env_static is identity).
- Existing components with overrides that previously REPLACED env_static — operator now sees more env vars in the rendered Pod than before. Each new env adds the template's value. Worth a one-line scan of operator domain yamls before merging this in any environment that actively uses such overrides; in practice operator's `chat:` block was the only such site on this platform.

## Operator note (not in scope, see backlog)

`ENABLE_MODEL_FILTER` + `MODEL_FILTER_LIST` were no-ops in Open WebUI v0.9.x (env-based filter deprecated; per-model ACL is the only visibility lever). The chat template kept those envs as a leftover from earlier versions; this PR removes them. Operator currently sets per-model visibility manually via the Open WebUI Admin Panel after a pre-OIDC local-admin login. Engine extension to automate via the admin API (POST `/api/v1/models/{id}` with operator-curated `models:` map per chat tenant) is in the ops backlog under "Open WebUI per-model config automation".

## Test plan

- [x] `./tf apply` clean — chat Deployment in-place updates, env_static carries both template defaults + per-tenant override
- [x] Open WebUI sign-in via Zitadel completes (redirect_uri now `https://...`)
- [x] All template envs visible in pod (`OAUTH_PROVIDER_NAME`, `RAG_*`, `DEFAULT_MODELS`, etc.) alongside override `WEBUI_URL` / `OPENID_REDIRECT_URI` / `DEFAULT_USER_ROLE`
- [ ] Backlog: per-model visibility automation — separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)