### PR TITLE
fix(outputs): narrow zitadel_pat try() to legitimate empty-state cases

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -163,13 +163,25 @@ output "vault" {
 output "zitadel_pat" {
   description = "PAT for the Zitadel TF provider (machine user `tf-platform`, IAM_OWNER, far-future expiry). Lifted from the in-cluster `zitadel-tf-pat` Secret that the FIRSTINSTANCE-bootstrapped pat-broker sidecar populates. Empty when Zitadel is disabled OR the sidecar hasn't run yet (pre-bootstrap clean clone); populated after the first `./tf apply` brings Zitadel up. Fetch with `terraform output -raw zitadel_pat`, then paste into `.env` as `TF_VAR_zitadel_pat=...` so subsequent applies provision kind:app components."
   sensitive   = true
-  value = try(
-    base64decode([
+  # Two legitimate empty-state cases — only those collapse to "":
+  #   1. Zitadel disabled: the data source for_each map is empty
+  #      (no "enabled" key), so we short-circuit on the service flag
+  #      before indexing it.
+  #   2. Zitadel enabled but the pat-broker sidecar hasn't populated
+  #      `zitadel-tf-pat` yet (clean-clone bootstrap): the filter
+  #      returns zero objects and `one()` collapses to null, which
+  #      `coalesce(..., "")` turns into "".
+  # Anything else (the Secret exists but `data.access_token` is
+  # missing, malformed base64, ...) is a real schema regression and
+  # must surface as a plan-time error rather than be swallowed by a
+  # broad `try()`.
+  value = local.platform.services.zitadel.enabled ? coalesce(
+    one([
       for o in data.kubernetes_resources.zitadel_tf_pat_output["enabled"].objects :
-      o if o.metadata.name == "zitadel-tf-pat"
-    ][0].data.access_token),
+      base64decode(o.data.access_token) if o.metadata.name == "zitadel-tf-pat"
+    ]),
     ""
-  )
+  ) : ""
 }
 
 output "namespaces" {


### PR DESCRIPTION
## Summary

The `output "zitadel_pat"` value was wrapped in a single broad `try(..., "")` covering the entire chain:

```hcl
value = try(
  base64decode([
    for o in data.kubernetes_resources.zitadel_tf_pat_output["enabled"].objects :
    o if o.metadata.name == "zitadel-tf-pat"
  ][0].data.access_token),
  ""
)
```

That swallows everything — the legitimate "Secret not yet created" case, but also "Secret exists with no data field", "`data.access_token` key was renamed upstream", "value isn't valid base64", and any other schema regression. The output silently goes empty in every scenario, which means a real bug ships as "PAT just disappeared, must be something else".

## Change

Refactored to two explicit empty-state branches:

1. **Zitadel disabled** — short-circuit on `services.zitadel.enabled` before indexing the data source `for_each` map (which is empty in that case)
2. **Zitadel enabled, Secret not yet populated** — `one([...])` on the filtered list returns null when zero objects match; `coalesce(..., "")` turns that into `""`

```hcl
value = local.platform.services.zitadel.enabled ? coalesce(
  one([
    for o in data.kubernetes_resources.zitadel_tf_pat_output["enabled"].objects :
    base64decode(o.data.access_token) if o.metadata.name == "zitadel-tf-pat"
  ]),
  ""
) : ""
```

Anything else (missing `data.access_token`, malformed base64, ...) now surfaces at plan / refresh time as the real error it is, instead of being silently swallowed by `try()`.

`one()` errors deliberately if >1 Secret matches, but `zitadel-tf-pat` is a fixed Secret name within a single namespace — the >1 case can't legitimately happen and would itself be a regression worth surfacing.

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform validate` — Success
- [x] `terraform plan` — `0 changes`. Output value is computationally identical for the current "Secret populated" state; only the failure modes diverge

## Context

P1 finding from the 2026-05-09 platform code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)