### PR TITLE
feat(platform): traefik DaemonSet, MetalLB v0.15, redis ACL auto-rerun, ARC runner bump

### DIFF
--- a/config/limits/platform.yaml
+++ b/config/limits/platform.yaml
@@ -1,3 +1,3 @@
-cpu:    "12"
-memory: "24Gi"
-pods:   20
+cpu:    "16"
+memory: "32Gi"
+pods:   30

--- a/locals.tf
+++ b/locals.tf
@@ -169,6 +169,15 @@ locals {
         node_selector = {}
         tolerations   = []
       }
+      addons = {
+        # Pod-placement + workload-kind override for the bundled
+        # `terraform-k8s-addons` Traefik release. All three are
+        # opt-in — leaving defaults preserves the chart's stock
+        # `Deployment` with no toleration / nodeSelector.
+        traefik_deployment_kind = null
+        traefik_tolerations     = []
+        traefik_node_selector   = {}
+      }
     }
   }
   _platform_file     = "${path.module}/config/platform.yaml"
@@ -190,6 +199,7 @@ locals {
       github_runners = merge(local._platform_defaults.services.github_runners, try(local._platform_services.github_runners, {}))
       backup         = merge(local._platform_defaults.services.backup, try(local._platform_services.backup, {}))
       platform_dash  = merge(local._platform_defaults.services.platform_dash, try(local._platform_services.platform_dash, {}))
+      addons         = merge(local._platform_defaults.services.addons, try(local._platform_services.addons, {}))
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ check "k3s_ssh_vars_set" {
 # Layer 2: Platform add-ons (Traefik, cert-manager, monitoring, namespaces).
 # -----------------------------------------------------------------------------
 module "addons" {
-  source = "git::https://github.com/rromenskyi/terraform-k8s-addons.git?ref=v2.1.0"
+  source = "git::https://github.com/rromenskyi/terraform-k8s-addons.git?ref=v2.3.0"
 
   kubeconfig_path      = module.k8s.kubeconfig_path
   cluster_name         = module.k8s.cluster_name
@@ -110,6 +110,23 @@ module "addons" {
   # chart-side one on would create two IRs serving the dashboard at
   # different hostnames with different auth.
   enable_traefik_dashboard = false
+
+  # Traefik runs as ClusterIP, not LoadBalancer. The cluster's only
+  # public ingress for HTTPS is the Cloudflare Tunnel (`cloudflared`
+  # in the `ops` namespace), which resolves Traefik through the
+  # cluster DNS name `traefik.ingress-controller.svc.cluster.local`
+  # and reaches it via the in-cluster ClusterIP — no external IP
+  # needed on the Traefik Service.
+  traefik_service_type = "ClusterIP"
+
+  # Traefik workload kind + placement come from the operator config
+  # (`services.addons.traefik_*` in `config/platform.yaml`). Engine
+  # stays generic — every tenant-specific taint key, label, or
+  # workload-kind decision lives in the gitignored operator file,
+  # not here.
+  traefik_deployment_kind = local.platform.services.addons.traefik_deployment_kind
+  traefik_tolerations     = local.platform.services.addons.traefik_tolerations
+  traefik_node_selector   = local.platform.services.addons.traefik_node_selector
 }
 
 # =============================================================================
@@ -169,6 +186,7 @@ module "project" {
   redis_namespace           = module.redis.namespace
   redis_host                = module.redis.host
   redis_default_secret      = module.redis.default_secret_name
+  redis_helm_revision       = module.redis.helm_revision
   ollama_url                = module.ollama.url
 
   # Zitadel — issuer URL is null when `services.zitadel.enabled = false`,

--- a/modules/github-runners/main.tf
+++ b/modules/github-runners/main.tf
@@ -86,7 +86,7 @@ variable "scale_sets" {
     namespace            = string
     min_runners          = optional(number, 0)
     max_runners          = optional(number, 4)
-    runner_image         = optional(string, "ghcr.io/actions/actions-runner:2.328.0")
+    runner_image         = optional(string, "ghcr.io/actions/actions-runner:2.334.0")
     runner_resources     = optional(any, {})
     runner_node_selector = optional(map(string), {})
     runner_tolerations = optional(list(object({

--- a/modules/metallb/main.tf
+++ b/modules/metallb/main.tf
@@ -52,7 +52,7 @@ variable "namespace" {
 variable "version_pin" {
   description = "Helm chart version for metallb/metallb. Pinned so an upstream re-tag doesn't change CRD shape or defaults across applies."
   type        = string
-  default     = "0.14.9"
+  default     = "0.15.3"
 }
 
 variable "controller_node_selector" {
@@ -92,7 +92,7 @@ variable "speaker_tolerations" {
 }
 
 variable "shared_ip_annotations" {
-  description = "Map of `<namespace>/<service-name>` → shared-ip key. Engine annotates the listed Service with `metallb.universe.tf/allow-shared-ip: <key>` so MetalLB legalises sharing one VIP across multiple Services with non-conflicting port/protocol pairs (e.g. Traefik on TCP 80/443 and a SIP proxy on UDP 5160). Both Services must carry the SAME key; the engine writes the annotation server-side without touching the Service's other fields, so a chart-managed Service (Helm, ArgoCD) keeps its ownership intact. Empty map (default) emits no annotations. Only meaningful when at least one pool's IP is targeted by multiple Services."
+  description = "Map of `<namespace>/<service-name>` → shared-ip key. Engine annotates the listed Service with `metallb.io/allow-shared-ip: <key>` so MetalLB legalises sharing one VIP across multiple Services with non-conflicting port/protocol pairs (e.g. Traefik on TCP 80/443 and a SIP proxy on UDP 5160). Both Services must carry the SAME key AND the same `externalTrafficPolicy` (MetalLB rejects sharing across mismatched policies); the engine writes the annotation server-side without touching the Service's other fields, so a chart-managed Service (Helm, ArgoCD) keeps its ownership intact. Empty map (default) emits no annotations. Only meaningful when at least one pool's IP is targeted by multiple Services."
   type        = map(string)
   default     = {}
   validation {
@@ -241,8 +241,16 @@ resource "kubernetes_annotations" "shared_ip" {
     name      = split("/", each.key)[1]
     namespace = split("/", each.key)[0]
   }
+  # MetalLB v0.15+ recognises only the canonical `metallb.io/...`
+  # annotation prefix for sharing-key extraction. The legacy
+  # `metallb.universe.tf/...` form still fires a `deprecatedAnnotation`
+  # warn in controller logs but is read as empty for sharing-key
+  # purposes — a Service with only legacy annotations cannot share a
+  # VIP with a canonical-annotated Service even when values match.
+  # Tenant charts that still emit legacy annotations need to migrate
+  # to the canonical prefix on their side.
   annotations = {
-    "metallb.universe.tf/allow-shared-ip" = each.value
+    "metallb.io/allow-shared-ip" = each.value
   }
 }
 

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -88,6 +88,12 @@ variable "redis_default_secret" {
   default     = null
 }
 
+variable "redis_helm_revision" {
+  description = "Helm release revision counter for the shared Redis chart. Interpolated into the tenant-provisioner Job's `metadata.name`, so any chart upgrade (revision bump) renames the Job and Terraform replaces it — re-running the ACL setup against whatever the post-upgrade master happens to be. Skipping this would leave tenants on stale ACL state after a master switch (the failure mode that produces `WRONGPASS` across every consumer). Zero / null when sentinel mode is disabled (legacy single-pod path uses a different bring-up Job)."
+  type        = number
+  default     = 0
+}
+
 variable "ollama_url" {
   description = "In-cluster URL of the shared Ollama (e.g. http://ollama.platform.svc.cluster.local:11434). Injected as `OLLAMA_HOST` into any component that sets `ollama: true`. Null when `services.ollama = false`."
   type        = string
@@ -739,7 +745,14 @@ resource "kubernetes_job_v1" "redis_setup" {
   depends_on = [kubernetes_namespace_v1.this]
 
   metadata {
-    name      = "redis-setup-${local.namespace}"
+    # Job name carries the Valkey helm revision so a chart upgrade
+    # (which can switch the Sentinel master and discard the
+    # previously-applied tenant ACL) renames the Job, Terraform
+    # replaces it, and the ACL is re-applied against the post-upgrade
+    # master. Without this, tenant pods get `WRONGPASS` after every
+    # redis chart upgrade until the operator manually `terraform taint`s
+    # the Job — historic flake source documented 2026-05-09.
+    name      = "redis-setup-${local.namespace}-rev${var.redis_helm_revision}"
     namespace = var.redis_namespace
     labels = {
       "app.kubernetes.io/managed-by" = "terraform"
@@ -753,7 +766,7 @@ resource "kubernetes_job_v1" "redis_setup" {
     template {
       metadata {
         labels = {
-          job = "redis-setup-${local.namespace}"
+          job = "redis-setup-${local.namespace}-rev${var.redis_helm_revision}"
         }
       }
 

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -689,3 +689,8 @@ output "default_secret_name" {
   value       = one([for s in kubernetes_secret_v1.default : s.metadata[0].name])
   description = "Name of the Secret holding the `default`-user password. The tenant-provisioner Job reads it when calling ACL SETUSER. Null if disabled."
 }
+
+output "helm_revision" {
+  value       = length(local.sentinel_instances) > 0 ? helm_release.valkey_sentinel["enabled"].metadata.revision : 0
+  description = "Helm release revision counter for the Valkey/Sentinel chart. Increments on every `helm upgrade` (chart bump, values change, replicas/affinity update, etc). Consumers (tenant ACL provisioner Jobs) interpolate this into their resource name so a chart upgrade — which can switch the master pod and lose previously-applied ACL state — automatically re-runs the ACL setup with the new credentials. Zero when sentinel mode is disabled (no chart deployed). Sentinel-mode-only by design — the legacy single-pod path uses a different bring-up Job that is not affected by master switches."
+}

--- a/platform_dash_db.tf
+++ b/platform_dash_db.tf
@@ -165,7 +165,11 @@ resource "kubernetes_job_v1" "redis_dashboard_ro_setup" {
   depends_on = [module.redis]
 
   metadata {
-    name      = "redis-dashboard-ro-setup"
+    # Job name carries the Valkey helm revision so a chart upgrade
+    # auto-replaces this Job and re-applies the read-only ACL against
+    # the post-upgrade Sentinel master. Same pattern as the
+    # per-tenant `redis_setup` Jobs in modules/project.
+    name      = "redis-dashboard-ro-setup-rev${module.redis.helm_revision}"
     namespace = module.redis.namespace
     labels = {
       "managed-by" = "platform-dash-db-discovery"


### PR DESCRIPTION
## Summary

One bundled engine cleanup PR spanning four loosely-related areas. None introduce destroy/replace by themselves; consumer config (gitignored) carries the actual behavioral knobs.

### addons module + Traefik DaemonSet wiring
- Bump `terraform-k8s-addons` ref `v2.1.0` → `v2.3.0`. New inputs landed there: `traefik_external_traffic_policy`, `traefik_deployment_kind`, `traefik_tolerations`, `traefik_node_selector`. Plus upstream Traefik chart bump 34.2.0 → 39.0.9 (Traefik v3.6.15).
- Default `traefik_service_type = "ClusterIP"` because in a Cloudflare-Tunnel-only public-ingress topology a LoadBalancer Service requests a public VIP nothing uses, and (if MetalLB-allocated) blocks other LoadBalancer Services from sharing that VIP. The MetalLB sharing rule is "identical BackendKey" not "identical externalTrafficPolicy" — Cluster vs Local Services produce empty-string vs selector-string keys that never match per `internal/allocator/k8salloc/k8salloc.go` `BackendKey()` in MetalLB v0.15.3.
- New `services.addons` block in `_platform_defaults` exposes the Traefik DaemonSet / tolerations / nodeSelector knobs to the operator yaml. Engine stays generic; tenant-specific taint keys and labels stay in operator-side gitignored config.

### MetalLB v0.15.3 + canonical annotation prefix
- Bump `version_pin` 0.14.9 → 0.15.3. v0.15+ silently treats the legacy `metallb.universe.tf/allow-shared-ip` prefix as empty sharing-key (still emits deprecation warn but the canonical `metallb.io/...` form is the only one read by the allocator).
- Engine-side `kubernetes_annotations` now writes only the canonical `metallb.io/allow-shared-ip` prefix. Tenant charts that still emit the legacy prefix on their own Services need to migrate, otherwise sharing silently breaks.

### Redis ACL auto-rerun on chart upgrade
- New `helm_revision` output on the redis module exposes the Valkey/Sentinel chart's monotonic revision counter.
- The per-tenant `redis_setup` Job (`modules/project/main.tf`) and the dashboard read-only `redis_dashboard_ro_setup` Job (`platform_dash_db.tf`) interpolate that revision into their `metadata.name`. A chart upgrade — which can switch the Sentinel master and discard the previously-applied tenant ACL — automatically renames every Job, Terraform replaces them, and ACLs re-apply against the post-upgrade master.
- Without this, every Valkey chart upgrade left all tenants on `WRONGPASS` until the operator manually tainted six Jobs.

### ARC runner image bump
- Default `runner_image` 2.328.0 → 2.334.0. GitHub deprecated 2.328.0 ("Runner version v2.328.0 is deprecated and cannot receive messages") — pods register but the broker rejects the long-poll, the agent exits non-zero, ARC marks the runner `TooManyPodFailures`, no jobs land.

### Quota bump
- `config/limits/platform.yaml`: 12→16 CPU, 24→32Gi memory, 20→30 pods. Tighter limit was insufficient for the current set of bring-up Jobs to schedule concurrently.

## Test plan

- [ ] `terraform plan` shows no destroy/replace beyond the redis Job recreations from the new `rev<N>` name suffixes
- [ ] `terraform apply` converges; Traefik runs as DaemonSet across eligible nodes; redis ACL Jobs recreate with `rev<N>` suffix; MetalLB pods bounce to v0.15.3
- [ ] HTTPS path through Cloudflare Tunnel → Traefik ClusterIP works (`curl -I https://<any-tunnel-host>`)
- [ ] Tenant `LoadBalancer` Services pointed at dedicated pool IPs allocate cleanly (no MetalLB sharing rejection)
- [ ] Tenant pods with shared-Redis dependencies connect with their ACL credentials post-apply (no `WRONGPASS`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)