### PR TITLE
fix(buildkitd): reconcile code with live CERN userns config + parameterise probe knobs

### DIFF
--- a/buildkitd.tf
+++ b/buildkitd.tf
@@ -3,8 +3,11 @@
 # `tcp://buildkitd.arc-buildkitd.svc.cluster.local:1234` —
 # workflows on ARC-managed runners hit it via
 # `docker buildx create --driver remote --use --bootstrap` +
-# `docker buildx build`. Cache slabs live on a PVC so sequential
-# builds reuse layers across runner pods (which are ephemeral).
+# `docker buildx build`. Cache slabs live on a hostPath so
+# sequential builds reuse layers across runner pods (which are
+# ephemeral). hostPath survives Pod restarts but pins the daemon
+# to one node — single-replica + node_selector keeps the cache
+# stable.
 #
 # Why standalone vs `--driver kubernetes` (per-job buildkitd Pod):
 # the kubernetes driver creates / destroys a buildkitd Pod per
@@ -14,11 +17,31 @@
 # possible cache poisoning if untrusted code runs in CI) for
 # warm-cache build speed and zero RBAC delegation.
 #
-# Image: `moby/buildkit:<ver>-rootless`. Rootless mode runs as
-# uid 1000, no `privileged: true` on the Pod, no host kernel
-# capabilities. User-namespace remapping inside the container
-# isolates the build; that's enough for our trust boundary
-# (single-operator cluster, no untrusted PRs in our CI today).
+# Trust model: CERN userns pattern. The container runs with
+# `securityContext.privileged: true` (buildkit's OCI worker
+# needs CAP_SYS_ADMIN to set up overlayfs / mount the build
+# rootfs) BUT under `hostUsers: false` — the privileged uid 0
+# inside the container is remapped through a user-namespace to
+# an unprivileged uid on the host. The Pod is "privileged inside
+# its userns, unprivileged on the host", and the kernel — not
+# PSA — is what limits the blast radius. This needs:
+#   - `pod-security.kubernetes.io/enforce: privileged` on the ns
+#     (PSA admission lets `privileged: true` through)
+#   - `hostUsers: false` in the Pod spec (Kubernetes 1.30 alpha,
+#     1.34 beta — k3s on this cluster runs 1.34.6)
+#
+# Why `kubectl_manifest` and not `kubernetes_deployment_v1`: the
+# upstream `hashicorp/kubernetes` provider 2.x has no schema
+# field for `pod.spec.hostUsers`, so the only way to set the
+# field is the raw-YAML resource type from the `gavinbunney/
+# kubectl` provider.
+#
+# Image: `moby/buildkit:<ver>` — rootful. The rootless variant
+# (`-rootless` tag) needs unprivileged user-namespace creation,
+# which Ubuntu 23.10+ blocks by default at the AppArmor
+# `userns_create` LSM hook unless that hook is opened up
+# host-wide via sysctl. CERN privileged-in-userns sidesteps the
+# hook and is the upstream-documented production pattern.
 
 locals {
   buildkitd_enabled   = local.platform.services.buildkitd.enabled
@@ -33,166 +56,107 @@ resource "kubernetes_namespace_v1" "buildkitd" {
     labels = {
       "app.kubernetes.io/managed-by" = "terraform"
       "app.kubernetes.io/component"  = "buildkitd"
-      # Rootless buildkit needs `restricted` PSA exemption for
-      # `procMount: Unmasked` on the user-namespace setup. Use
-      # `baseline` so the Pod's seccomp / unprivileged userns
-      # capabilities aren't blocked at admission.
-      "pod-security.kubernetes.io/enforce" = "baseline"
+      # Privileged because the container sets `privileged: true`.
+      # The blast radius is contained by `hostUsers: false`
+      # (kernel userns remapping), not by PSA — see file header
+      # for the trust model.
+      "pod-security.kubernetes.io/enforce" = "privileged"
     }
   }
 }
 
-resource "kubernetes_persistent_volume_claim_v1" "buildkitd_cache" {
+resource "kubectl_manifest" "buildkitd" {
   count = local.buildkitd_enabled ? 1 : 0
 
-  metadata {
-    name      = "buildkitd-cache"
-    namespace = kubernetes_namespace_v1.buildkitd[0].metadata[0].name
-  }
-
-  spec {
-    access_modes = ["ReadWriteOnce"]
-    resources {
-      requests = {
-        storage = local.platform.services.buildkitd.cache_size
+  yaml_body = yamlencode({
+    apiVersion = "apps/v1"
+    kind       = "Deployment"
+    metadata = {
+      name      = "buildkitd"
+      namespace = kubernetes_namespace_v1.buildkitd[0].metadata[0].name
+      labels = {
+        "app.kubernetes.io/name"      = "buildkitd"
+        "app.kubernetes.io/component" = "buildkitd"
       }
     }
-    storage_class_name = local.platform.services.buildkitd.storage_class != "" ? local.platform.services.buildkitd.storage_class : null
-  }
-
-  wait_until_bound = false
-}
-
-resource "kubernetes_deployment_v1" "buildkitd" {
-  count = local.buildkitd_enabled ? 1 : 0
-
-  metadata {
-    name      = "buildkitd"
-    namespace = kubernetes_namespace_v1.buildkitd[0].metadata[0].name
-    labels = {
-      "app.kubernetes.io/name"      = "buildkitd"
-      "app.kubernetes.io/component" = "buildkitd"
-    }
-  }
-
-  spec {
-    # Single replica — one shared cache. Scaling out loses cache
-    # locality (each replica's PVC is independent on RWO).
-    replicas = 1
-
-    selector {
-      match_labels = {
-        "app.kubernetes.io/name" = "buildkitd"
+    spec = {
+      # Single replica — one shared cache. Scaling out fragments
+      # cache locality (each Pod's hostPath is independent on its
+      # node) and would need a session-affinity layer in front of
+      # the Service to keep a build pinned to its warm replica.
+      replicas = 1
+      selector = {
+        matchLabels = { "app.kubernetes.io/name" = "buildkitd" }
       }
-    }
-
-    strategy {
-      # Recreate (not RollingUpdate) because PVC is RWO — a new
-      # replica can't attach while the old one holds the volume.
-      type = "Recreate"
-    }
-
-    template {
-      metadata {
-        labels = {
-          "app.kubernetes.io/name" = "buildkitd"
-        }
-        annotations = {
-          # Rootless buildkit needs the seccomp + apparmor
-          # profiles relaxed for unprivileged-user-namespace
-          # creation. `unconfined` is broad but not privileged.
-          "container.apparmor.security.beta.kubernetes.io/buildkitd" = "unconfined"
-        }
+      strategy = {
+        # Recreate not RollingUpdate: hostPath cache is
+        # node-pinned and we don't want two Pods racing on the
+        # same files during a rollover.
+        type = "Recreate"
       }
-
-      spec {
-        node_selector = local.platform.services.buildkitd.node_selector
-
-        dynamic "toleration" {
-          for_each = local.platform.services.buildkitd.tolerations
-          content {
-            key      = toleration.value.key
-            operator = toleration.value.operator
-            value    = toleration.value.value
-            effect   = toleration.value.effect
-          }
+      template = {
+        metadata = {
+          labels = { "app.kubernetes.io/name" = "buildkitd" }
         }
-
-        security_context {
-          run_as_user     = 1000
-          run_as_group    = 1000
-          fs_group        = 1000
-          run_as_non_root = true
-          seccomp_profile {
-            type = "Unconfined"
-          }
-        }
-
-        container {
-          name  = "buildkitd"
-          image = "moby/buildkit:${local.platform.services.buildkitd.image_tag}"
-
-          args = [
-            "--addr",
-            "unix:///run/user/1000/buildkit/buildkitd.sock",
-            "--addr",
-            "tcp://0.0.0.0:1234",
-            # OCI worker — standard, no `--oci-worker-no-process-sandbox`
-            # so unprivileged user-namespace isolation kicks in
-            # automatically.
-            "--oci-worker-no-process-sandbox=false",
-          ]
-
-          port {
-            container_port = 1234
-            name           = "grpc"
-            protocol       = "TCP"
-          }
-
-          security_context {
-            run_as_user                = 1000
-            run_as_group               = 1000
-            run_as_non_root            = true
-            allow_privilege_escalation = false
-            seccomp_profile {
-              type = "Unconfined"
+        spec = {
+          hostUsers    = false
+          nodeSelector = local.platform.services.buildkitd.node_selector
+          tolerations  = local.platform.services.buildkitd.tolerations
+          containers = [{
+            name  = "buildkitd"
+            image = "moby/buildkit:${local.platform.services.buildkitd.image_tag}"
+            args = [
+              "--addr",
+              "unix:///run/buildkit/buildkitd.sock",
+              "--addr",
+              "tcp://0.0.0.0:1234",
+            ]
+            ports = [{
+              containerPort = 1234
+              name          = "grpc"
+              protocol      = "TCP"
+            }]
+            securityContext = {
+              privileged = true
             }
-          }
-
-          readiness_probe {
-            exec {
-              command = ["buildctl", "debug", "workers"]
+            readinessProbe = {
+              exec = {
+                command = ["buildctl", "debug", "workers"]
+              }
+              initialDelaySeconds = local.platform.services.buildkitd.readiness_initial_delay_seconds
+              periodSeconds       = local.platform.services.buildkitd.readiness_period_seconds
+              timeoutSeconds      = local.platform.services.buildkitd.readiness_timeout_seconds
+              failureThreshold    = local.platform.services.buildkitd.readiness_failure_threshold
             }
-            initial_delay_seconds = 5
-            period_seconds        = 30
-          }
-
-          volume_mount {
-            name       = "cache"
-            mount_path = "/home/user/.local/share/buildkit"
-          }
-
-          resources {
-            requests = {
-              cpu    = local.platform.services.buildkitd.cpu_request
-              memory = local.platform.services.buildkitd.memory_request
+            volumeMounts = [{
+              name      = "cache"
+              mountPath = local.platform.services.buildkitd.mount_path
+            }]
+            resources = {
+              requests = {
+                cpu    = local.platform.services.buildkitd.cpu_request
+                memory = local.platform.services.buildkitd.memory_request
+              }
+              limits = {
+                cpu    = local.platform.services.buildkitd.cpu_limit
+                memory = local.platform.services.buildkitd.memory_limit
+              }
             }
-            limits = {
-              cpu    = local.platform.services.buildkitd.cpu_limit
-              memory = local.platform.services.buildkitd.memory_limit
+          }]
+          volumes = [{
+            name = "cache"
+            hostPath = {
+              path = local.platform.services.buildkitd.host_path
+              type = "DirectoryOrCreate"
             }
-          }
-        }
-
-        volume {
-          name = "cache"
-          persistent_volume_claim {
-            claim_name = kubernetes_persistent_volume_claim_v1.buildkitd_cache[0].metadata[0].name
-          }
+          }]
         }
       }
     }
-  }
+  })
+
+  wait_for_rollout = true
+  depends_on       = [kubernetes_namespace_v1.buildkitd]
 }
 
 resource "kubernetes_service_v1" "buildkitd" {

--- a/locals.tf
+++ b/locals.tf
@@ -182,16 +182,40 @@ locals {
         # Cluster-internal BuildKit daemon for self-hosted runner
         # image builds. Disabled by default — opt in only when ARC
         # runners need a remote buildx driver.
-        enabled        = false
-        image_tag      = "v0.16.0-rootless"
-        cache_size     = "20Gi"
-        storage_class  = ""
-        cpu_request    = "200m"
-        cpu_limit      = "4"
-        memory_request = "512Mi"
-        memory_limit   = "8Gi"
-        node_selector  = {}
-        tolerations    = []
+        #
+        # Trust model: CERN userns pattern. Container runs
+        # `privileged: true` BUT under `hostUsers: false`, so the
+        # privileged uid 0 inside the container is remapped to an
+        # unprivileged uid on the host (kernel userns isolation).
+        # See `buildkitd.tf` header for the full rationale.
+        #
+        # `host_path` is the cluster-node directory the cache slabs
+        # land in (hostPath volume — survives Pod restarts but not
+        # node moves; buildkitd is a single-replica daemon so node
+        # affinity via `node_selector` keeps the cache pinned).
+        # `mount_path` is the in-container path; defaults to the
+        # rootful buildkit data dir.
+        #
+        # Readiness-probe knobs are exposed because the default
+        # `period_seconds = 10` + `timeout_seconds = 1` killed the
+        # Pod mid-build on busy clusters (`buildctl debug workers`
+        # contends with the active build for the OCI worker lock).
+        # Defaults below are the values that survived a real ARC
+        # build cycle on this cluster.
+        enabled                         = false
+        image_tag                       = "v0.29.0"
+        host_path                       = "/data/vol/buildkit-cache"
+        mount_path                      = "/var/lib/buildkit"
+        cpu_request                     = "200m"
+        cpu_limit                       = "4"
+        memory_request                  = "512Mi"
+        memory_limit                    = "8Gi"
+        readiness_initial_delay_seconds = 5
+        readiness_period_seconds        = 60
+        readiness_timeout_seconds       = 15
+        readiness_failure_threshold     = 5
+        node_selector                   = {}
+        tolerations                     = []
       }
     }
   }


### PR DESCRIPTION
## Summary

Brings `buildkitd.tf` back into sync with what the cluster actually runs (the working CERN userns pattern that landed via `kubectl apply` mid-debug and was never written back to the repo) and lifts the operationally-tuned tweaks from hardcoded literals into `locals.tf` so they're configurable per the platform's pod-placement convention.

After this commit `terraform plan` is clean on buildkitd — the file is an honest representation of what the cluster runs.

## Why the rewrite

`HEAD` was the rootless-buildkit attempt:
- `moby/buildkit:v0.16.0-rootless`, `runAsUser: 1000`, no `privileged`, PVC cache
- That config doesn't survive on Ubuntu 23.10+ with the AppArmor `userns_create` LSM hook closed by default

The config that produced 1/1 Running is the **CERN userns pattern**:
- `securityContext.privileged: true` *inside* a Pod with `hostUsers: false`
- The privileged uid 0 inside the container is remapped through a user-namespace to an unprivileged uid on the host
- The container is "privileged inside its userns, unprivileged on the host" — kernel isolates the blast radius, not PSA
- Needs `pod-security.kubernetes.io/enforce: privileged` on the namespace + `hostUsers: false` (k8s 1.30 alpha, 1.34 beta — k3s here is 1.34.6)

`terraform state` already holds `kubectl_manifest.buildkitd[0]` matching this shape — only the source code was stale.

## Code changes (`buildkitd.tf`)

- Resource type `kubernetes_deployment_v1` + `kubernetes_persistent_volume_claim_v1` → single `kubectl_manifest` Deployment. The upstream `hashicorp/kubernetes` provider 2.x has no schema field for `pod.spec.hostUsers`, so the raw-YAML resource type from `gavinbunney/kubectl` is the only way to set the field.
- Volume RWO PVC → `hostPath: /data/vol/buildkit-cache` (matches live; PVC was overkill for a node-pinned single-replica daemon).
- Namespace PSA label `baseline` → `privileged` (required for `privileged: true`; trust boundary is the kernel userns, not PSA).
- Image `v0.16.0-rootless` → `v0.29.0` (rootful).
- File header rewritten to document the CERN trust model + why `kubectl_manifest` over `kubernetes_deployment_v1`.

## Tweaks parameterised (`locals.tf` `services.buildkitd` defaults)

| field | default | why exposed |
| --- | --- | --- |
| `image_tag` | `v0.29.0` | was `v0.16.0-rootless` |
| `host_path` (new) | `/data/vol/buildkit-cache` | cluster-node cache dir; matches `$HOST_VOLUME_PATH` convention |
| `mount_path` (new) | `/var/lib/buildkit` | in-container cache path (rootful buildkit data dir) |
| `readiness_initial_delay_seconds` (new) | `5` | survived a real ARC build cycle |
| `readiness_period_seconds` (new) | `60` | buildkit defaults of `10s` killed the Pod mid-build under load |
| `readiness_timeout_seconds` (new) | `15` | `buildctl debug workers` contends with active builds for the OCI worker lock |
| `readiness_failure_threshold` (new) | `5` | one missed probe shouldn't bin a warm cache |

**Removed**: `cache_size`, `storage_class` — PVC-only, no equivalent for hostPath.

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform validate` — Success
- [x] `terraform plan` — `3 to add, 0 to change, 0 to destroy`. All 3 are unrelated idempotent provisioner Jobs (`backup.restic_init`, `minio.buckets`, `postgres.pg_extensions`); zero buildkitd churn
- [ ] `./tf apply` after merge — should be the same 3 idempotent Jobs

## Notes for reviewers

- This is a documentation-of-reality commit, not a behaviour change. State already had this YAML; code now matches. No `kubectl apply`-vs-TF drift left to surprise the next operator.
- If you ever want the rootless variant back, the path is: open the AppArmor `userns_create` hook host-wide via sysctl + flip `image_tag` to `<ver>-rootless` + drop `privileged` and `hostUsers: false`. Don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)