### PR TITLE
fix(minio): update bucket_secret_names output to new consumers shape

### DIFF
--- a/minio.tf
+++ b/minio.tf
@@ -31,6 +31,6 @@ output "minio_endpoint" {
 }
 
 output "minio_buckets" {
-  description = "Map of bucket name → consumer-namespace Secret name. Empty when MinIO is disabled or no buckets are configured."
+  description = "Map of bucket name → list of `{namespace, secret_name}` for every consumer on that bucket. Empty when MinIO is disabled or no buckets are configured."
   value       = module.minio.bucket_secret_names
 }

--- a/modules/minio/main.tf
+++ b/modules/minio/main.tf
@@ -850,6 +850,6 @@ output "service_name" {
 }
 
 output "bucket_secret_names" {
-  description = "Map of bucket name → emitted Secret name (in the consumer namespace). Empty when no buckets configured or module disabled."
-  value       = { for k, v in local.bucket_targets : k => v.secret_name }
+  description = "Map of bucket name → list of `{namespace, secret_name}` for every consumer Secret emitted on that bucket. Empty when no buckets configured or module disabled."
+  value       = { for k, v in local.bucket_targets : k => v.consumers }
 }


### PR DESCRIPTION
## Summary

Tail-fix on top of #85. The PR reshaped \`var.buckets\` from one-consumer-per-bucket to a \`consumers\` list, but \`output \"bucket_secret_names\"\` still referenced the removed \`secret_name\` attribute, breaking \`terraform plan\` with \"object does not have an attribute named secret_name\".

Output now returns the full per-consumer list per bucket (\`{ <bucket>: [{namespace, secret_name}, ...] }\`).

## Test plan

- [ ] \`terraform plan\` succeeds against a config with the new \`consumers\` list shape (no \"object does not have an attribute named secret_name\" error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)