### PR TITLE
fix(github-runners): plan-time precondition for scale_set GitHub auth

### DIFF
--- a/modules/github-runners/main.tf
+++ b/modules/github-runners/main.tf
@@ -137,6 +137,21 @@ resource "helm_release" "scale_set" {
     kubernetes_secret_v1.github_pat,
   ]
 
+  # Catch the misconfiguration at plan time rather than at runtime as
+  # a CrashLoopBackOff on the listener Pod. A scale-set entry with
+  # `github_secret_name = ""` (engine-emit mode) requires a matching
+  # entry in `var.tokens` so the engine can materialise the
+  # `<key>-github-pat` Secret the chart's listener mounts. Without
+  # the token, the chart still installs but `githubConfigSecret`
+  # points at a Secret that never gets created — the listener Pod
+  # then loops on "Secret not found" until somebody notices.
+  lifecycle {
+    precondition {
+      condition     = each.value.github_secret_name != "" || contains(nonsensitive(keys(var.tokens)), each.key)
+      error_message = "Scale set `${each.key}`: no GitHub auth wired. Either set `github_secret_name` to an externally-managed Secret carrying GitHub App fields, or supply a PAT via `var.tokens[\"${each.key}\"]` (operator typically pastes into `.env` as `TF_VAR_github_runner_tokens={ ${each.key} = \"ghp_...\" }`) so the engine can emit `${each.key}-github-pat` automatically."
+    }
+  }
+
   name             = each.key
   repository       = "oci://ghcr.io/actions/actions-runner-controller-charts"
   chart            = "gha-runner-scale-set"


### PR DESCRIPTION
## Summary

A scale-set entry with `github_secret_name = ""` (engine-emit mode) needs a matching `var.tokens[<key>]` so the engine can materialise the `<key>-github-pat` Secret the chart's listener mounts. If the operator forgets the token:

- `kubernetes_secret_v1.github_pat[<key>]` is silently skipped (its `for_each` filter excludes the entry)
- `helm_release.scale_set[<key>]` still installs, pointing `githubConfigSecret` at a Secret that never gets created
- The listener Pod loops on "Secret not found" at runtime until somebody notices in the cluster log

The apply itself succeeds, so the surface area where this breaks is "after green CI, before the next time you happen to inspect runner pods".

## Change

`lifecycle.precondition` on `helm_release.scale_set` that fails at plan time when neither auth source is wired:

```hcl
lifecycle {
  precondition {
    condition     = each.value.github_secret_name != "" || contains(nonsensitive(keys(var.tokens)), each.key)
    error_message = "Scale set `${each.key}`: no GitHub auth wired. Either set `github_secret_name` to ... or supply a PAT via `var.tokens[\"${each.key}\"]` ..."
  }
}
```

`nonsensitive(keys(var.tokens))` is needed because `var.tokens` itself is `sensitive = true` — `keys(...)` inherits the marker, but key names already exist unencrypted in `services.github_runners.scale_sets`, so unwrapping for the `contains()` check is safe.

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform validate` — Success
- [x] `terraform plan` — `0 changes` for github-runners + 3 unrelated idempotent provisioner Jobs. Precondition passes for every currently-configured scale set
- [ ] Misconfiguration shape verifiable by removing a token from `TF_VAR_github_runner_tokens` and re-planning — TF would refuse with the named error before apply runs (don't actually do this in the operator's `.env` — the verification was done mentally against the code path)

## Context

P1 finding from the 2026-05-09 platform code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)