### PR TITLE
feat(project): use terraform-null-label for chart_oidc project / app naming

### DIFF
--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -980,14 +980,45 @@ check "zitadel_provider_authenticated_when_chart_oidc_used" {
   }
 }
 
+# Naming for chart_oidc_apps entries.
+#
+# The yaml key (e.g. `sipmesh-frontend-oidc`) is descriptive of the
+# Secret it produces (k8s Secret carrying `AUTH_ZITADEL_*`), but
+# defaulting the Zitadel project + app name to the same string
+# leaves operators reading the Zitadel UI unable to tell which
+# environment they're looking at — `sipmesh-frontend-oidc` could be
+# dev, prod, staging.
+#
+# Solution: route naming through `terraform-null-label` so the
+# Zitadel project + app name auto-include the env (`sipmesh-frontend
+# -dev`), while the k8s Secret name keeps the descriptive `-oidc`
+# suffix the chart's `envFrom` references. Operators can override
+# every output via explicit `project_name` / `app_name` /
+# `secret_name` fields per entry — `try(each.value.X, default)`
+# preserves the override-wins semantics.
+#
+# `trimsuffix(each.key, "-oidc")` strips the operator's descriptive
+# Secret-naming convention before composing the project / app id —
+# the engine's strong opinion is that yaml keys SHOULD end in
+# `-oidc` (matches what the pod's envFrom references) but the
+# Zitadel-side names SHOULD NOT (operators read those in the
+# Zitadel console where `-oidc` is just noise).
+module "chart_oidc_label" {
+  for_each = var.chart_oidc_apps
+
+  source     = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+  name       = trimsuffix(each.key, "-oidc")
+  attributes = [local.env]
+}
+
 module "chart_oidc" {
   for_each = var.chart_oidc_apps
 
   source = "../zitadel-app"
 
   org_id           = var.zitadel_org_id
-  project_name     = each.key
-  app_name         = try(each.value.app_name, each.key)
+  project_name     = try(each.value.project_name, module.chart_oidc_label[each.key].id)
+  app_name         = try(each.value.app_name, module.chart_oidc_label[each.key].id)
   issuer_url       = var.zitadel_issuer_url
   redirect_uris    = try(each.value.redirect_uris, [])
   post_logout_uris = try(each.value.post_logout_uris, [])
@@ -995,7 +1026,7 @@ module "chart_oidc" {
   roles            = try(each.value.roles, [])
 
   secret_namespace = kubernetes_namespace_v1.this.metadata[0].name
-  secret_name      = each.key
+  secret_name      = try(each.value.secret_name, each.key)
   secret_formats   = try(each.value.secret_formats, ["auth_js"])
 }
 


### PR DESCRIPTION
## Summary

Operator reviewing the Zitadel console couldn't tell which env a chart_oidc-managed project belonged to — the engine defaulted both `project_name` and `app_name` to the literal yaml key (`<X>-oidc`), which is useful as a k8s Secret name hint but uninformative as a Zitadel project name when multiple envs share a Zitadel instance.

Routes the naming through `terraform-null-label` (v0.1.0) so the Zitadel project + app id auto-include the env attribute, while the k8s Secret name keeps the descriptive `-oidc` suffix the chart's envFrom references.

## Engine wiring per chart_oidc_apps entry

| Output | Default | Override |
|---|---|---|
| `project_name` | `<key trim "-oidc">-<env>` (via null-label) | `each.value.project_name` |
| `app_name`     | `<key trim "-oidc">-<env>` (via null-label) | `each.value.app_name` |
| `secret_name`  | `<key>` (literal yaml key, descriptive)     | `each.value.secret_name` |

The trimsuffix logic enforces a soft convention: yaml keys SHOULD end in `-oidc` (matches the Secret name the chart's envFrom consumes), the Zitadel-side names strip it before composing the env-tagged id.

## First adoption of terraform-null-label in this repo

Pulled from `github.com/rromenskyi/terraform-null-label` at tag `v0.1.0`. The module is provider-less (pure local logic — composes ids from `namespace` / `environment` / `name` / `attributes` per `label_order`, supports chained `context`, optional `id_max_length` capping with hash-suffix), so it adds no provider dependency to the consuming module.

If the chart_oidc adoption lands cleanly, the same null-label can sweep through other naming sites (Postgres extra DB names, MinIO bucket consumers, …) in follow-ups.

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform init` — null-label fetched + indexed
- [x] `terraform validate` — Success
- [x] `terraform plan` — `3 to add, 2 to change, 0 to destroy`:
  - 3 always-created idempotent provisioner Jobs (baseline)
  - 2 `zitadel_project.this` name updates **in-place** (provider supports — `project_id`, `clientId`, roles, grants all preserved)
- [ ] Apply: zero pod restarts expected; downstream consumers (Auth.js / chart envFrom / Argo Dex) reference `clientId`, not project name

🤖 Generated with [Claude Code](https://claude.com/claude-code)