### PR TITLE
feat(cloudflare): default tunnel-mode argocd_hostnames service to Traefik

### DIFF
--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -146,12 +146,16 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "main" {
           }
         }
       ],
-      # Argo CD-managed hostnames opted into the tunnel. Same shape
-      # as legacy entries above; backend always Traefik on `web`.
+      # Argo CD-managed hostnames opted into the tunnel. Backend
+      # defaults to the cluster Traefik (`web` entrypoint) — the
+      # standard path for any chart-managed IngressRoute. Operator
+      # can override per-entry via `service:` in the yaml when an
+      # Argo-managed app exposes a Service the tunnel should hit
+      # directly without going through Traefik.
       [
         for hostname, cfg in local.tunnel_argocd_hostnames : {
           hostname = hostname
-          service  = cfg.service
+          service  = try(cfg.service, "https://traefik.ingress-controller.svc:443")
           origin_request = {
             origin_server_name = hostname
             http2_origin       = false


### PR DESCRIPTION
## Summary

`argocd_hostnames` entries with `cf_tunnel: true` previously required the operator to spell out a `service:` URL in the domain yaml. In practice every chart-managed app's IngressRoute lands on the cluster Traefik (Traefik is the only thing fronting the cluster's ingress chain), so the URL was always the same boilerplate `https://traefik.ingress-controller.svc:443`.

Default the engine to that. Operators can still override per-entry via `service:` when an Argo-managed app exposes a Service the tunnel should hit directly, bypassing Traefik (rare, but keeps the door open).

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform validate` — Success
- [x] Existing tunnel-mode entries with explicit `service:` keep their override — `try(cfg.service, default)` preserves operator-supplied values
- [x] Existing direct-mode entries (`cf_tunnel: false`) are unaffected — they go through the `direct_argocd_hostnames` branch and never read `cfg.service`

## Context

Drops one trivially-derivable knob from the operator-yaml schema. Aligns with the engine philosophy of "sensible defaults that match every realistic case, override-only when atypical".

🤖 Generated with [Claude Code](https://claude.com/claude-code)