### PR TITLE
feat(redis): expose affinity input on Sentinel-mode helm_release

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -26,6 +26,7 @@ locals {
         storage_class = ""
         node_selector = {}
         tolerations   = []
+        affinity      = {}
         sentinel      = {}
       }
       ollama = {

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -69,6 +69,12 @@ variable "tolerations" {
   default = []
 }
 
+variable "affinity" {
+  description = "Optional pod / node affinity rendered into the Bitnami `valkey` chart's `replica.affinity` block (sentinel mode). Standard Kubernetes affinity shape — `nodeAffinity`, `podAffinity`, `podAntiAffinity` map keys, native v1 schema. Common use: `nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution` excluding a high-latency node from the sentinel pool when the chart's default cluster-wide pod-anti-affinity would otherwise scatter a replica there. Single-instance mode ignores this input. Empty map (default) preserves the chart's default placement."
+  type        = any
+  default     = {}
+}
+
 variable "sentinel" {
   description = "Optional Valkey Sentinel HA topology. When `enabled = true`, the module switches from the default single-StatefulSet implementation to a Bitnami `valkey` Helm release running `architecture: replication` + `sentinel.enabled: true`, plus an HAProxy Deployment in front (sentinel-aware health checks via `tcp-check expect role:master`) so consumers keep talking to the flat `redis.<ns>.svc:6379` Service without any client-side changes. **Operator opts in** via `services.redis.sentinel:` in `config/platform.yaml`. Default `enabled = false` preserves the simple single-instance path. Switching `false → true` is a one-way data wipe (the existing single-instance PVC is destroyed when its for_each collapses; tenant ACL Jobs need re-trigger to repopulate per-tenant users on the fresh chart deploy)."
   type = object({
@@ -478,6 +484,11 @@ resource "helm_release" "valkey_sentinel" {
       }
       nodeSelector = var.node_selector
       tolerations  = var.tolerations
+      # Empty-map default leaves the chart's bundled
+      # podAntiAffinity in place; an operator-supplied affinity
+      # block REPLACES it wholesale (the chart's render path
+      # resolves a single `affinity:` field, no merge).
+      affinity = var.affinity
     }
   })]
 }

--- a/redis.tf
+++ b/redis.tf
@@ -15,4 +15,5 @@ module "redis" {
 
   node_selector = local.platform.services.redis.node_selector
   tolerations   = local.platform.services.redis.tolerations
+  affinity      = local.platform.services.redis.affinity
 }


### PR DESCRIPTION
## Summary

New `services.redis.affinity` operator-tunable, plumbed through to the Bitnami `valkey` chart's `replica.affinity` block in Sentinel mode. Empty default preserves the chart's bundled placement; non-empty operator value replaces it wholesale.

## Why

Sentinel-mode replicas spread across nodes via the chart's bundled `podAntiAffinityPreset: soft`. There's no operator-side knob to add `nodeAffinity` constraints on top — say, exclude a specific node by hostname when one VM peer's timer-loop pauses are triggering serial Sentinel `+tilt` events without forking the chart. This input fills that gap without a chart bump.

## Compatibility

- Default `{}` keeps the chart's existing placement — no diff for consumers that don't set the variable.
- Setting `affinity` REPLACES the chart's bundled anti-affinity (single field, no merge). Operator yaml needs to include both `podAntiAffinity` (to keep one-per-node spread) and any extra `nodeAffinity` rules together.

## Testing

- [x] `terraform plan` clean on consumers without `affinity` set
- [x] `terraform plan` shows in-place chart values update on consumers that DO set it
- [ ] Live exclude-node use case verification deferred to operator (driving incident in this session was reverted by the time this PR landed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)