### PR TITLE
feat(zitadel): expose default OIDC token lifetimes as operator-tunable

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -110,6 +110,21 @@ locals {
           allow_external_idp      = true
           allow_username_password = true
         }
+        # Instance-wide OIDC token lifetimes. Defaults match
+        # Zitadel's bundled defaults (12h access/id, 30d refresh,
+        # 7d idle) so a clean install lands the same shape upstream
+        # ships. Override to shorten — e.g. 5m access keeps OIDC
+        # consumers re-fetching `/userinfo` close to the IdP's
+        # current state, so role-grant changes (Zitadel UI / TF /
+        # API) propagate to consumers (Stalwart, chat, ArgoCD)
+        # within the access-token lifetime instead of being stuck
+        # on stale tokens until LRU eviction or pod restart.
+        oidc_settings = {
+          access_token_lifetime         = "12h"
+          id_token_lifetime             = "12h"
+          refresh_token_expiration      = "720h"
+          refresh_token_idle_expiration = "168h"
+        }
         # Provider transport — how the Zitadel TF provider (gRPC)
         # reaches the Zitadel API. Default = `public`: provider hits
         # the real ExternalDomain over HTTPS, which works on any

--- a/zitadel.tf
+++ b/zitadel.tf
@@ -178,3 +178,21 @@ resource "zitadel_default_login_policy" "main" {
   multi_factors  = ["MULTI_FACTOR_TYPE_U2F_WITH_VERIFICATION"]
   second_factors = ["SECOND_FACTOR_TYPE_OTP", "SECOND_FACTOR_TYPE_U2F"]
 }
+
+# Instance-wide OIDC token lifetimes. Operator-tunable via
+# `services.zitadel.oidc_settings`. Default values mirror Zitadel's
+# upstream defaults (12h access / 12h id / 30d refresh / 7d idle);
+# shorter `access_token_lifetime` (e.g. 5m) bounds the staleness
+# window on every OIDC consumer — Stalwart, chat, ArgoCD — so a
+# role grant flipped via the Zitadel UI surfaces in the consumer
+# within one token-lifetime cycle instead of being stuck on a
+# cached pre-grant token until LRU eviction or pod restart.
+resource "zitadel_default_oidc_settings" "main" {
+  count      = local.platform.services.zitadel.enabled ? 1 : 0
+  depends_on = [module.zitadel]
+
+  access_token_lifetime         = local.platform.services.zitadel.oidc_settings.access_token_lifetime
+  id_token_lifetime             = local.platform.services.zitadel.oidc_settings.id_token_lifetime
+  refresh_token_expiration      = local.platform.services.zitadel.oidc_settings.refresh_token_expiration
+  refresh_token_idle_expiration = local.platform.services.zitadel.oidc_settings.refresh_token_idle_expiration
+}


### PR DESCRIPTION
## Summary

New `services.zitadel.oidc_settings` block plumbed through to a `zitadel_default_oidc_settings` resource at the root. Four operator-tunable fields:

- `access_token_lifetime` (default `12h`)
- `id_token_lifetime` (default `12h`)
- `refresh_token_expiration` (default `720h` / 30d)
- `refresh_token_idle_expiration` (default `168h` / 7d)

Defaults mirror Zitadel's upstream defaults so a clean install / existing operator stays exactly where it was — backwards compatible.

## Why

Consumer-side cache staleness: every Zitadel-consuming workload (Stalwart, chat, ArgoCD via Dex, future) caches access-token → user-info lookups internally to keep `/userinfo` round-trips off the hot path. Caches are typically capacity-LRU with no TTL — a role grant flipped via the Zitadel UI sits in the consumer's cache until eviction or pod restart, surfacing as "I granted the role but the consumer still 401-s".

Setting `access_token_lifetime: 5m` bounds the staleness — every OIDC consumer rotates to a fresh access_token inside its lifetime window, the cache key changes, and the next `/userinfo` call sees current grant state. Refresh tokens stay long-lived (30d / 7d idle) so end-user UX is unaffected — auth libraries rotate access tokens transparently.

## Trade-off

Shorter access-token lifetime = more `/userinfo` round-trips to Zitadel cluster-wide. On a single-operator low-volume platform the load is invisible; on a high-volume multi-tenant deploy operator can leave the default 12h.

## Testing

- [x] `terraform plan` clean — single new resource, no destroys / replaces
- [x] Live apply on the operator's cluster — `zitadel_default_oidc_settings.main` created, `GET /admin/v1/settings/oidc` confirms `accessTokenLifetime: "300s"` post-apply
- [x] Refresh token / idle defaults preserved at 30d / 7d so existing OIDC consumer sessions don't get bounced

🤖 Generated with [Claude Code](https://claude.com/claude-code)