### PR TITLE
refactor(root): convert count→for_each toggles per AGENT.md

### DIFF
--- a/argocd.tf
+++ b/argocd.tf
@@ -31,7 +31,7 @@ check "argocd_hostname_set" {
 # step would have run. The chart's `create_namespace = false` below
 # expects the namespace to already exist.
 resource "kubernetes_namespace_v1" "argocd" {
-  count = local.platform.services.argocd.enabled ? 1 : 0
+  for_each = local.platform.services.argocd.enabled ? toset(["enabled"]) : toset([])
 
   metadata {
     name = local.platform.services.argocd.namespace
@@ -46,7 +46,7 @@ resource "kubernetes_namespace_v1" "argocd" {
 # downstream only consume `client_id` / `client_secret` directly.
 module "argocd_oidc" {
   source     = "./modules/zitadel-app"
-  count      = local.platform.services.argocd.enabled && local.platform.services.zitadel.enabled ? 1 : 0
+  for_each   = local.platform.services.argocd.enabled && local.platform.services.zitadel.enabled ? toset(["enabled"]) : toset([])
   depends_on = [kubernetes_namespace_v1.argocd]
   # No `depends_on = [module.zitadel]` — the org_id input below is
   # resolved at root via `data.zitadel_orgs.platform_org`, so the
@@ -60,7 +60,7 @@ module "argocd_oidc" {
     random     = random
   }
 
-  org_id       = local.platform.services.zitadel.enabled ? data.zitadel_orgs.platform_org[0].ids[0] : ""
+  org_id       = local.platform.services.zitadel.enabled ? data.zitadel_orgs.platform_org["enabled"].ids[0] : ""
   project_name = "argocd"
   app_name     = "argocd"
   issuer_url   = "https://${local.platform.services.zitadel.external_domain}"
@@ -95,8 +95,8 @@ module "argocd" {
   hostname = local.platform.services.argocd.hostname
 
   oidc_issuer        = local.platform.services.zitadel.enabled ? "https://${local.platform.services.zitadel.external_domain}" : ""
-  oidc_client_id     = try(module.argocd_oidc[0].client_id, "")
-  oidc_client_secret = try(module.argocd_oidc[0].client_secret, "")
+  oidc_client_id     = try(module.argocd_oidc["enabled"].client_id, "")
+  oidc_client_secret = try(module.argocd_oidc["enabled"].client_secret, "")
   oidc_admin_groups  = ["argocd_admin"]
 
   node_selector = local.platform.services.argocd.node_selector

--- a/backup.tf
+++ b/backup.tf
@@ -72,7 +72,7 @@ check "backup_inputs_set_when_enabled" {
 # rotation in the source namespace propagates on the next apply.
 
 resource "kubernetes_secret_v1" "backup_postgres_superuser" {
-  count = local.platform.services.backup.enabled && local.platform.services.postgres.enabled ? 1 : 0
+  for_each = local.platform.services.backup.enabled && local.platform.services.postgres.enabled ? toset(["enabled"]) : toset([])
 
   depends_on = [module.backup]
 
@@ -86,12 +86,12 @@ resource "kubernetes_secret_v1" "backup_postgres_superuser" {
   }
 
   data = {
-    POSTGRES_PASSWORD = data.kubernetes_secret_v1.postgres_superuser[0].data["POSTGRES_PASSWORD"]
+    POSTGRES_PASSWORD = data.kubernetes_secret_v1.postgres_superuser["enabled"].data["POSTGRES_PASSWORD"]
   }
 }
 
 data "kubernetes_secret_v1" "postgres_superuser" {
-  count = local.platform.services.backup.enabled && local.platform.services.postgres.enabled ? 1 : 0
+  for_each = local.platform.services.backup.enabled && local.platform.services.postgres.enabled ? toset(["enabled"]) : toset([])
 
   metadata {
     name      = module.postgres.superuser_secret_name
@@ -100,7 +100,7 @@ data "kubernetes_secret_v1" "postgres_superuser" {
 }
 
 resource "kubernetes_secret_v1" "backup_mysql_root" {
-  count = local.platform.services.backup.enabled && local.platform.services.mysql.enabled ? 1 : 0
+  for_each = local.platform.services.backup.enabled && local.platform.services.mysql.enabled ? toset(["enabled"]) : toset([])
 
   depends_on = [module.backup]
 
@@ -114,12 +114,12 @@ resource "kubernetes_secret_v1" "backup_mysql_root" {
   }
 
   data = {
-    MYSQL_ROOT_PASSWORD = data.kubernetes_secret_v1.mysql_root[0].data["MYSQL_ROOT_PASSWORD"]
+    MYSQL_ROOT_PASSWORD = data.kubernetes_secret_v1.mysql_root["enabled"].data["MYSQL_ROOT_PASSWORD"]
   }
 }
 
 data "kubernetes_secret_v1" "mysql_root" {
-  count = local.platform.services.backup.enabled && local.platform.services.mysql.enabled ? 1 : 0
+  for_each = local.platform.services.backup.enabled && local.platform.services.mysql.enabled ? toset(["enabled"]) : toset([])
 
   metadata {
     name      = module.mysql.root_secret_name
@@ -128,7 +128,7 @@ data "kubernetes_secret_v1" "mysql_root" {
 }
 
 resource "kubernetes_secret_v1" "backup_redis_default" {
-  count = local.platform.services.backup.enabled && local.platform.services.redis.enabled ? 1 : 0
+  for_each = local.platform.services.backup.enabled && local.platform.services.redis.enabled ? toset(["enabled"]) : toset([])
 
   depends_on = [module.backup]
 
@@ -142,12 +142,12 @@ resource "kubernetes_secret_v1" "backup_redis_default" {
   }
 
   data = {
-    REDIS_PASSWORD = data.kubernetes_secret_v1.redis_default[0].data["REDIS_PASSWORD"]
+    REDIS_PASSWORD = data.kubernetes_secret_v1.redis_default["enabled"].data["REDIS_PASSWORD"]
   }
 }
 
 data "kubernetes_secret_v1" "redis_default" {
-  count = local.platform.services.backup.enabled && local.platform.services.redis.enabled ? 1 : 0
+  for_each = local.platform.services.backup.enabled && local.platform.services.redis.enabled ? toset(["enabled"]) : toset([])
 
   metadata {
     name      = module.redis.default_secret_name
@@ -156,7 +156,7 @@ data "kubernetes_secret_v1" "redis_default" {
 }
 
 resource "kubernetes_secret_v1" "backup_vault_token" {
-  count = local.platform.services.backup.enabled && local.platform.services.vault.enabled ? 1 : 0
+  for_each = local.platform.services.backup.enabled && local.platform.services.vault.enabled ? toset(["enabled"]) : toset([])
 
   depends_on = [module.backup]
 
@@ -170,12 +170,12 @@ resource "kubernetes_secret_v1" "backup_vault_token" {
   }
 
   data = {
-    "root-token" = data.kubernetes_secret_v1.vault_bootstrap[0].data["root-token"]
+    "root-token" = data.kubernetes_secret_v1.vault_bootstrap["enabled"].data["root-token"]
   }
 }
 
 data "kubernetes_secret_v1" "vault_bootstrap" {
-  count = local.platform.services.backup.enabled && local.platform.services.vault.enabled ? 1 : 0
+  for_each = local.platform.services.backup.enabled && local.platform.services.vault.enabled ? toset(["enabled"]) : toset([])
 
   metadata {
     name      = "vault-bootstrap"

--- a/buildkitd.tf
+++ b/buildkitd.tf
@@ -49,7 +49,7 @@ locals {
 }
 
 resource "kubernetes_namespace_v1" "buildkitd" {
-  count = local.buildkitd_enabled ? 1 : 0
+  for_each = local.buildkitd_enabled ? toset(["enabled"]) : toset([])
 
   metadata {
     name = local.buildkitd_namespace
@@ -66,14 +66,14 @@ resource "kubernetes_namespace_v1" "buildkitd" {
 }
 
 resource "kubectl_manifest" "buildkitd" {
-  count = local.buildkitd_enabled ? 1 : 0
+  for_each = local.buildkitd_enabled ? toset(["enabled"]) : toset([])
 
   yaml_body = yamlencode({
     apiVersion = "apps/v1"
     kind       = "Deployment"
     metadata = {
       name      = "buildkitd"
-      namespace = kubernetes_namespace_v1.buildkitd[0].metadata[0].name
+      namespace = kubernetes_namespace_v1.buildkitd["enabled"].metadata[0].name
       labels = {
         "app.kubernetes.io/name"      = "buildkitd"
         "app.kubernetes.io/component" = "buildkitd"
@@ -160,11 +160,11 @@ resource "kubectl_manifest" "buildkitd" {
 }
 
 resource "kubernetes_service_v1" "buildkitd" {
-  count = local.buildkitd_enabled ? 1 : 0
+  for_each = local.buildkitd_enabled ? toset(["enabled"]) : toset([])
 
   metadata {
     name      = "buildkitd"
-    namespace = kubernetes_namespace_v1.buildkitd[0].metadata[0].name
+    namespace = kubernetes_namespace_v1.buildkitd["enabled"].metadata[0].name
     labels = {
       "app.kubernetes.io/name"      = "buildkitd"
       "app.kubernetes.io/component" = "buildkitd"
@@ -189,5 +189,5 @@ resource "kubernetes_service_v1" "buildkitd" {
 
 output "buildkitd_endpoint" {
   description = "In-cluster BuildKit gRPC endpoint for `docker buildx create --driver remote --endpoint <this>`. Empty when buildkitd is disabled."
-  value       = local.buildkitd_enabled ? "tcp://${kubernetes_service_v1.buildkitd[0].metadata[0].name}.${kubernetes_namespace_v1.buildkitd[0].metadata[0].name}.svc.cluster.local:1234" : ""
+  value       = local.buildkitd_enabled ? "tcp://${kubernetes_service_v1.buildkitd["enabled"].metadata[0].name}.${kubernetes_namespace_v1.buildkitd["enabled"].metadata[0].name}.svc.cluster.local:1234" : ""
 }

--- a/mail.tf
+++ b/mail.tf
@@ -19,7 +19,7 @@
 # sets `mail.primary: true`.
 
 resource "kubernetes_namespace_v1" "mail" {
-  count = local.mail == null ? 0 : 1
+  for_each = local.mail == null ? toset([]) : toset(["enabled"])
 
   metadata {
     name = "mail"
@@ -40,11 +40,11 @@ resource "kubernetes_namespace_v1" "mail" {
 # expected mailbox count is one digit. 2Gi memory + 2 CPU leaves
 # enough room without blowing past a typical home-lab node.
 resource "kubernetes_resource_quota_v1" "mail" {
-  count = local.mail == null ? 0 : 1
+  for_each = local.mail == null ? toset([]) : toset(["enabled"])
 
   metadata {
     name      = "mail-budget"
-    namespace = kubernetes_namespace_v1.mail[0].metadata[0].name
+    namespace = kubernetes_namespace_v1.mail["enabled"].metadata[0].name
     labels = {
       "app.kubernetes.io/managed-by" = "terraform"
     }
@@ -66,7 +66,7 @@ module "stalwart" {
   depends_on = [module.addons, module.zitadel, kubernetes_resource_quota_v1.mail]
 
   enabled          = local.mail != null
-  namespace        = local.mail == null ? "" : kubernetes_namespace_v1.mail[0].metadata[0].name
+  namespace        = local.mail == null ? "" : kubernetes_namespace_v1.mail["enabled"].metadata[0].name
   volume_base_path = var.host_volume_path
 
   # Primary domain + matching Cloudflare zone come from the domain
@@ -90,7 +90,7 @@ module "stalwart" {
   # creates an OIDC app + role + the bootstrap plan attaches Zitadel
   # as the authentication directory. When off, Stalwart still comes
   # up with internal directory + recovery admin only.
-  zitadel_org_id                 = local.platform.services.zitadel.enabled ? data.zitadel_orgs.platform_org[0].ids[0] : ""
+  zitadel_org_id                 = local.platform.services.zitadel.enabled ? data.zitadel_orgs.platform_org["enabled"].ids[0] : ""
   zitadel_issuer_url             = local.platform.services.zitadel.enabled ? "https://${local.platform.services.zitadel.external_domain}" : ""
   zitadel_provider_authenticated = var.zitadel_pat != ""
 
@@ -127,11 +127,11 @@ module "roundcube" {
   depends_on = [module.stalwart]
 
   enabled          = local.mail != null && local.platform.services.zitadel.enabled
-  namespace        = local.mail == null ? "" : kubernetes_namespace_v1.mail[0].metadata[0].name
+  namespace        = local.mail == null ? "" : kubernetes_namespace_v1.mail["enabled"].metadata[0].name
   hostname         = try(local.mail.hostname, "")
   volume_base_path = var.host_volume_path
 
-  zitadel_org_id                 = local.platform.services.zitadel.enabled ? data.zitadel_orgs.platform_org[0].ids[0] : ""
+  zitadel_org_id                 = local.platform.services.zitadel.enabled ? data.zitadel_orgs.platform_org["enabled"].ids[0] : ""
   zitadel_issuer_url             = local.platform.services.zitadel.enabled ? "https://${local.platform.services.zitadel.external_domain}" : ""
   zitadel_provider_authenticated = var.zitadel_pat != ""
   zitadel_project_id             = local.platform.services.zitadel.enabled ? module.stalwart.zitadel_project_id : ""
@@ -144,7 +144,7 @@ module "roundcube" {
 # `enabled` would pull org_id resolution into the apply phase and
 # every dependent resource would re-plan as "must replace".
 data "zitadel_orgs" "platform_org" {
-  count = local.platform.services.zitadel.enabled ? 1 : 0
+  for_each = local.platform.services.zitadel.enabled ? toset(["enabled"]) : toset([])
 
   name        = "ZITADEL"
   name_method = "TEXT_QUERY_METHOD_EQUALS"

--- a/main.tf
+++ b/main.tf
@@ -196,7 +196,7 @@ module "project" {
   # `module.project` don't have to query Zitadel themselves (which
   # would re-introduce the data-source-defer cascade described on
   # `resource "zitadel_default_login_policy"` in zitadel.tf).
-  zitadel_org_id                 = local.platform.services.zitadel.enabled ? data.zitadel_orgs.platform_org[0].ids[0] : ""
+  zitadel_org_id                 = local.platform.services.zitadel.enabled ? data.zitadel_orgs.platform_org["enabled"].ids[0] : ""
   zitadel_issuer_url             = local.platform.services.zitadel.enabled ? "https://${local.platform.services.zitadel.external_domain}" : null
   zitadel_provider_authenticated = var.zitadel_pat != ""
 

--- a/oauth2_proxy.tf
+++ b/oauth2_proxy.tf
@@ -43,7 +43,7 @@ module "oauth2_proxy" {
   enabled                        = local.platform.services.zitadel.enabled
   namespace                      = "ingress-controller"
   zitadel_provider_authenticated = var.zitadel_pat != ""
-  zitadel_org_id                 = local.platform.services.zitadel.enabled ? data.zitadel_orgs.platform_org[0].ids[0] : ""
+  zitadel_org_id                 = local.platform.services.zitadel.enabled ? data.zitadel_orgs.platform_org["enabled"].ids[0] : ""
 
   issuer_url    = local.platform.services.zitadel.enabled ? "https://${local.platform.services.zitadel.external_domain}" : ""
   auth_hostname = local._oauth2_parent_domain == "" ? "" : "auth.${local._oauth2_parent_domain}"

--- a/platform_dash.tf
+++ b/platform_dash.tf
@@ -39,8 +39,8 @@ check "platform_dash_image_set" {
 # AUTH_ZITADEL_ISSUER / AUTH_ZITADEL_ID / AUTH_ZITADEL_SECRET /
 # AUTH_SECRET — the module's Deployment mounts it via env_from.
 module "platform_dash_oidc" {
-  source = "./modules/zitadel-app"
-  count  = local.platform.services.platform_dash.enabled && local.platform.services.zitadel.enabled ? 1 : 0
+  source   = "./modules/zitadel-app"
+  for_each = local.platform.services.platform_dash.enabled && local.platform.services.zitadel.enabled ? toset(["enabled"]) : toset([])
   # `depends_on = [module.zitadel]` is intentionally absent. With
   # `org_id` flowing in from `data.zitadel_orgs.platform_org` at root
   # the module no longer queries Zitadel itself, so the module-level
@@ -55,7 +55,7 @@ module "platform_dash_oidc" {
     random     = random
   }
 
-  org_id       = local.platform.services.zitadel.enabled ? data.zitadel_orgs.platform_org[0].ids[0] : ""
+  org_id       = local.platform.services.zitadel.enabled ? data.zitadel_orgs.platform_org["enabled"].ids[0] : ""
   project_name = "platform-dash"
   app_name     = "platform-dash"
   issuer_url   = "https://${local.platform.services.zitadel.external_domain}"
@@ -105,8 +105,8 @@ module "platform_dash" {
   replicas             = local.platform.services.platform_dash.replicas
   resources            = local.platform.services.platform_dash.resources
   hostname             = local.platform.services.platform_dash.hostname
-  oidc_secret_name     = try(module.platform_dash_oidc[0].secret_name, "platform-dash-oidc")
-  oidc_secret_checksum = try(module.platform_dash_oidc[0].secret_checksum, "no-oidc")
+  oidc_secret_name     = try(module.platform_dash_oidc["enabled"].secret_name, "platform-dash-oidc")
+  oidc_secret_checksum = try(module.platform_dash_oidc["enabled"].secret_checksum, "no-oidc")
 
   node_selector = local.platform.services.platform_dash.node_selector
   tolerations   = local.platform.services.platform_dash.tolerations

--- a/platform_dash_db.tf
+++ b/platform_dash_db.tf
@@ -66,21 +66,21 @@ locals {
 # Symbol-free so the URI doesn't need URL-encoding (the dashboard
 # pg / ioredis clients consume raw connection strings).
 resource "random_password" "dashboard_ro_pg" {
-  count   = local.dash_pg_enabled ? 1 : 0
-  length  = 32
-  special = false
+  for_each = local.dash_pg_enabled ? toset(["enabled"]) : toset([])
+  length   = 32
+  special  = false
 }
 
 resource "random_password" "dashboard_ro_redis" {
-  count   = local.dash_red_enabled ? 1 : 0
-  length  = 32
-  special = false
+  for_each = local.dash_red_enabled ? toset(["enabled"]) : toset([])
+  length   = 32
+  special  = false
 }
 
 resource "random_password" "dashboard_ro_mysql" {
-  count   = local.dash_mysql_enabled ? 1 : 0
-  length  = 32
-  special = false
+  for_each = local.dash_mysql_enabled ? toset(["enabled"]) : toset([])
+  length   = 32
+  special  = false
 }
 
 # ── Postgres: provision dashboard_ro via psql Job ────────────────────────────
@@ -89,7 +89,7 @@ resource "random_password" "dashboard_ro_mysql" {
 # need (all stat queries can run against any single db on a
 # pg_monitor connection).
 resource "kubernetes_job_v1" "pg_dashboard_ro_setup" {
-  count      = local.dash_pg_enabled ? 1 : 0
+  for_each   = local.dash_pg_enabled ? toset(["enabled"]) : toset([])
   depends_on = [module.postgres]
 
   metadata {
@@ -127,7 +127,7 @@ resource "kubernetes_job_v1" "pg_dashboard_ro_setup" {
           }
           env {
             name  = "RO_PASSWORD"
-            value = random_password.dashboard_ro_pg[0].result
+            value = random_password.dashboard_ro_pg["enabled"].result
           }
 
           resources {
@@ -161,7 +161,7 @@ resource "kubernetes_job_v1" "pg_dashboard_ro_setup" {
 # `~*` allows access to all keys (read-only); `&*` allows all
 # pub/sub channels (subscribe is read in spirit). No write categories.
 resource "kubernetes_job_v1" "redis_dashboard_ro_setup" {
-  count      = local.dash_red_enabled ? 1 : 0
+  for_each   = local.dash_red_enabled ? toset(["enabled"]) : toset([])
   depends_on = [module.redis]
 
   metadata {
@@ -199,7 +199,7 @@ resource "kubernetes_job_v1" "redis_dashboard_ro_setup" {
           }
           env {
             name  = "RO_PASSWORD"
-            value = random_password.dashboard_ro_redis[0].result
+            value = random_password.dashboard_ro_redis["enabled"].result
           }
 
           resources {
@@ -240,7 +240,7 @@ resource "kubernetes_job_v1" "redis_dashboard_ro_setup" {
 # only. dashboard_ro@'%' so the role works from the dashboard pod
 # regardless of source IP.
 resource "kubernetes_job_v1" "mysql_dashboard_ro_setup" {
-  count      = local.dash_mysql_enabled ? 1 : 0
+  for_each   = local.dash_mysql_enabled ? toset(["enabled"]) : toset([])
   depends_on = [module.mysql]
 
   metadata {
@@ -274,7 +274,7 @@ resource "kubernetes_job_v1" "mysql_dashboard_ro_setup" {
           }
           env {
             name  = "RO_PASSWORD"
-            value = random_password.dashboard_ro_mysql[0].result
+            value = random_password.dashboard_ro_mysql["enabled"].result
           }
 
           resources {
@@ -316,7 +316,7 @@ resource "kubernetes_job_v1" "mysql_dashboard_ro_setup" {
 # without per-namespace RoleBindings. Rotating the password = next
 # terraform apply rebuilds both the user and this Secret atomically.
 resource "kubernetes_secret_v1" "platform_pg_dashboard" {
-  count      = local.dash_pg_enabled ? 1 : 0
+  for_each   = local.dash_pg_enabled ? toset(["enabled"]) : toset([])
   depends_on = [kubernetes_job_v1.pg_dashboard_ro_setup]
 
   metadata {
@@ -327,12 +327,12 @@ resource "kubernetes_secret_v1" "platform_pg_dashboard" {
     }
   }
   data = {
-    URI = "postgres://dashboard_ro:${random_password.dashboard_ro_pg[0].result}@${module.postgres.host}:${module.postgres.port}/postgres?sslmode=disable"
+    URI = "postgres://dashboard_ro:${random_password.dashboard_ro_pg["enabled"].result}@${module.postgres.host}:${module.postgres.port}/postgres?sslmode=disable"
   }
 }
 
 resource "kubernetes_secret_v1" "platform_redis_dashboard" {
-  count      = local.dash_red_enabled ? 1 : 0
+  for_each   = local.dash_red_enabled ? toset(["enabled"]) : toset([])
   depends_on = [kubernetes_job_v1.redis_dashboard_ro_setup]
 
   metadata {
@@ -343,12 +343,12 @@ resource "kubernetes_secret_v1" "platform_redis_dashboard" {
     }
   }
   data = {
-    URI = "redis://dashboard_ro:${random_password.dashboard_ro_redis[0].result}@${module.redis.host}:${module.redis.port}/0"
+    URI = "redis://dashboard_ro:${random_password.dashboard_ro_redis["enabled"].result}@${module.redis.host}:${module.redis.port}/0"
   }
 }
 
 resource "kubernetes_secret_v1" "platform_mysql_dashboard" {
-  count      = local.dash_mysql_enabled ? 1 : 0
+  for_each   = local.dash_mysql_enabled ? toset(["enabled"]) : toset([])
   depends_on = [kubernetes_job_v1.mysql_dashboard_ro_setup]
 
   metadata {
@@ -359,7 +359,7 @@ resource "kubernetes_secret_v1" "platform_mysql_dashboard" {
     }
   }
   data = {
-    URI = "mysql://dashboard_ro:${random_password.dashboard_ro_mysql[0].result}@${module.mysql.host}:${module.mysql.port}/mysql"
+    URI = "mysql://dashboard_ro:${random_password.dashboard_ro_mysql["enabled"].result}@${module.mysql.host}:${module.mysql.port}/mysql"
   }
 }
 
@@ -367,7 +367,7 @@ resource "kubernetes_secret_v1" "platform_mysql_dashboard" {
 # Single source of truth the dashboard's lib/db-targets.server.ts
 # reads via its SA. `targets.yaml` is the documented schema.
 resource "kubernetes_config_map_v1" "platform_dash_db_targets" {
-  count = local.dash_namespace != null && length(local.dash_db_targets) > 0 ? 1 : 0
+  for_each = local.dash_namespace != null && length(local.dash_db_targets) > 0 ? toset(["enabled"]) : toset([])
 
   metadata {
     name      = "platform-dash-db-targets"

--- a/zitadel.tf
+++ b/zitadel.tf
@@ -144,7 +144,7 @@ module "zitadel" {
 # data-source-defer condition can no longer fire, so this resource
 # lives at the level that owns the lookup.
 resource "zitadel_default_login_policy" "main" {
-  count      = local.platform.services.zitadel.enabled ? 1 : 0
+  for_each   = local.platform.services.zitadel.enabled ? toset(["enabled"]) : toset([])
   depends_on = [module.zitadel]
 
   allow_register     = local.platform.services.zitadel.login_policy.allow_register
@@ -188,7 +188,7 @@ resource "zitadel_default_login_policy" "main" {
 # within one token-lifetime cycle instead of being stuck on a
 # cached pre-grant token until LRU eviction or pod restart.
 resource "zitadel_default_oidc_settings" "main" {
-  count      = local.platform.services.zitadel.enabled ? 1 : 0
+  for_each   = local.platform.services.zitadel.enabled ? toset(["enabled"]) : toset([])
   depends_on = [module.zitadel]
 
   access_token_lifetime         = local.platform.services.zitadel.oidc_settings.access_token_lifetime

--- a/zitadel_actions.tf
+++ b/zitadel_actions.tf
@@ -26,9 +26,9 @@
 # tokens without the bridged claim.
 
 resource "zitadel_action" "groups_claim" {
-  count = local.platform.services.zitadel.enabled ? 1 : 0
+  for_each = local.platform.services.zitadel.enabled ? toset(["enabled"]) : toset([])
 
-  org_id  = data.zitadel_orgs.platform_org[0].ids[0]
+  org_id  = data.zitadel_orgs.platform_org["enabled"].ids[0]
   name    = "groups_claim_from_project_roles"
   timeout = "10s"
   # `allowed_to_fail = true` — defensive default for an Action that
@@ -85,13 +85,13 @@ resource "zitadel_action" "groups_claim" {
 # "complement_token" in older docs was renamed; the trigger types
 # stayed `PRE_*_CREATION`.)
 resource "zitadel_trigger_actions" "groups_claim_userinfo" {
-  count = local.platform.services.zitadel.enabled ? 1 : 0
+  for_each = local.platform.services.zitadel.enabled ? toset(["enabled"]) : toset([])
 
-  org_id       = data.zitadel_orgs.platform_org[0].ids[0]
+  org_id       = data.zitadel_orgs.platform_org["enabled"].ids[0]
   flow_type    = "FLOW_TYPE_CUSTOMISE_TOKEN"
   trigger_type = "TRIGGER_TYPE_PRE_USERINFO_CREATION"
 
-  action_ids = [zitadel_action.groups_claim[0].id]
+  action_ids = [zitadel_action.groups_claim["enabled"].id]
 }
 
 # Same script also runs on access-token issuance so service-side
@@ -100,11 +100,11 @@ resource "zitadel_trigger_actions" "groups_claim_userinfo" {
 # Trigger is independent — tokens go through a separate Zitadel
 # pipeline.
 resource "zitadel_trigger_actions" "groups_claim_access_token" {
-  count = local.platform.services.zitadel.enabled ? 1 : 0
+  for_each = local.platform.services.zitadel.enabled ? toset(["enabled"]) : toset([])
 
-  org_id       = data.zitadel_orgs.platform_org[0].ids[0]
+  org_id       = data.zitadel_orgs.platform_org["enabled"].ids[0]
   flow_type    = "FLOW_TYPE_CUSTOMISE_TOKEN"
   trigger_type = "TRIGGER_TYPE_PRE_ACCESS_TOKEN_CREATION"
 
-  action_ids = [zitadel_action.groups_claim[0].id]
+  action_ids = [zitadel_action.groups_claim["enabled"].id]
 }


### PR DESCRIPTION
## Summary

AGENT.md mandates `for_each = var.enabled ? toset(["enabled"]) : toset([])` over `count = var.enabled ? 1 : 0`. Modules already followed this idiom; root `.tf` files lagged behind. This PR converts all **32 toggle-shaped count usages** across 9 root files plus the **32 corresponding `[0]` references**.

State migration via `terraform state mv` was already executed locally — no `moved` blocks committed (one-shot migration noise once the move lands). Plan after the migration is back to baseline (3 idempotent provisioner Jobs + the unapplied PR #91 ConfigMap update; **zero destroy**).

## Files touched

| file | resources/modules converted |
| --- | --- |
| `argocd.tf` | 2 |
| `backup.tf` | 8 |
| `buildkitd.tf` | 3 |
| `mail.tf` | 3 |
| `platform_dash.tf` | 1 |
| `platform_dash_db.tf` | 10 |
| `zitadel.tf` | 2 |
| `zitadel_actions.tf` | 3 |

(`main.tf` and `oauth2_proxy.tf` only saw `[0] → ["enabled"]` reference rewrites for refs to resources moved in the files above.)

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform validate` — Success
- [x] State migrated locally (`terraform state mv` x32)
- [x] `terraform plan` after state-mv — `3 to add, 1 to change, 0 to destroy`. Same baseline as before this PR (idempotent Jobs + unapplied PR #91)

## Context

P3 finding from the 2026-05-09 platform code review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)