### PR TITLE
fix(redis): stop leaking Redis password into HAProxy ConfigMap

### DIFF
--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -454,7 +454,7 @@ resource "kubernetes_config_map_v1" "haproxy_config" {
       backend redis_back
         option tcp-check
         tcp-check connect
-        tcp-check send AUTH\ ${random_password.default["enabled"].result}\r\n
+        tcp-check send AUTH\ $${REDIS_PASSWORD}\r\n
         tcp-check expect string +OK
         tcp-check send PING\r\n
         tcp-check expect string +PONG


### PR DESCRIPTION
## Summary

The HAProxy `tcp-check send AUTH ...` directive in `modules/redis/main.tf` was rendering the cleartext Redis password into the `redis-haproxy-config` ConfigMap via Terraform interpolation. Anyone with `get configmap` RBAC in the `platform` namespace (every operator, every dashboard reader, every CI runner with read-only kubeconfig) could read the live Redis-default password.

The HAProxy container already mounts `REDIS_PASSWORD` from the `redis-default` Secret as an env var, so the right shape is HAProxy's built-in env substitution (`\${VAR}` literal in the config file, expanded by HAProxy at parse time). The file's own comment already documented that this was the intended shape — only the code was wrong.

## Change

`modules/redis/main.tf` line 457 — one byte different:

```diff
- tcp-check send AUTH\ ${random_password.default["enabled"].result}\r\n
+ tcp-check send AUTH\ $${REDIS_PASSWORD}\r\n
```

The double-`$$` escape produces a literal `${REDIS_PASSWORD}` in the rendered ConfigMap; HAProxy 2.0+ (we run `haproxytech/haproxy-alpine:3.0`) substitutes from the process env at startup. Container env was already wired:

```hcl
env {
  name = "REDIS_PASSWORD"
  value_from {
    secret_key_ref { name = "redis-default", key = "REDIS_PASSWORD" }
  }
}
```

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform validate` — Success
- [x] `terraform plan`:
  - `1 to change` for `module.redis.kubernetes_config_map_v1.haproxy_config["enabled"]` (in-place, no restart)
  - + 3 unrelated idempotent provisioner Jobs (`backup.restic_init`, `minio.buckets`, `postgres.pg_extensions`)
- [x] **Proof the leak was real**: TF's plan summary explicitly notes `this attribute value will no longer be marked as sensitive after applying this change` — TF had been propagating the `random_password.default` sensitivity taint into the ConfigMap `data`, which only happens when the actual password value (not a placeholder) is being written
- [ ] After apply: `kubectl -n platform get cm redis-haproxy-config -o yaml | grep AUTH` should show `AUTH ${REDIS_PASSWORD}` literal, not the password
- [ ] HAProxy Pod readiness should remain Ready — env substitution at HAProxy parse time produces the same effective config as the previously inlined literal

## Context

P1 finding from the 2026-05-09 platform code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)