### PR TITLE
feat(stalwart): pin access-token cache capacity to the validation floor

### DIFF
--- a/modules/stalwart/main.tf
+++ b/modules/stalwart/main.tf
@@ -493,6 +493,29 @@ locals {
           directoryId = "#dir-zitadel"
         }
       }),
+
+      # Minimise the access-token positive cache. Stalwart's `Cache`
+      # struct caches access-token → user-info lookups by capacity
+      # only (LRU eviction, no TTL). When an operator grants a new
+      # OIDC role in Zitadel, an existing cached access_token still
+      # resolves to the pre-grant identity until LRU pressure
+      # eventually evicts it OR the pod restarts.
+      #
+      # Stalwart validation refuses values below 2048 ("must be at
+      # least 2048" — verified at apply 2026-05-08), so we cap at
+      # the floor. Combined with the 5-minute access-token lifetime
+      # set on the Zitadel side (`services.zitadel.oidc_settings`),
+      # an entry can stay cached at most one token-lifetime window
+      # before the OIDC consumer rotates to a fresh token (and a
+      # fresh cache key) — bounding role-grant staleness to ≤5min
+      # without per-request `/userinfo` round-trips.
+      jsonencode({
+        "@type" = "update"
+        object  = "Cache"
+        value = {
+          accessTokens = 2048
+        }
+      }),
     ] : [],
 
     # ── Outbound smart host (when configured) ─────────────────────


### PR DESCRIPTION
## Summary

Pins Stalwart's `Cache.accessTokens` capacity to **2048** (the smallest value Stalwart's runtime validation accepts — anything below errors at apply time with `must be at least 2048`).

## Why

Stalwart caches `access_token → user-info` lookups by capacity only — LRU eviction, no TTL. After an operator grants a new OIDC role in the IdP (Zitadel UI, TF, API), an existing cached access_token keeps resolving to the pre-grant identity until LRU pressure eventually evicts it OR the pod restarts. Surfaces as "I granted the role, why is Stalwart still 401-ing" — operator workaround was a manual `kubectl rollout restart` after every grant change.

Bounding the cache to the validation floor + shorter access-token lifetime on the IdP side (5m via the platform's `services.zitadel.oidc_settings` — separate PR) caps role-grant staleness to ≤ one token-lifetime window without the per-request `/userinfo` round-trip a `cache=0` would imply.

## Trade-off

Cache hit ratio drops on busy mailboxes — every 2049th distinct token falls through to `/userinfo`. Cluster-internal IdP, sub-ms RTT, the latency hit is negligible against the operational gain.

## Testing

- [x] `terraform plan` clean — change is a one-liner add to the existing `Authentication` singleton update group in `plan.ndjson`
- [x] Live apply — Stalwart applier sidecar reports `✓ updated Cache (1)` on the next rollout (operator's seed-hash annotation pattern triggers the deployment to pull the new plan)
- [ ] Operator-flow verification: grant a Zitadel role, check that the next access-token rotation surfaces the role in Stalwart without manual restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)