### PR TITLE
refactor(buildkitd): extract into modules/buildkitd/ per AGENT.md layout

### DIFF
--- a/buildkitd.tf
+++ b/buildkitd.tf
@@ -1,193 +1,33 @@
-# Cluster-internal BuildKit daemon for self-hosted runner image
-# builds. Single shared `buildkitd` Pod exposes its gRPC API on
-# `tcp://buildkitd.arc-buildkitd.svc.cluster.local:1234` —
-# workflows on ARC-managed runners hit it via
-# `docker buildx create --driver remote --use --bootstrap` +
-# `docker buildx build`. Cache slabs live on a hostPath so
-# sequential builds reuse layers across runner pods (which are
-# ephemeral). hostPath survives Pod restarts but pins the daemon
-# to one node — single-replica + node_selector keeps the cache
-# stable.
+# BuildKit daemon — root wiring.
 #
-# Why standalone vs `--driver kubernetes` (per-job buildkitd Pod):
-# the kubernetes driver creates / destroys a buildkitd Pod per
-# build, which (a) needs RBAC on the runner SA to manage Pods,
-# (b) loses cache on every job teardown. Single shared daemon
-# trades isolation between concurrent builds (one warm cache,
-# possible cache poisoning if untrusted code runs in CI) for
-# warm-cache build speed and zero RBAC delegation.
-#
-# Trust model: CERN userns pattern. The container runs with
-# `securityContext.privileged: true` (buildkit's OCI worker
-# needs CAP_SYS_ADMIN to set up overlayfs / mount the build
-# rootfs) BUT under `hostUsers: false` — the privileged uid 0
-# inside the container is remapped through a user-namespace to
-# an unprivileged uid on the host. The Pod is "privileged inside
-# its userns, unprivileged on the host", and the kernel — not
-# PSA — is what limits the blast radius. This needs:
-#   - `pod-security.kubernetes.io/enforce: privileged` on the ns
-#     (PSA admission lets `privileged: true` through)
-#   - `hostUsers: false` in the Pod spec (Kubernetes 1.30 alpha,
-#     1.34 beta — k3s on this cluster runs 1.34.6)
-#
-# Why `kubectl_manifest` and not `kubernetes_deployment_v1`: the
-# upstream `hashicorp/kubernetes` provider 2.x has no schema
-# field for `pod.spec.hostUsers`, so the only way to set the
-# field is the raw-YAML resource type from the `gavinbunney/
-# kubectl` provider.
-#
-# Image: `moby/buildkit:<ver>` — rootful. The rootless variant
-# (`-rootless` tag) needs unprivileged user-namespace creation,
-# which Ubuntu 23.10+ blocks by default at the AppArmor
-# `userns_create` LSM hook unless that hook is opened up
-# host-wide via sysctl. CERN privileged-in-userns sidesteps the
-# hook and is the upstream-documented production pattern.
+# Module owns the namespace, kubectl_manifest Deployment (CERN userns
+# pattern), and ClusterIP Service. Operator drives toggle + tuning
+# via `services.buildkitd` in `config/platform.yaml`. See
+# `modules/buildkitd/main.tf` header for the trust model and the
+# `kubectl_manifest`-vs-`kubernetes_deployment_v1` rationale.
 
-locals {
-  buildkitd_enabled   = local.platform.services.buildkitd.enabled
-  buildkitd_namespace = "arc-buildkitd"
-}
+module "buildkitd" {
+  source = "./modules/buildkitd"
 
-resource "kubernetes_namespace_v1" "buildkitd" {
-  for_each = local.buildkitd_enabled ? toset(["enabled"]) : toset([])
+  enabled        = local.platform.services.buildkitd.enabled
+  image_tag      = local.platform.services.buildkitd.image_tag
+  host_path      = local.platform.services.buildkitd.host_path
+  mount_path     = local.platform.services.buildkitd.mount_path
+  cpu_request    = local.platform.services.buildkitd.cpu_request
+  cpu_limit      = local.platform.services.buildkitd.cpu_limit
+  memory_request = local.platform.services.buildkitd.memory_request
+  memory_limit   = local.platform.services.buildkitd.memory_limit
 
-  metadata {
-    name = local.buildkitd_namespace
-    labels = {
-      "app.kubernetes.io/managed-by" = "terraform"
-      "app.kubernetes.io/component"  = "buildkitd"
-      # Privileged because the container sets `privileged: true`.
-      # The blast radius is contained by `hostUsers: false`
-      # (kernel userns remapping), not by PSA — see file header
-      # for the trust model.
-      "pod-security.kubernetes.io/enforce" = "privileged"
-    }
-  }
-}
+  readiness_initial_delay_seconds = local.platform.services.buildkitd.readiness_initial_delay_seconds
+  readiness_period_seconds        = local.platform.services.buildkitd.readiness_period_seconds
+  readiness_timeout_seconds       = local.platform.services.buildkitd.readiness_timeout_seconds
+  readiness_failure_threshold     = local.platform.services.buildkitd.readiness_failure_threshold
 
-resource "kubectl_manifest" "buildkitd" {
-  for_each = local.buildkitd_enabled ? toset(["enabled"]) : toset([])
-
-  yaml_body = yamlencode({
-    apiVersion = "apps/v1"
-    kind       = "Deployment"
-    metadata = {
-      name      = "buildkitd"
-      namespace = kubernetes_namespace_v1.buildkitd["enabled"].metadata[0].name
-      labels = {
-        "app.kubernetes.io/name"      = "buildkitd"
-        "app.kubernetes.io/component" = "buildkitd"
-      }
-    }
-    spec = {
-      # Single replica — one shared cache. Scaling out fragments
-      # cache locality (each Pod's hostPath is independent on its
-      # node) and would need a session-affinity layer in front of
-      # the Service to keep a build pinned to its warm replica.
-      replicas = 1
-      selector = {
-        matchLabels = { "app.kubernetes.io/name" = "buildkitd" }
-      }
-      strategy = {
-        # Recreate not RollingUpdate: hostPath cache is
-        # node-pinned and we don't want two Pods racing on the
-        # same files during a rollover.
-        type = "Recreate"
-      }
-      template = {
-        metadata = {
-          labels = { "app.kubernetes.io/name" = "buildkitd" }
-        }
-        spec = {
-          hostUsers    = false
-          nodeSelector = local.platform.services.buildkitd.node_selector
-          tolerations  = local.platform.services.buildkitd.tolerations
-          containers = [{
-            name  = "buildkitd"
-            image = "moby/buildkit:${local.platform.services.buildkitd.image_tag}"
-            args = [
-              "--addr",
-              "unix:///run/buildkit/buildkitd.sock",
-              "--addr",
-              "tcp://0.0.0.0:1234",
-            ]
-            ports = [{
-              containerPort = 1234
-              name          = "grpc"
-              protocol      = "TCP"
-            }]
-            securityContext = {
-              privileged = true
-            }
-            readinessProbe = {
-              exec = {
-                command = ["buildctl", "debug", "workers"]
-              }
-              initialDelaySeconds = local.platform.services.buildkitd.readiness_initial_delay_seconds
-              periodSeconds       = local.platform.services.buildkitd.readiness_period_seconds
-              timeoutSeconds      = local.platform.services.buildkitd.readiness_timeout_seconds
-              failureThreshold    = local.platform.services.buildkitd.readiness_failure_threshold
-            }
-            volumeMounts = [{
-              name      = "cache"
-              mountPath = local.platform.services.buildkitd.mount_path
-            }]
-            resources = {
-              requests = {
-                cpu    = local.platform.services.buildkitd.cpu_request
-                memory = local.platform.services.buildkitd.memory_request
-              }
-              limits = {
-                cpu    = local.platform.services.buildkitd.cpu_limit
-                memory = local.platform.services.buildkitd.memory_limit
-              }
-            }
-          }]
-          volumes = [{
-            name = "cache"
-            hostPath = {
-              path = local.platform.services.buildkitd.host_path
-              type = "DirectoryOrCreate"
-            }
-          }]
-        }
-      }
-    }
-  })
-
-  wait_for_rollout = true
-  depends_on       = [kubernetes_namespace_v1.buildkitd]
-}
-
-resource "kubernetes_service_v1" "buildkitd" {
-  for_each = local.buildkitd_enabled ? toset(["enabled"]) : toset([])
-
-  metadata {
-    name      = "buildkitd"
-    namespace = kubernetes_namespace_v1.buildkitd["enabled"].metadata[0].name
-    labels = {
-      "app.kubernetes.io/name"      = "buildkitd"
-      "app.kubernetes.io/component" = "buildkitd"
-    }
-  }
-
-  spec {
-    type = "ClusterIP"
-
-    selector = {
-      "app.kubernetes.io/name" = "buildkitd"
-    }
-
-    port {
-      name        = "grpc"
-      port        = 1234
-      target_port = 1234
-      protocol    = "TCP"
-    }
-  }
+  node_selector = local.platform.services.buildkitd.node_selector
+  tolerations   = local.platform.services.buildkitd.tolerations
 }
 
 output "buildkitd_endpoint" {
   description = "In-cluster BuildKit gRPC endpoint for `docker buildx create --driver remote --endpoint <this>`. Empty when buildkitd is disabled."
-  value       = local.buildkitd_enabled ? "tcp://${kubernetes_service_v1.buildkitd["enabled"].metadata[0].name}.${kubernetes_namespace_v1.buildkitd["enabled"].metadata[0].name}.svc.cluster.local:1234" : ""
+  value       = module.buildkitd.endpoint
 }

--- a/modules/buildkitd/CHANGELOG.md
+++ b/modules/buildkitd/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this module are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+the project itself follows [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- Initial extraction from the root `buildkitd.tf` file. Resources, defaults,
+  inputs, and outputs are functionally identical to the prior root-inline
+  shape; only the address layout changed (every resource now lives under
+  `module.buildkitd.*`). Operator runs `terraform state mv` to relocate the
+  three live resources before the next apply.

--- a/modules/buildkitd/README.md
+++ b/modules/buildkitd/README.md
@@ -1,0 +1,57 @@
+# buildkitd
+
+Cluster-internal BuildKit daemon for self-hosted runner image builds — single shared Pod with hostPath cache, exposes gRPC on port 1234. Trust model is the CERN userns pattern (`securityContext.privileged: true` inside a Pod with `hostUsers: false`); see `main.tf` header for the full rationale and why `kubectl_manifest` was needed instead of `kubernetes_deployment_v1`.
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+| ---- | ------- |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | ~> 1.14 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.0 |
+
+## Providers
+
+| Name | Version |
+| ---- | ------- |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | ~> 1.14 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | ~> 2.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+| ---- | ---- |
+| [kubectl_manifest.this](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
+| [kubernetes_namespace_v1.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
+| [kubernetes_service_v1.this](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_v1) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+| ---- | ----------- | ---- | ------- | :------: |
+| <a name="input_cpu_limit"></a> [cpu\_limit](#input\_cpu\_limit) | Container `resources.limits.cpu` for the buildkitd Pod. Cap the spike so a runaway build doesn't starve the rest of the node. `4` (cores) suits a typical multi-stage Dockerfile build. | `string` | `"4"` | no |
+| <a name="input_cpu_request"></a> [cpu\_request](#input\_cpu\_request) | Container `resources.requests.cpu` for the buildkitd Pod. Buildkit is bursty — the daemon mostly idles between builds and spikes during multi-stage builds. Keep the request low so the Pod isn't blocking scheduler headroom from other workloads. | `string` | `"200m"` | no |
+| <a name="input_enabled"></a> [enabled](#input\_enabled) | Whether to install the buildkitd Pod + Service. False collapses every resource to zero — namespace, kubectl\_manifest Deployment, and ClusterIP all disappear, and the `endpoint` output resolves to an empty string. | `bool` | `false` | no |
+| <a name="input_host_path"></a> [host\_path](#input\_host\_path) | Cluster-node directory the build cache slabs land in (hostPath volume). Survives Pod restarts but is node-pinned — the daemon should be pinned to the same node via `node_selector` so the cache stays warm. Convention is `<host_volume_path>/buildkit-cache`. | `string` | `"/data/vol/buildkit-cache"` | no |
+| <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | Tag of the upstream `moby/buildkit` image to run. MUST be the rootful variant — the `-rootless` tags need unprivileged userns creation, which Ubuntu 23.10+ blocks at the AppArmor `userns_create` LSM hook by default. Bump as upstream cuts new releases. | `string` | `"v0.29.0"` | no |
+| <a name="input_memory_limit"></a> [memory\_limit](#input\_memory\_limit) | Container `resources.limits.memory` for the buildkitd Pod. Hit OOM during a build → the build fails with a confusing `failed to copy: cancelled` error rather than a clean OOMKilled, so size for the largest expected build. | `string` | `"8Gi"` | no |
+| <a name="input_memory_request"></a> [memory\_request](#input\_memory\_request) | Container `resources.requests.memory` for the buildkitd Pod. The daemon's resident set is small (~256Mi) when idle, but in-flight builds blow up the working set during layer pack/unpack. | `string` | `"512Mi"` | no |
+| <a name="input_mount_path"></a> [mount\_path](#input\_mount\_path) | In-container path the cache is mounted at. Defaults to the rootful buildkit data directory (`/var/lib/buildkit`). Override only if the operator runs a fork that uses a different layout. | `string` | `"/var/lib/buildkit"` | no |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace the buildkitd Pod + Service land in. Convention is `arc-buildkitd` (a sibling of the ARC controller's `arc-system` namespace), but operator can override per cluster. Module owns the namespace creation, so the name must not collide with one already managed elsewhere. | `string` | `"arc-buildkitd"` | no |
+| <a name="input_node_selector"></a> [node\_selector](#input\_node\_selector) | Node selector for the buildkitd Pod. Strongly recommended in any multi-node cluster — the hostPath cache is node-pinned and the daemon needs to land on the same node every time, otherwise a Pod reschedule starts with a cold cache. Empty (default) lets the scheduler pick freely. | `map(string)` | `{}` | no |
+| <a name="input_readiness_failure_threshold"></a> [readiness\_failure\_threshold](#input\_readiness\_failure\_threshold) | `readinessProbe.failureThreshold`. One missed probe shouldn't bin a warm cache; `5` gives the daemon room to ride out a transient lock-contention burst. | `number` | `5` | no |
+| <a name="input_readiness_initial_delay_seconds"></a> [readiness\_initial\_delay\_seconds](#input\_readiness\_initial\_delay\_seconds) | `readinessProbe.initialDelaySeconds`. buildkitd boots fast (binary, no JVM), so the default of `5` is more than enough. | `number` | `5` | no |
+| <a name="input_readiness_period_seconds"></a> [readiness\_period\_seconds](#input\_readiness\_period\_seconds) | `readinessProbe.periodSeconds`. The buildkit-default of `10` killed Pods mid-build under load — `buildctl debug workers` (the probe command) contends with the active build for the OCI worker lock. `60` keeps the probe out of the build's hot path. | `number` | `60` | no |
+| <a name="input_readiness_timeout_seconds"></a> [readiness\_timeout\_seconds](#input\_readiness\_timeout\_seconds) | `readinessProbe.timeoutSeconds`. The buildkit-default of `1` is too aggressive when the worker is busy serving a build. `15` is the value that survived a real ARC build cycle on this cluster. | `number` | `15` | no |
+| <a name="input_tolerations"></a> [tolerations](#input\_tolerations) | Tolerations for the buildkitd Pod. Standard k8s toleration shape — set this when the chosen node carries a NoSchedule taint that the buildkitd Pod needs to bypass. | <pre>list(object({<br/>    key      = optional(string)<br/>    operator = optional(string, "Exists")<br/>    value    = optional(string)<br/>    effect   = optional(string)<br/>  }))</pre> | `[]` | no |
+
+## Outputs
+
+| Name | Description |
+| ---- | ----------- |
+| <a name="output_endpoint"></a> [endpoint](#output\_endpoint) | In-cluster BuildKit gRPC endpoint for `docker buildx create --driver remote --endpoint <this>`. Empty when the module is disabled. |
+<!-- END_TF_DOCS -->

--- a/modules/buildkitd/main.tf
+++ b/modules/buildkitd/main.tf
@@ -1,0 +1,198 @@
+# Cluster-internal BuildKit daemon for self-hosted runner image
+# builds. Single shared `buildkitd` Pod exposes its gRPC API on
+# `tcp://buildkitd.<namespace>.svc.cluster.local:1234` — workflows on
+# ARC-managed runners hit it via `docker buildx create --driver
+# remote --use --bootstrap` + `docker buildx build`. Cache slabs
+# live on a hostPath so sequential builds reuse layers across runner
+# pods (which are ephemeral). hostPath survives Pod restarts but
+# pins the daemon to one node — single-replica + node_selector
+# keeps the cache stable.
+#
+# Why standalone vs `--driver kubernetes` (per-job buildkitd Pod):
+# the kubernetes driver creates / destroys a buildkitd Pod per
+# build, which (a) needs RBAC on the runner SA to manage Pods,
+# (b) loses cache on every job teardown. Single shared daemon
+# trades isolation between concurrent builds (one warm cache,
+# possible cache poisoning if untrusted code runs in CI) for
+# warm-cache build speed and zero RBAC delegation.
+#
+# Trust model: CERN userns pattern. The container runs with
+# `securityContext.privileged: true` (buildkit's OCI worker needs
+# CAP_SYS_ADMIN to set up overlayfs / mount the build rootfs) BUT
+# under `hostUsers: false` — the privileged uid 0 inside the
+# container is remapped through a user-namespace to an
+# unprivileged uid on the host. The Pod is "privileged inside its
+# userns, unprivileged on the host", and the kernel — not PSA — is
+# what limits the blast radius. This needs:
+#   - `pod-security.kubernetes.io/enforce: privileged` on the ns
+#     (PSA admission lets `privileged: true` through)
+#   - `hostUsers: false` in the Pod spec (Kubernetes 1.30 alpha,
+#     1.34 beta — k3s on this cluster runs 1.34.6)
+#
+# Why `kubectl_manifest` and not `kubernetes_deployment_v1`: the
+# upstream `hashicorp/kubernetes` provider 2.x has no schema field
+# for `pod.spec.hostUsers`, so the only way to set the field is the
+# raw-YAML resource type from the `gavinbunney/kubectl` provider.
+#
+# Image: `moby/buildkit:<ver>` — rootful. The rootless variant
+# (`-rootless` tag) needs unprivileged user-namespace creation,
+# which Ubuntu 23.10+ blocks by default at the AppArmor
+# `userns_create` LSM hook unless that hook is opened up host-wide
+# via sysctl. CERN privileged-in-userns sidesteps the hook and is
+# the upstream-documented production pattern.
+
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.14"
+    }
+  }
+}
+
+locals {
+  instances = var.enabled ? toset(["enabled"]) : toset([])
+}
+
+resource "kubernetes_namespace_v1" "this" {
+  for_each = local.instances
+
+  metadata {
+    name = var.namespace
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/component"  = "buildkitd"
+      # Privileged because the container sets `privileged: true`.
+      # The blast radius is contained by `hostUsers: false`
+      # (kernel userns remapping), not by PSA — see file header
+      # for the trust model.
+      "pod-security.kubernetes.io/enforce" = "privileged"
+    }
+  }
+}
+
+resource "kubectl_manifest" "this" {
+  for_each = local.instances
+
+  yaml_body = yamlencode({
+    apiVersion = "apps/v1"
+    kind       = "Deployment"
+    metadata = {
+      name      = "buildkitd"
+      namespace = kubernetes_namespace_v1.this["enabled"].metadata[0].name
+      labels = {
+        "app.kubernetes.io/name"      = "buildkitd"
+        "app.kubernetes.io/component" = "buildkitd"
+      }
+    }
+    spec = {
+      # Single replica — one shared cache. Scaling out fragments
+      # cache locality (each Pod's hostPath is independent on its
+      # node) and would need a session-affinity layer in front of
+      # the Service to keep a build pinned to its warm replica.
+      replicas = 1
+      selector = {
+        matchLabels = { "app.kubernetes.io/name" = "buildkitd" }
+      }
+      strategy = {
+        # Recreate not RollingUpdate: hostPath cache is
+        # node-pinned and we don't want two Pods racing on the
+        # same files during a rollover.
+        type = "Recreate"
+      }
+      template = {
+        metadata = {
+          labels = { "app.kubernetes.io/name" = "buildkitd" }
+        }
+        spec = {
+          hostUsers    = false
+          nodeSelector = var.node_selector
+          tolerations  = var.tolerations
+          containers = [{
+            name  = "buildkitd"
+            image = "moby/buildkit:${var.image_tag}"
+            args = [
+              "--addr",
+              "unix:///run/buildkit/buildkitd.sock",
+              "--addr",
+              "tcp://0.0.0.0:1234",
+            ]
+            ports = [{
+              containerPort = 1234
+              name          = "grpc"
+              protocol      = "TCP"
+            }]
+            securityContext = {
+              privileged = true
+            }
+            readinessProbe = {
+              exec = {
+                command = ["buildctl", "debug", "workers"]
+              }
+              initialDelaySeconds = var.readiness_initial_delay_seconds
+              periodSeconds       = var.readiness_period_seconds
+              timeoutSeconds      = var.readiness_timeout_seconds
+              failureThreshold    = var.readiness_failure_threshold
+            }
+            volumeMounts = [{
+              name      = "cache"
+              mountPath = var.mount_path
+            }]
+            resources = {
+              requests = {
+                cpu    = var.cpu_request
+                memory = var.memory_request
+              }
+              limits = {
+                cpu    = var.cpu_limit
+                memory = var.memory_limit
+              }
+            }
+          }]
+          volumes = [{
+            name = "cache"
+            hostPath = {
+              path = var.host_path
+              type = "DirectoryOrCreate"
+            }
+          }]
+        }
+      }
+    }
+  })
+
+  wait_for_rollout = true
+  depends_on       = [kubernetes_namespace_v1.this]
+}
+
+resource "kubernetes_service_v1" "this" {
+  for_each = local.instances
+
+  metadata {
+    name      = "buildkitd"
+    namespace = kubernetes_namespace_v1.this["enabled"].metadata[0].name
+    labels = {
+      "app.kubernetes.io/name"      = "buildkitd"
+      "app.kubernetes.io/component" = "buildkitd"
+    }
+  }
+
+  spec {
+    type = "ClusterIP"
+
+    selector = {
+      "app.kubernetes.io/name" = "buildkitd"
+    }
+
+    port {
+      name        = "grpc"
+      port        = 1234
+      target_port = 1234
+      protocol    = "TCP"
+    }
+  }
+}

--- a/modules/buildkitd/outputs.tf
+++ b/modules/buildkitd/outputs.tf
@@ -1,0 +1,8 @@
+output "endpoint" {
+  description = "In-cluster BuildKit gRPC endpoint for `docker buildx create --driver remote --endpoint <this>`. Empty when the module is disabled."
+  value = (
+    var.enabled
+    ? "tcp://${kubernetes_service_v1.this["enabled"].metadata[0].name}.${kubernetes_namespace_v1.this["enabled"].metadata[0].name}.svc.cluster.local:1234"
+    : ""
+  )
+}

--- a/modules/buildkitd/variables.tf
+++ b/modules/buildkitd/variables.tf
@@ -1,0 +1,94 @@
+variable "enabled" {
+  description = "Whether to install the buildkitd Pod + Service. False collapses every resource to zero — namespace, kubectl_manifest Deployment, and ClusterIP all disappear, and the `endpoint` output resolves to an empty string."
+  type        = bool
+  default     = false
+}
+
+variable "namespace" {
+  description = "Namespace the buildkitd Pod + Service land in. Convention is `arc-buildkitd` (a sibling of the ARC controller's `arc-system` namespace), but operator can override per cluster. Module owns the namespace creation, so the name must not collide with one already managed elsewhere."
+  type        = string
+  default     = "arc-buildkitd"
+}
+
+variable "image_tag" {
+  description = "Tag of the upstream `moby/buildkit` image to run. MUST be the rootful variant — the `-rootless` tags need unprivileged userns creation, which Ubuntu 23.10+ blocks at the AppArmor `userns_create` LSM hook by default. Bump as upstream cuts new releases."
+  type        = string
+  default     = "v0.29.0"
+}
+
+variable "host_path" {
+  description = "Cluster-node directory the build cache slabs land in (hostPath volume). Survives Pod restarts but is node-pinned — the daemon should be pinned to the same node via `node_selector` so the cache stays warm. Convention is `<host_volume_path>/buildkit-cache`."
+  type        = string
+  default     = "/data/vol/buildkit-cache"
+}
+
+variable "mount_path" {
+  description = "In-container path the cache is mounted at. Defaults to the rootful buildkit data directory (`/var/lib/buildkit`). Override only if the operator runs a fork that uses a different layout."
+  type        = string
+  default     = "/var/lib/buildkit"
+}
+
+variable "cpu_request" {
+  description = "Container `resources.requests.cpu` for the buildkitd Pod. Buildkit is bursty — the daemon mostly idles between builds and spikes during multi-stage builds. Keep the request low so the Pod isn't blocking scheduler headroom from other workloads."
+  type        = string
+  default     = "200m"
+}
+
+variable "cpu_limit" {
+  description = "Container `resources.limits.cpu` for the buildkitd Pod. Cap the spike so a runaway build doesn't starve the rest of the node. `4` (cores) suits a typical multi-stage Dockerfile build."
+  type        = string
+  default     = "4"
+}
+
+variable "memory_request" {
+  description = "Container `resources.requests.memory` for the buildkitd Pod. The daemon's resident set is small (~256Mi) when idle, but in-flight builds blow up the working set during layer pack/unpack."
+  type        = string
+  default     = "512Mi"
+}
+
+variable "memory_limit" {
+  description = "Container `resources.limits.memory` for the buildkitd Pod. Hit OOM during a build → the build fails with a confusing `failed to copy: cancelled` error rather than a clean OOMKilled, so size for the largest expected build."
+  type        = string
+  default     = "8Gi"
+}
+
+variable "readiness_initial_delay_seconds" {
+  description = "`readinessProbe.initialDelaySeconds`. buildkitd boots fast (binary, no JVM), so the default of `5` is more than enough."
+  type        = number
+  default     = 5
+}
+
+variable "readiness_period_seconds" {
+  description = "`readinessProbe.periodSeconds`. The buildkit-default of `10` killed Pods mid-build under load — `buildctl debug workers` (the probe command) contends with the active build for the OCI worker lock. `60` keeps the probe out of the build's hot path."
+  type        = number
+  default     = 60
+}
+
+variable "readiness_timeout_seconds" {
+  description = "`readinessProbe.timeoutSeconds`. The buildkit-default of `1` is too aggressive when the worker is busy serving a build. `15` is the value that survived a real ARC build cycle on this cluster."
+  type        = number
+  default     = 15
+}
+
+variable "readiness_failure_threshold" {
+  description = "`readinessProbe.failureThreshold`. One missed probe shouldn't bin a warm cache; `5` gives the daemon room to ride out a transient lock-contention burst."
+  type        = number
+  default     = 5
+}
+
+variable "node_selector" {
+  description = "Node selector for the buildkitd Pod. Strongly recommended in any multi-node cluster — the hostPath cache is node-pinned and the daemon needs to land on the same node every time, otherwise a Pod reschedule starts with a cold cache. Empty (default) lets the scheduler pick freely."
+  type        = map(string)
+  default     = {}
+}
+
+variable "tolerations" {
+  description = "Tolerations for the buildkitd Pod. Standard k8s toleration shape — set this when the chosen node carries a NoSchedule taint that the buildkitd Pod needs to bypass."
+  type = list(object({
+    key      = optional(string)
+    operator = optional(string, "Exists")
+    value    = optional(string)
+    effect   = optional(string)
+  }))
+  default = []
+}


### PR DESCRIPTION
## Summary

Every other shared service (mysql, postgres, redis, ollama, vault, zitadel, argocd, github_runners, longhorn, metallb, minio, …) lives in `modules/<name>/` with a thin root `<name>.tf` wiring file. **buildkitd was the lone exception** — its three resources lived inline in root `buildkitd.tf` because the file was first written in the middle of the BuildKit debug saga and never got hoisted out.

This PR moves it to the standard layout. Functionally identical — defaults, resource shape, and output value are preserved verbatim. State migration (3 `./tf state mv`) ran locally; plan after move is back to baseline (3 idempotent Jobs + the unapplied PR #91 CM; zero destroy).

## What changed

- **`modules/buildkitd/main.tf`** — every resource extracted, full trust-model + `kubectl_manifest`-vs-`kubernetes_deployment_v1` rationale + image-choice header lives here. Resource names follow the `modules/platform-dash` convention (`this` for the primary resource of each kind).
- **`modules/buildkitd/variables.tf`** — every field previously keyed off `local.platform.services.buildkitd.*` becomes an explicit input with a description.
- **`modules/buildkitd/outputs.tf`** — `endpoint` (the in-cluster gRPC URL).
- **`modules/buildkitd/{README,CHANGELOG}.md`** — per AGENT.md module conventions.
- **`buildkitd.tf`** (root) — collapses from 193 lines to 33: header + module call + output re-export. Same shape as `github_runners.tf`.

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform validate` — Success
- [x] `./tf init` to install the new module — succeeded
- [x] State migrated locally:
  ```
  kubernetes_namespace_v1.buildkitd["enabled"] → module.buildkitd.kubernetes_namespace_v1.this["enabled"]
  kubectl_manifest.buildkitd["enabled"]        → module.buildkitd.kubectl_manifest.this["enabled"]
  kubernetes_service_v1.buildkitd["enabled"]   → module.buildkitd.kubernetes_service_v1.this["enabled"]
  ```
- [x] `./tf plan` after state-mv — `3 to add, 1 to change, 0 to destroy`. Same baseline as before this PR (idempotent Jobs + unapplied PR #91); **zero buildkitd diff**

## Context

Operator-prompted refactor — buildkitd was the only service breaking the modules-vs-root pattern. Lands the layout consistency that was deferred during the BuildKit debug saga.

🤖 Generated with [Claude Code](https://claude.com/claude-code)