### PR TITLE
feat(project): route default tenant credential names through null-label

### DIFF
--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -262,12 +262,25 @@ locals {
     for _, c in local.normalized_components : try(c.ollama, false)
   ]) || try(var.shared_services.ollama, false)
 
-  db_name = replace(local.namespace, "-", "_")
-  db_user = replace(local.namespace, "-", "_")
+  # Routed through `terraform-null-label` (same module already adopted
+  # by chart_oidc + postgres extras) so naming rules are uniform across
+  # the engine. The output `module.label.id` is `<namespace>` with
+  # `_` delimiter (Postgres-identifier-safe) — exactly what the prior
+  # `replace(local.namespace, "-", "_")` produced. Visible names are
+  # unchanged for every existing tenant.
+  #
+  # `id_max_length = 63` is Postgres's `NAMEDATALEN - 1`. On overflow
+  # null-label truncates to cap-9 chars + delimiter + 8-char sha256
+  # suffix to keep uniqueness. Long namespaces no longer get silently
+  # truncated by Postgres itself.
+  db_name = module.pg_credentials_label.id
+  db_user = module.pg_credentials_label.id
 
-  # PostgreSQL naming rules match MySQL's here — same safe subset.
-  pg_database = replace(local.namespace, "-", "_")
-  pg_user     = replace(local.namespace, "-", "_")
+  # PostgreSQL default-DB naming uses the same identifier — DB and
+  # role names are equal here on purpose (the module is opinionated:
+  # one DB == one role per tenant for the legacy single-DB path).
+  pg_database = module.pg_credentials_label.id
+  pg_user     = module.pg_credentials_label.id
 
   # Redis ACL user names don't allow all characters. Namespace slugs
   # already fit the safe subset (lowercase + dash). Key prefix namespaces
@@ -275,6 +288,35 @@ locals {
   # tenant can never collide with another.
   redis_user       = local.namespace
   redis_key_prefix = "${local.namespace}:"
+}
+
+# `terraform-null-label` instance for the project's tenant-credential
+# identifiers (Postgres + MySQL DB / role names). Postgres-safe `_`
+# delimiter and length cap (`NAMEDATALEN - 1 = 63`) match what the
+# `pg_extra_label` adoption in PR #102 already does for the
+# `extra_databases` path; this brings the legacy single-DB path under
+# the same engine convention.
+#
+# `name = local.namespace` produces `id = "phost_<slug>_<env>"` after
+# the underscore delimiter — byte-for-byte identical to the prior
+# `replace(local.namespace, "-", "_")`. Plan diff is zero for any
+# existing tenant. The `tags` output is wired up here and ready for
+# downstream `metadata.labels` adoption — kept unconsumed in this PR
+# so the foundation lands cleanly first; the per-resource label sweep
+# is a follow-up PR.
+module "pg_credentials_label" {
+  source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+
+  namespace   = local.namespace
+  environment = local.env
+  # `replace(local.namespace, "-", "_")` because null-label's `delimiter`
+  # joins label components but does not transform character sets within
+  # a single component. The delimiter below would only matter when
+  # `label_order` had multiple entries.
+  name          = replace(local.namespace, "-", "_")
+  delimiter     = "_"
+  label_order   = ["name"]
+  id_max_length = 63
 }
 
 # Catch typos / missing component definitions at plan time.


### PR DESCRIPTION
## Summary

Third adoption of `terraform-null-label` after PR #101 (chart_oidc) and PR #102 (postgres extras). The legacy single-DB Postgres / MySQL credential identifiers (`pg_database` / `pg_user` / `db_name` / `db_user`) now flow through the label module instead of an inline `replace(local.namespace, "-", "_")`.

Visible names are **byte-for-byte identical** for every existing tenant — `terraform plan` shows zero project-module diff. Refactor is fully transparent.

## What lands

- New `module "pg_credentials_label"` instance in `modules/project`. Encodes namespace + env + name (the underscored namespace), Postgres-safe `_` delimiter, length cap 63 (Postgres `NAMEDATALEN - 1`).
- `local.pg_database` / `local.pg_user` / `local.db_name` / `local.db_user` resolve to `module.pg_credentials_label.id` instead of inline `replace(...)`.
- Redis ACL user / key prefix locals **unchanged** — Redis allows dashes in usernames so null-label here would be cosmetic-only with no overflow safety win.

## What's deliberately NOT in this PR

- Per-resource `metadata.labels` sweep using `module.pg_credentials_label.tags`. Tags are wired up at the module output level but not consumed by any resource yet. Foundation lands first; the resource-level label sweep is a follow-up so the diff stays trivially reviewable.

## Wins

- Engine code uniform across legacy + extras paths (both now via null-label).
- `id_max_length = 63` catches overflow with hash-suffix truncation instead of Postgres silently chopping the last chars off — long namespaces no longer surprise.

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform init` — null-label module cached
- [x] `terraform validate` — Success
- [x] `terraform plan` — `3 to add, 0 to change, 0 to destroy` (the three always-created idempotent provisioner Jobs only). Zero project-module churn for any of the 5 existing tenants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)