### PR TITLE
feat(github-runners): GitHub self-hosted runners via ARC v0.9+

### DIFF
--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -268,6 +268,56 @@ services:
     #   enabled:       true
     #   replica_count: 5
 
+  # GitHub self-hosted runners via ARC (Actions Runner Controller v0.9+).
+  #
+  # GitHub-maintained ARC has a built-in listener that polls the GH
+  # Actions API and scales runner pods 0 → max_runners as the queue
+  # grows. No KEDA needed. The earlier `summerwind/actions-runner-
+  # controller` is deprecated; this module uses
+  # `actions/actions-runner-controller-charts` only.
+  #
+  # GitHub auth per scale set: operator pre-creates a k8s Secret in
+  # the scale set's namespace carrying either:
+  #   - `github_token` (PAT — scope: workflow registration on the
+  #     specific org / repo / enterprise URL)
+  #   - `github_app_id` + `github_app_installation_id` +
+  #     `github_app_private_key` (GitHub App — preferred for orgs)
+  #
+  # Engine references the Secret by name; engine does NOT create or
+  # rotate it. Bootstrap once via `kubectl create secret generic
+  # arc-github-pat -n <ns> --from-literal=github_token=...`.
+  github_runners:
+    enabled: false
+    # Controller is shared across every scale set — stateless,
+    # cheap to leave on a stable tier.
+    # controller_node_selector:
+    #   workload-tier: general
+    # Map of scale sets — each entry is one runner pool. Map key is
+    # also the chart release name and runner-label-set identifier.
+    # scale_sets:
+    #   org-runners:
+    #     # Org-level runners — workflows in any repo under the org
+    #     # land in this pool. Use repo-level URL
+    #     # (https://github.com/<org>/<repo>) to scope to one repo.
+    #     github_config_url:  https://github.com/<org>
+    #     # Pre-created Secret in the namespace below (see comment
+    #     # above for required keys).
+    #     github_secret_name: arc-github-pat
+    #     namespace:          arc-runners
+    #     # Scale-to-zero between jobs (default min_runners: 0).
+    #     # Bump min ≥1 to keep warm runners; pay continuous CPU
+    #     # for queue-latency reduction. ARC controller charges no
+    #     # GitHub API rate when idle.
+    #     min_runners: 0
+    #     max_runners: 4
+    #     # Pin runners to the fat compute tier — runner pods are
+    #     # short-lived but can spike on multi-core builds.
+    #     runner_node_selector:
+    #       workload-tier: general
+    #     runner_resources:
+    #       requests: { cpu: "500m",  memory: "1Gi"  }
+    #       limits:   { cpu: "4",     memory: "8Gi"  }
+
   longhorn:
     enabled: false
     # `replica_count` — how many copies of each volume Longhorn

--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -314,6 +314,21 @@ services:
     #     # short-lived but can spike on multi-core builds.
     #     runner_node_selector:
     #       workload-tier: general
+    #     # Optional standard k8s v1 affinity. Common pattern:
+    #     # spread N runners across N nodes via podAntiAffinity on
+    #     # `kubernetes.io/hostname` so a single node loss takes
+    #     # out at most one runner. Combine with nodeAffinity rules
+    #     # to opt runners into specific tiers (edge / general /
+    #     # whatever the operator labels).
+    #     runner_affinity:
+    #       podAntiAffinity:
+    #         preferredDuringSchedulingIgnoredDuringExecution:
+    #           - weight: 100
+    #             podAffinityTerm:
+    #               labelSelector:
+    #                 matchLabels:
+    #                   actions.github.com/scale-set-name: <key-above>
+    #               topologyKey: kubernetes.io/hostname
     #     runner_resources:
     #       requests: { cpu: "500m",  memory: "1Gi"  }
     #       limits:   { cpu: "4",     memory: "8Gi"  }

--- a/github_runners.tf
+++ b/github_runners.tf
@@ -1,0 +1,27 @@
+# GitHub self-hosted runners — Actions Runner Controller (ARC v0.9+).
+#
+# Modern ARC has a built-in listener that polls the GitHub Actions
+# API and scales runner pods 0 → max_runners as the queue grows. No
+# KEDA needed. The earlier KEDA-based ARC (`actions-runner-controller`
+# from `summerwind`) is deprecated; this module uses the
+# GitHub-maintained `actions/actions-runner-controller` charts only.
+#
+# Operator drives layout via `services.github_runners.scale_sets` —
+# each entry is one runner pool (org / repo / enterprise). The
+# engine carries no GitHub URLs, no PATs, no per-set names: every
+# operator-specific value lives in `config/platform.yaml`.
+
+module "github_runners" {
+  source     = "./modules/github-runners"
+  depends_on = [module.addons]
+
+  enabled                  = local.platform.services.github_runners.enabled
+  controller_node_selector = local.platform.services.github_runners.controller_node_selector
+  controller_tolerations   = local.platform.services.github_runners.controller_tolerations
+  scale_sets               = local.platform.services.github_runners.scale_sets
+}
+
+output "github_runners_scale_sets" {
+  description = "List of installed runner scale set names. Empty when disabled or no scale sets configured."
+  value       = module.github_runners.scale_set_names
+}

--- a/locals.tf
+++ b/locals.tf
@@ -84,6 +84,12 @@ locals {
         distributed   = {}
         buckets       = {}
       }
+      github_runners = {
+        enabled                  = false
+        controller_node_selector = {}
+        controller_tolerations   = []
+        scale_sets               = {}
+      }
       backup = {
         enabled                = false
         postgres_databases     = []
@@ -169,19 +175,20 @@ locals {
   _platform_services = try(local._platform_raw.services, {})
   platform = {
     services = {
-      mysql         = merge(local._platform_defaults.services.mysql, try(local._platform_services.mysql, {}))
-      postgres      = merge(local._platform_defaults.services.postgres, try(local._platform_services.postgres, {}))
-      redis         = merge(local._platform_defaults.services.redis, try(local._platform_services.redis, {}))
-      ollama        = merge(local._platform_defaults.services.ollama, try(local._platform_services.ollama, {}))
-      zitadel       = merge(local._platform_defaults.services.zitadel, try(local._platform_services.zitadel, {}))
-      vault         = merge(local._platform_defaults.services.vault, try(local._platform_services.vault, {}))
-      argocd        = merge(local._platform_defaults.services.argocd, try(local._platform_services.argocd, {}))
-      kured         = merge(local._platform_defaults.services.kured, try(local._platform_services.kured, {}))
-      longhorn      = merge(local._platform_defaults.services.longhorn, try(local._platform_services.longhorn, {}))
-      metallb       = merge(local._platform_defaults.services.metallb, try(local._platform_services.metallb, {}))
-      minio         = merge(local._platform_defaults.services.minio, try(local._platform_services.minio, {}))
-      backup        = merge(local._platform_defaults.services.backup, try(local._platform_services.backup, {}))
-      platform_dash = merge(local._platform_defaults.services.platform_dash, try(local._platform_services.platform_dash, {}))
+      mysql          = merge(local._platform_defaults.services.mysql, try(local._platform_services.mysql, {}))
+      postgres       = merge(local._platform_defaults.services.postgres, try(local._platform_services.postgres, {}))
+      redis          = merge(local._platform_defaults.services.redis, try(local._platform_services.redis, {}))
+      ollama         = merge(local._platform_defaults.services.ollama, try(local._platform_services.ollama, {}))
+      zitadel        = merge(local._platform_defaults.services.zitadel, try(local._platform_services.zitadel, {}))
+      vault          = merge(local._platform_defaults.services.vault, try(local._platform_services.vault, {}))
+      argocd         = merge(local._platform_defaults.services.argocd, try(local._platform_services.argocd, {}))
+      kured          = merge(local._platform_defaults.services.kured, try(local._platform_services.kured, {}))
+      longhorn       = merge(local._platform_defaults.services.longhorn, try(local._platform_services.longhorn, {}))
+      metallb        = merge(local._platform_defaults.services.metallb, try(local._platform_services.metallb, {}))
+      minio          = merge(local._platform_defaults.services.minio, try(local._platform_services.minio, {}))
+      github_runners = merge(local._platform_defaults.services.github_runners, try(local._platform_services.github_runners, {}))
+      backup         = merge(local._platform_defaults.services.backup, try(local._platform_services.backup, {}))
+      platform_dash  = merge(local._platform_defaults.services.platform_dash, try(local._platform_services.platform_dash, {}))
     }
   }
 

--- a/modules/github-runners/main.tf
+++ b/modules/github-runners/main.tf
@@ -1,0 +1,203 @@
+# GitHub self-hosted runners via ARC (Actions Runner Controller).
+#
+# Modern path: GitHub-maintained ARC v0.9+ ships two charts —
+# `gha-runner-scale-set-controller` (one per cluster, watches the
+# AutoscalingRunnerSet CRD) and `gha-runner-scale-set` (one per
+# runner pool, registers with a specific org / repo / enterprise
+# URL via the GitHub Actions API). The controller's listener-pod
+# pattern replaced the older KEDA-based ARC: it polls GitHub for
+# queued workflow_jobs and creates / deletes runner pods directly,
+# scaling 0 → max_runners and back as the queue drains. No KEDA
+# needed.
+#
+# Authentication is per-scale-set: either a GitHub App (org-wide,
+# preferred) or a PAT (token-scoped to a single org / repo / user
+# context). The engine accepts both via the operator-supplied
+# Secret name input — engine doesn't store the credential, just
+# wires the Secret reference into the chart values.
+#
+# Source-IP / network egress: runners pull from GitHub's HTTPS API
+# only — no L4 ingress need on the cluster side, no MetalLB
+# concern. Outbound bandwidth + image-pull caching is the usual
+# bottleneck on self-hosted; sizing comes from the operator's
+# observed CI workload.
+
+terraform {
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}
+
+# ── Inputs ─────────────────────────────────────────────────────────────────
+
+variable "enabled" {
+  description = "Whether to install ARC controller + any scale sets. False collapses every resource."
+  type        = bool
+  default     = false
+}
+
+variable "namespace_controller" {
+  description = "Namespace for the cluster-wide ARC controller. The controller is shared across every scale set; scale-set runner pods land in their own per-set namespaces (see `scale_sets[].namespace`)."
+  type        = string
+  default     = "arc-system"
+}
+
+variable "controller_chart_version" {
+  description = "Pinned chart version for `gha-runner-scale-set-controller`. Pin both controller and scale-set chart to the same version — they share a CRD that crosses both releases, and a version skew can break listener-pod creation."
+  type        = string
+  default     = "0.9.3"
+}
+
+variable "scale_set_chart_version" {
+  description = "Pinned chart version for `gha-runner-scale-set`. Match the controller's version (see `controller_chart_version`)."
+  type        = string
+  default     = "0.9.3"
+}
+
+variable "controller_node_selector" {
+  description = "Node selector for the controller Deployment. Empty = scheduler picks. Pin to a stable tier (e.g. `{ workload-tier: general }`) so the controller doesn't bounce onto edge nodes."
+  type        = map(string)
+  default     = {}
+}
+
+variable "controller_tolerations" {
+  description = "Tolerations for the controller Deployment. Standard k8s toleration shape."
+  type = list(object({
+    key      = optional(string)
+    operator = optional(string, "Exists")
+    value    = optional(string)
+    effect   = optional(string)
+  }))
+  default = []
+}
+
+variable "scale_sets" {
+  description = "Map of runner scale sets to install. Map key is the scale-set name (also the chart release name and the runner label set's identifier). Each entry: `github_config_url` (full URL — `https://github.com/<org>` or `https://github.com/<org>/<repo>` or `https://github.com/enterprises/<ent>`), `github_secret_name` (k8s Secret in the scale-set's namespace carrying either `github_token` for PAT auth or `github_app_id` + `github_app_installation_id` + `github_app_private_key` for GitHub App auth — engine does NOT create this Secret, operator pre-creates it), `namespace` (where the runner pods + listener land — engine creates it), `min_runners` (int, default 0 — scale to zero between jobs is the default; set ≥1 to keep warm runners), `max_runners` (int, default 4 — upper bound on concurrent runners; pick based on cluster headroom), `runner_image` (defaults to GitHub's hosted image equivalent), `runner_resources` (k8s resources block), `runner_node_selector` / `runner_tolerations` (placement for runner pods, separate from controller). Empty map = no scale sets, controller still installs (cheap to leave running)."
+  type = map(object({
+    github_config_url    = string
+    github_secret_name   = string
+    namespace            = string
+    min_runners          = optional(number, 0)
+    max_runners          = optional(number, 4)
+    runner_image         = optional(string, "ghcr.io/actions/actions-runner:latest")
+    runner_resources     = optional(any, {})
+    runner_node_selector = optional(map(string), {})
+    runner_tolerations = optional(list(object({
+      key      = optional(string)
+      operator = optional(string, "Exists")
+      value    = optional(string)
+      effect   = optional(string)
+    })), [])
+  }))
+  default = {}
+}
+
+# ── Locals ─────────────────────────────────────────────────────────────────
+
+locals {
+  instances         = var.enabled ? toset(["enabled"]) : toset([])
+  scale_set_targets = var.enabled ? var.scale_sets : {}
+  # Each scale set lands in its own namespace — engine creates them
+  # idempotently rather than asking the operator to pre-create.
+  scale_set_namespaces = distinct([for _, s in local.scale_set_targets : s.namespace])
+}
+
+# ── Controller namespace + chart ───────────────────────────────────────────
+
+resource "kubernetes_namespace_v1" "controller" {
+  for_each = local.instances
+
+  metadata {
+    name = var.namespace_controller
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/component"  = "arc-controller"
+    }
+  }
+}
+
+resource "helm_release" "controller" {
+  for_each = local.instances
+
+  name             = "arc-controller"
+  repository       = "oci://ghcr.io/actions/actions-runner-controller-charts"
+  chart            = "gha-runner-scale-set-controller"
+  version          = var.controller_chart_version
+  namespace        = kubernetes_namespace_v1.controller["enabled"].metadata[0].name
+  create_namespace = false
+
+  values = [yamlencode({
+    nodeSelector = var.controller_node_selector
+    tolerations  = var.controller_tolerations
+  })]
+}
+
+# ── Per-scale-set namespaces ───────────────────────────────────────────────
+
+resource "kubernetes_namespace_v1" "scale_set" {
+  for_each = toset(local.scale_set_namespaces)
+
+  metadata {
+    name = each.key
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/component"  = "arc-runners"
+    }
+  }
+}
+
+# ── Scale sets ─────────────────────────────────────────────────────────────
+
+resource "helm_release" "scale_set" {
+  for_each = local.scale_set_targets
+
+  depends_on = [
+    helm_release.controller,
+    kubernetes_namespace_v1.scale_set,
+  ]
+
+  name             = each.key
+  repository       = "oci://ghcr.io/actions/actions-runner-controller-charts"
+  chart            = "gha-runner-scale-set"
+  version          = var.scale_set_chart_version
+  namespace        = each.value.namespace
+  create_namespace = false
+
+  values = [yamlencode({
+    githubConfigUrl    = each.value.github_config_url
+    githubConfigSecret = each.value.github_secret_name
+    minRunners         = each.value.min_runners
+    maxRunners         = each.value.max_runners
+    template = {
+      spec = {
+        nodeSelector = each.value.runner_node_selector
+        tolerations  = each.value.runner_tolerations
+        containers = [{
+          name      = "runner"
+          image     = each.value.runner_image
+          command   = ["/home/runner/run.sh"]
+          resources = each.value.runner_resources
+        }]
+      }
+    }
+  })]
+}
+
+# ── Outputs ────────────────────────────────────────────────────────────────
+
+output "controller_namespace" {
+  description = "Namespace where the ARC controller is installed. Empty when `enabled = false`."
+  value       = var.enabled ? var.namespace_controller : ""
+}
+
+output "scale_set_names" {
+  description = "List of installed scale set names (matches operator-configured map keys). Empty when disabled or no scale sets configured."
+  value       = [for k, _ in local.scale_set_targets : k]
+}

--- a/modules/github-runners/main.tf
+++ b/modules/github-runners/main.tf
@@ -79,14 +79,14 @@ variable "controller_tolerations" {
 }
 
 variable "scale_sets" {
-  description = "Map of runner scale sets to install. Map key is the scale-set name (also the chart release name and the runner label set's identifier). Each entry: `github_config_url` (full URL — `https://github.com/<org>` or `https://github.com/<org>/<repo>` or `https://github.com/enterprises/<ent>`), `github_secret_name` (k8s Secret in the scale-set's namespace carrying either `github_token` for PAT auth or `github_app_id` + `github_app_installation_id` + `github_app_private_key` for GitHub App auth — engine does NOT create this Secret, operator pre-creates it), `namespace` (where the runner pods + listener land — engine creates it), `min_runners` (int, default 0 — scale to zero between jobs is the default; set ≥1 to keep warm runners), `max_runners` (int, default 4 — upper bound on concurrent runners; pick based on cluster headroom), `runner_image` (defaults to GitHub's hosted image equivalent), `runner_resources` (k8s resources block), `runner_node_selector` / `runner_tolerations` (placement for runner pods, separate from controller). Empty map = no scale sets, controller still installs (cheap to leave running)."
+  description = "Map of runner scale sets to install. Map key is the scale-set name (also the chart release name and the runner label set's identifier). Each entry: `github_config_url` (full URL — `https://github.com/<org>` or `https://github.com/<org>/<repo>` or `https://github.com/enterprises/<ent>`), `github_secret_name` (k8s Secret in the scale-set's namespace carrying either `github_token` for PAT auth or `github_app_id` + `github_app_installation_id` + `github_app_private_key` for GitHub App auth — engine does NOT create this Secret, operator pre-creates it), `namespace` (where the runner pods + listener land — engine creates it), `min_runners` (int, default 0 — scale to zero between jobs is the default; set ≥1 to keep warm runners), `max_runners` (int, default 4 — upper bound on concurrent runners; pick based on cluster headroom), `runner_image` (default pinned to a verified-pullable upstream tag — bump as upstream cuts new releases), `runner_resources` (k8s resources block), `runner_node_selector` / `runner_tolerations` / `runner_affinity` (placement for runner pods — separate from controller). `runner_affinity` is the standard k8s v1 affinity shape (`nodeAffinity`, `podAffinity`, `podAntiAffinity` keys); empty map preserves chart defaults (no anti-affinity), set `podAntiAffinity` on `kubernetes.io/hostname` to spread N runners across N nodes so a single node loss takes out at most one runner. Empty map = no scale sets, controller still installs (cheap to leave running)."
   type = map(object({
     github_config_url    = string
     github_secret_name   = string
     namespace            = string
     min_runners          = optional(number, 0)
     max_runners          = optional(number, 4)
-    runner_image         = optional(string, "ghcr.io/actions/actions-runner:latest")
+    runner_image         = optional(string, "ghcr.io/actions/actions-runner:2.328.0")
     runner_resources     = optional(any, {})
     runner_node_selector = optional(map(string), {})
     runner_tolerations = optional(list(object({
@@ -95,6 +95,7 @@ variable "scale_sets" {
       value    = optional(string)
       effect   = optional(string)
     })), [])
+    runner_affinity = optional(any, {})
   }))
   default = {}
 }
@@ -179,6 +180,7 @@ resource "helm_release" "scale_set" {
       spec = {
         nodeSelector = each.value.runner_node_selector
         tolerations  = each.value.runner_tolerations
+        affinity     = each.value.runner_affinity
         containers = [{
           name      = "runner"
           image     = each.value.runner_image


### PR DESCRIPTION
## Summary

New `modules/github-runners/` provisions:

1. **Cluster-wide ARC controller** — Helm release of `gha-runner-scale-set-controller` from `actions/actions-runner-controller-charts` (the GitHub-maintained chart, NOT the deprecated `summerwind` fork). Single deployment, watches the AutoscalingRunnerSet CRD across the cluster.
2. **Per-pool scale sets** — one `gha-runner-scale-set` Helm release per operator-declared entry. Each scale set's listener-pod polls the GitHub Actions API for queued workflow_jobs scoped to its `github_config_url` and creates / deletes runner pods 0 → max_runners as the queue grows.

## Operator-visible config

```yaml
services:
  github_runners:
    enabled: true
    controller_node_selector:
      workload-tier: general
    scale_sets:
      org-runners:
        github_config_url:  https://github.com/<org>
        github_secret_name: arc-github-pat   # operator pre-creates
        namespace:          arc-runners
        min_runners: 0
        max_runners: 4
        runner_node_selector:
          workload-tier: general
        runner_resources:
          requests: { cpu: "500m",  memory: "1Gi"  }
          limits:   { cpu: "4",     memory: "8Gi"  }
```

## No KEDA

ARC v0.9+ has its own scale loop driven by the listener-pod's GitHub API polling. The earlier KEDA-based `summerwind/actions-runner-controller` is deprecated; this module uses the GitHub-maintained chart only.

## Auth

Per scale set the operator pre-creates a k8s Secret in the scale set's namespace carrying either:
- `github_token` (PAT — scope: `workflow` registration on the URL)
- `github_app_id` + `github_app_installation_id` + `github_app_private_key` (GitHub App — preferred for orgs)

Engine references the Secret by name; engine does NOT create or rotate it. Standard `kubectl create secret generic arc-github-pat -n <ns> --from-literal=github_token=...` bootstrap.

## Engine generic

- Module knows nothing about specific orgs / repos / labels — operator yaml drives every URL / token / placement.
- Default off; apply on a clean cluster lands zero ARC resources until the operator opts in.
- Pinned chart versions (controller + scale set both `0.9.3`, must match — they share a CRD).

## Testing

- [x] `terraform plan` clean on disabled state — no diff for consumers that haven't opted in
- [x] Module compiles, controller chart pulls from OCI registry
- [ ] Live apply with one scale set + GitHub PAT — pending operator OK + Secret bootstrap
- [ ] Workflow run picked up by self-hosted runner — verify with a `runs-on: [self-hosted]` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)