### PR TITLE
docs(p2): README schema sweep + platform.yaml.example completes all 16 services

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,30 +216,67 @@ terraform output -json projects | jq .
 
 ### Platform-service toggles (`config/platform.yaml`)
 
-The shared platform services are opt-in. The repo's `.example` ships everything off; copy it and flip the bits you want.
+The shared platform services are all opt-in. The repo's `.example` ships everything off; copy it, flip the bits you want, and re-apply:
 
-```yaml
-services:
-  mysql:
-    enabled: true
-  postgres:
-    enabled: true
-  redis:
-    enabled: true
-  ollama:
-    enabled: true
-    models:
-      - qwen3.5:0.8b        # tiny — instant single-shot prompts
-      - qwen3.5:2b          # small playground sibling
-      - qwen3.5:9b          # chat LLM default
-      - all-minilm:latest   # embeddings — used by chat component RAG
-    memory_request: 4Gi
-    memory_limit:   16Gi
-    cpu_request:    200m
-    cpu_limit:      "10"
+```bash
+cp config/platform.yaml.example config/platform.yaml
+$EDITOR config/platform.yaml
+./tf apply
 ```
 
-Each module (`modules/mysql`, `modules/postgres`, `modules/redis`, `modules/ollama`) collapses to zero resources when its `enabled` flag is off. Outputs resolve to null; tenants that ask for a disabled service fail a precondition with a clear error.
+Every service collapses to zero resources when its `enabled` flag is off — disabling a service after-the-fact deletes its workload + namespace + outputs. Outputs from disabled services resolve to `null`; tenant components that depend on one (`db: true`, `redis: true`, …) fail a `precondition` at plan time with an actionable error.
+
+| Service | What it provisions | Tenant-facing handle |
+| --- | --- | --- |
+| `mysql` | Single-replica StatefulSet + per-tenant DB / user / grant Job | `db: true` on a component |
+| `postgres` | Single-replica StatefulSet + per-tenant DB / role / grant Job | `postgres: true` on a component |
+| `redis` | Standalone StatefulSet OR Sentinel HA (helm chart) + HAProxy front + per-tenant ACL user Job | `redis: true` on a component |
+| `ollama` | StatefulSet for shared LLM inference; CPU-only or GPU-offloaded (Vulkan / CUDA) | `ollama: true` (auto-injects `OLLAMA_HOST` / `OLLAMA_BASE_URL`) |
+| `vault` | Vault CE StatefulSet with raft single-node, auto-unseal init Job, optional Zitadel OIDC | platform-internal (Phase 2 will expose tenant-scoped Secret reads via VSO) |
+| `zitadel` | Identity provider — Postgres-backed StatefulSet + init Job + Login UI v2 sidecar | OIDC issuer for `oidc:` components, Argo CD, platform-dash |
+| `argocd` | GitOps controller (upstream chart) with Dex+Zitadel SSO; route emitted as `kind: external` | manual app sync via Argo UI / CLI |
+| `kured` | Kubernetes Reboot Daemon — drains + reboots a node when `/var/run/reboot-required` appears | n/a (cluster maintenance) |
+| `longhorn` | Distributed block-storage StorageClass(es) replicated across cluster nodes; native B2 backup | use `longhorn-<pool>` SC name on `storage:` of a component |
+| `metallb` | Bare-metal `LoadBalancer` controller in L2 mode + per-pool address pools + L2 advertisements | tenant Services with `type: LoadBalancer` + `spec.loadBalancerIP` |
+| `minio` | Single-replica Deployment OR distributed StatefulSet (4+ erasure-coded replicas); per-bucket consumer Secrets | engine emits `S3_*` env-var Secret per consumer namespace; component `envFrom`s it |
+| `github_runners` | ARC v0.9+ controller + N scale sets (each its own namespace + chart release) | runner pools registered with org / repo / enterprise GitHub URLs |
+| `buildkitd` | Cluster-internal BuildKit daemon (`kubectl_manifest` Deployment with CERN userns: privileged-in-userns + `hostUsers: false`); hostPath cache; ClusterIP `tcp://buildkitd.arc-buildkitd.svc.cluster.local:1234` | ARC workflows hit it via `docker buildx create --driver remote --endpoint <that>` |
+| `backup` | restic + B2 — per-target CronJobs for Postgres / MySQL / Redis / Vault / hostPath PVs; weekly prune | operator-driven (`postgres_databases`, `mysql_databases`, `pv_paths` lists) |
+| `platform_dash` | Operator dashboard (SvelteKit) Deployment + Service in `platform` ns; Zitadel-OIDC-only authn | operator UI at `dash.<your-domain>` |
+| `addons` | Knobs for the bundled `terraform-k8s-addons` releases (currently Traefik `Deployment` ↔ `DaemonSet` + tolerations / nodeSelector) | n/a (changes ingress wiring) |
+
+The full schema for every service (every field, defaults, sub-block shapes, worked GPU / runner / metallb examples) lives in **`config/platform.yaml.example`** — that file is the canonical reference and the tracked-in-repo source of truth. The README does not duplicate it; consult `.example` when authoring `config/platform.yaml`.
+
+Notable cross-cutting fields every service supports:
+
+- `node_selector: { <label>: <value> }` — pin the workload to nodes with the matching label. Empty (default) lets the scheduler pick.
+- `tolerations: [{ key, operator, value, effect }]` — opt the workload into scheduling on tainted nodes.
+- `affinity: {...}` (ollama, redis-sentinel) — full k8s `pod.spec.affinity` shape for richer node / pod (anti-)affinity.
+
+### Root variables (`TF_VAR_…`)
+
+Variables read by the root stack from environment / `.env`. Sensitive values stay in the operator's gitignored `.env` (BWS migration is on the ops backlog).
+
+| Variable | Required when | Purpose |
+| --- | --- | --- |
+| `TF_VAR_cluster_name` | minikube | Minikube profile name (default `minikube`) |
+| `TF_VAR_memory` | minikube | Memory in MB allocated to the minikube VM (default `4096`) |
+| `TF_VAR_kubernetes_version` | minikube | k8s tag passed to minikube (default `v1.34.4`); k3s ignores this |
+| `TF_VAR_ssh_host` | k3s | Host where k3s is installed (default `127.0.0.1` for local) |
+| `TF_VAR_ssh_port` | k3s | SSH port (default `22`) |
+| `TF_VAR_ssh_user` | k3s | SSH user with passwordless sudo (no default) |
+| `TF_VAR_ssh_private_key_path` | k3s | Path to the SSH private key (no default) |
+| `LETSENCRYPT_EMAIL` | always | Let's Encrypt registration email (the cert-manager addon issues certs for any non-Cloudflare-Origin route) |
+| `CLOUDFLARE_API_TOKEN` | always | Token with `Account → Cloudflare Tunnel: Edit` + `Zone → DNS: Edit` on every domain (NOT the Global API Key — see "First-time Cloudflare setup" above) |
+| `CLOUDFLARE_ACCOUNT_ID` | always | Cloudflare Account ID for the tunnel resource |
+| `HOST_VOLUME_PATH` | always | Parent path that hostPath PVs land in on the cluster node (default `/data/vol`); macOS Docker-driver minikube needs `/minikube-host/Shared/vol` |
+| `TF_VAR_namespace_prefix` | optional | Prepended to every tenant namespace from `config/domains/*.yaml` (default `phost-`); set to `""` to disable |
+| `TF_VAR_github_runner_tokens` | when ARC engine-emit mode is used | Sensitive map keyed by `services.github_runners.scale_sets` map key, value is a GitHub PAT — engine materialises `<key>-github-pat` Secret automatically |
+| `TF_VAR_operator_secret_values` | when a domain yaml declares `secrets:` with literal data | Sensitive map of `{<secret-name>: {<key>: <value>}}` for credentials the engine cannot synthesize (third-party storage, OIDC client, vendor API keys) |
+| `TF_VAR_zitadel_pat` | after first apply with Zitadel enabled | PAT for the Zitadel TF provider — bootstrapped automatically on first apply, then exposed as `terraform output -raw zitadel_pat`; paste into `.env` to unblock subsequent applies that provision `kind: app` components |
+| `TF_VAR_zitadel_login_client_pat` | when Zitadel pod restarts persistently | PAT for the Zitadel `login-client` machine user — paste once to harden against pod-restart "waiting for login-client.pat..." regression (generation steps in `variables.tf`) |
+
+Backend credentials (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_REGION` / `B2_BUCKET` / `B2_ENDPOINT`) for the S3-API-compatible backend that holds `terraform.tfstate` are also `.env`-supplied and consumed by the `./tf` wrapper before invoking `terraform`.
 
 ### Domain configuration (`config/domains/*.yaml`)
 

--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -267,6 +267,27 @@ services:
     # distributed:
     #   enabled:       true
     #   replica_count: 5
+    #
+    # Buckets pre-created by the engine, each exposed to N consumer
+    # namespaces via per-consumer Secrets. Each consumer gets its
+    # own MinIO service-account key + its own k8s Secret in its own
+    # namespace (`S3_*` env vars), so leakage of one Secret limits
+    # blast radius to that service-account and is revocable without
+    # bucket recreation. Multiple consumers on the same bucket
+    # share data — same `s3:*` policy on the bucket per
+    # service-account (no per-consumer prefix scoping yet). A
+    # plan-time precondition rejects buckets with zero consumers.
+    # Map key is the bucket name (S3 naming rules apply: lowercase
+    # + dashes only).
+    # buckets:
+    #   tenant-archive:
+    #     region: auto                         # SDK-required string; MinIO ignores
+    #     consumers:
+    #       - { namespace: phost-example-com-prod, secret_name: example-archive-s3 }
+    #       - { namespace: phost-example-com-prod, secret_name: example-frontend-s3 }
+    #   shared-uploads:
+    #     consumers:
+    #       - { namespace: phost-other-tld-prod,   secret_name: other-uploads-s3 }
 
   # GitHub self-hosted runners via ARC (Actions Runner Controller v0.9+).
   #
@@ -276,16 +297,26 @@ services:
   # controller` is deprecated; this module uses
   # `actions/actions-runner-controller-charts` only.
   #
-  # GitHub auth per scale set: operator pre-creates a k8s Secret in
-  # the scale set's namespace carrying either:
-  #   - `github_token` (PAT — scope: workflow registration on the
-  #     specific org / repo / enterprise URL)
-  #   - `github_app_id` + `github_app_installation_id` +
-  #     `github_app_private_key` (GitHub App — preferred for orgs)
+  # GitHub auth per scale set has two shapes:
   #
-  # Engine references the Secret by name; engine does NOT create or
-  # rotate it. Bootstrap once via `kubectl create secret generic
-  # arc-github-pat -n <ns> --from-literal=github_token=...`.
+  #   (a) Engine-emitted PAT (default). Leave `github_secret_name`
+  #       empty in the scale-set entry below AND drop the PAT into
+  #       `TF_VAR_github_runner_tokens` in the operator's `.env`
+  #       (sensitive map keyed by the same map key as `scale_sets`).
+  #       Engine then materialises `<key>-github-pat` in the scale
+  #       set's namespace carrying `github_token: <value>` and wires
+  #       the chart to consume it. No `kubectl create secret` step
+  #       anywhere — the engine owns the Secret lifecycle.
+  #
+  #   (b) Externally-managed Secret. Set `github_secret_name` to the
+  #       name of a Secret you manage outside this engine (typical
+  #       case: GitHub App fields, since `tokens` only takes a single
+  #       PAT string per entry). The engine references the Secret by
+  #       name and never reads or rotates it.
+  #
+  # A `lifecycle.precondition` on the chart release fails the plan
+  # if neither auth source is wired for a scale set, with an error
+  # message naming the offending key.
   github_runners:
     enabled: false
     # Controller is shared across every scale set — stateless,
@@ -294,15 +325,19 @@ services:
     #   workload-tier: general
     # Map of scale sets — each entry is one runner pool. Map key is
     # also the chart release name and runner-label-set identifier.
+    # PATs for engine-emit mode (shape (a) above) come from
+    # `TF_VAR_github_runner_tokens` in `.env`, keyed by the same
+    # map key — e.g. `TF_VAR_github_runner_tokens='{"org-runners":"ghp_..."}'`.
     # scale_sets:
     #   org-runners:
     #     # Org-level runners — workflows in any repo under the org
     #     # land in this pool. Use repo-level URL
     #     # (https://github.com/<org>/<repo>) to scope to one repo.
     #     github_config_url:  https://github.com/<org>
-    #     # Pre-created Secret in the namespace below (see comment
-    #     # above for required keys).
-    #     github_secret_name: arc-github-pat
+    #     # Leave empty for shape (a) — engine emits
+    #     # `<key>-github-pat` from var.tokens. Set to an existing
+    #     # Secret name for shape (b).
+    #     github_secret_name: ""
     #     namespace:          arc-runners
     #     # Scale-to-zero between jobs (default min_runners: 0).
     #     # Bump min ≥1 to keep warm runners; pay continuous CPU
@@ -429,6 +464,91 @@ services:
     #   allow_register:          false
     #   allow_external_idp:      true
     #   allow_username_password: true
+
+  # Operator dashboard (SvelteKit) — single-pane status view of every
+  # tenant project + platform service. OIDC-only authentication via
+  # Zitadel; the engine creates the matching Zitadel application
+  # automatically (so `services.zitadel.enabled` is a hard pre-req,
+  # surfaced as a `check` block).
+  #
+  # Engine does NOT assume a specific dashboard build — operator owns
+  # the image. Push a build to any registry the cluster can pull from
+  # (GHCR, Docker Hub, in-cluster Harbor) and pin the tag here.
+  platform_dash:
+    enabled: false
+    # image:    ghcr.io/<your-handle>/platform-dash:vX.Y.Z
+    # hostname: dash.example.com               # routed via the same CF tunnel
+    # replicas: 1
+    # resources:
+    #   requests: { cpu: 100m, memory: 128Mi }
+    #   limits:   { cpu: 500m, memory: 512Mi }
+    # node_selector:
+    #   workload-tier: general
+
+  # Knobs for the bundled `terraform-k8s-addons` releases. Each field
+  # is a thin pass-through to the addon chart — leave commented to
+  # preserve the chart's stock behaviour. Currently only Traefik is
+  # exposed.
+  addons: {}
+    # `Deployment` (chart default; one Pod fronting all VIPs) or
+    # `DaemonSet` (one Pod per matched node — required when
+    # MetalLB pools have `l2_node_selectors` pinning each VIP to
+    # a specific node, so the Traefik backing the VIP must run on
+    # that node too).
+    # traefik_deployment_kind: DaemonSet
+    # Tolerations on the Traefik Pod — needed in DaemonSet mode if
+    # any matched node carries a NoSchedule taint (e.g. an edge
+    # node tagged `node-role.kubernetes.io/edge`).
+    # traefik_tolerations:
+    #   - { key: node-role.kubernetes.io/edge, operator: Exists, effect: NoSchedule }
+    # Optional node selector for the Traefik Pod — only useful in
+    # Deployment mode (DaemonSet runs everywhere it tolerates).
+    # traefik_node_selector:
+    #   workload-tier: edge
+
+  # Cluster-internal BuildKit daemon for self-hosted runner image
+  # builds. Single shared `buildkitd` Pod exposes its gRPC API on
+  # `tcp://buildkitd.arc-buildkitd.svc.cluster.local:1234`; ARC
+  # workflows hit it via `docker buildx create --driver remote
+  # --endpoint <that>`. Cache slabs land on a hostPath volume so
+  # sequential builds reuse layers across (ephemeral) runner pods.
+  #
+  # Runs the upstream rootful `moby/buildkit` image with the CERN
+  # userns pattern: `securityContext.privileged: true` *inside* a
+  # Pod with `hostUsers: false`, so the privileged uid 0 in-container
+  # remaps through a kernel user-namespace to an unprivileged uid on
+  # the host. The namespace label `pod-security.kubernetes.io/enforce`
+  # is set to `privileged` (required for `privileged: true`); the
+  # actual blast-radius bound is the kernel userns, not PSA. See
+  # `buildkitd.tf` header for the full trust model.
+  #
+  # Why not the rootless `*-rootless` image: Ubuntu 23.10+ closes
+  # the AppArmor `userns_create` LSM hook by default, which blocks
+  # unprivileged user-namespace creation. CERN privileged-in-userns
+  # sidesteps the hook and is the upstream-documented production
+  # pattern.
+  buildkitd:
+    enabled: false
+    # image_tag:  v0.29.0                       # rootful — `<ver>-rootless` will not work without sysctl tweaks
+    # host_path:  /data/vol/buildkit-cache      # cluster-node cache dir; pin daemon with node_selector
+    # mount_path: /var/lib/buildkit             # in-container cache path (rootful default)
+    # Resource budget — buildkit can spike on multi-stage builds.
+    # cpu_request:    200m
+    # cpu_limit:      "4"
+    # memory_request: 512Mi
+    # memory_limit:   8Gi
+    # Readiness-probe knobs. Buildkit's `buildctl debug workers`
+    # contends with the active build for the OCI worker lock, so
+    # the chart-default `period=10, timeout=1` killed Pods mid-build.
+    # Defaults below are values that survived a real ARC build cycle.
+    # readiness_initial_delay_seconds: 5
+    # readiness_period_seconds:        60
+    # readiness_timeout_seconds:       15
+    # readiness_failure_threshold:     5
+    # Pin the daemon to a specific node so the hostPath cache
+    # stays warm across rollouts.
+    # node_selector:
+    #   workload-tier: general
 
 # Pod placement (Phase B, optional per service)
 #


### PR DESCRIPTION
## Summary

Two related docs gaps from the 2026-05-09 review, fixed in one sweep:

1. **`config/platform.yaml.example` only covered 13 of 16 services**. Three were missing entirely (`platform_dash`, `addons`, `buildkitd` — the last landed in PR #90 with no `.example` coverage). The `services.minio.buckets` multi-consumer schema was absent from the minio block.

2. **`README.md` `### Platform-service toggles` only showed a 4-line yaml snippet** covering `mysql / postgres / redis / ollama`. The thirteen other services (vault, zitadel, argocd, longhorn, metallb, minio, github_runners, buildkitd, backup, platform_dash, kured, addons) had no README presence at all, so a new operator landing on the README couldn't see what was on the menu without diving into `locals.tf` or the modules.

Plus one stale-doc fix: the `services.github_runners` block in `.example` instructed the operator to bootstrap the GitHub auth Secret via `kubectl create secret generic ...` — directly conflicts with the engine's no-click-ops rule. The engine emits the Secret itself from `TF_VAR_github_runner_tokens`. The block now documents the two real auth shapes (engine-emit vs externally-managed) without any `kubectl` step.

## Changes

### `config/platform.yaml.example`

- **`services.minio.buckets`** — schema example showing the multi-consumer pattern (each consumer gets its own MinIO service-account key + Secret in its own namespace, blast-radius isolation, plan-time precondition rejecting buckets with zero consumers).
- **`services.platform_dash`** — `enabled: false` + commented full schema (image, hostname, replicas, resources, node_selector).
- **`services.addons`** — currently exposes Traefik `Deployment` ↔ `DaemonSet` switch + tolerations / nodeSelector for the bundled addons release.
- **`services.buildkitd`** — image_tag, host_path, mount_path, readiness probe knobs (the parameterised values from PR #90), with a header explaining the CERN userns trust model.
- **`services.github_runners`** — rewrote header + scale-set comment to document engine-emit vs externally-managed Secret modes. Removed the `kubectl create secret` instruction, added pointer to `TF_VAR_github_runner_tokens`.

### `README.md`

- **`### Platform-service toggles`** — replaced 4-service yaml snippet with a 16-row table summarising every service (what it provisions + tenant-facing handle). Points operators at `config/platform.yaml.example` as the canonical schema reference rather than duplicating it. Added explicit list of cross-cutting fields (`node_selector`, `tolerations`, `affinity`).
- **`### Root variables (TF_VAR_…)`** — new subsection — 16-row table documenting every `variables.tf` entry with its `TF_VAR_` env name, when required, what it does. Also notes the S3 backend credentials the `./tf` wrapper reads from `.env`.

## Test plan

- [x] `python -c "import yaml; yaml.safe_load(open('config/platform.yaml.example'))"` — parses as valid YAML
- [x] `terraform fmt -recursive` — clean (no `.tf` touched)
- [x] `terraform validate` — Success
- [x] `terraform plan` — shows only the pre-existing unapplied diff from PR #91 (`module.redis.kubernetes_config_map_v1.haproxy_config` in-place update — that PR is merged but not yet applied) + 3 unrelated idempotent provisioner Jobs. Zero diff from this PR's content
- [x] All 16 services in `_platform_defaults` (`locals.tf`) now have a matching block in `.example`; verified via the same `yaml.safe_load(...)` count

## Context

P2 finding from the 2026-05-09 platform code review — schema documentation lagging behind engine evolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)