### PR TITLE
feat(label+scrub): platform_label keystone + pre-commit scrub framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,8 @@ tfplan
 .claude
 CLAUDE.md
 .backup-config.log
+
+# Pre-commit scrub list — operator-private regex patterns. Engine
+# ships `config/.scrub-list.example` template; the live file with
+# operator's actual tenant slugs / IPs / node names stays gitignored.
+config/.scrub-list

--- a/_label.tf
+++ b/_label.tf
@@ -1,0 +1,37 @@
+# Root null-label context.
+#
+# This is the keystone of every other label module instance in the
+# engine. Downstream labels (per-project, per-resource) chain off the
+# `context` output here so:
+#   - tags added at this layer propagate to every k8s resource the
+#     engine emits — operator can stamp `cost-center`, `region`,
+#     `commit-sha`, etc. once and have them land on every Pod /
+#     Service / Secret / IngressRoute on the cluster
+#   - new modules wire up label naming with one line
+#     (`context = var.context` + `module "X_label" { context =
+#     var.context }`); no need to re-spell namespace / environment
+#     / cluster_name in every module
+#   - the engine's identifier scheme stays uniform — same label
+#     module produces every name, same length-cap rules apply
+#     uniformly
+#
+# `namespace = "platform"` because the engine itself is the
+# "platform" tier. Tenant projects override `namespace` with their
+# own k8s namespace (`phost-<slug>-<env>`) when chaining; the
+# override wins per-key, parent fields the child doesn't override
+# inherit.
+#
+# `name = var.cluster_name` so a kubectl filter like
+# `kubectl get all -l app.kubernetes.io/instance=<cluster_name>`
+# narrows to a specific cluster when the operator runs more than
+# one (today: minikube vs k3s — tomorrow: per-region clusters).
+module "platform_label" {
+  source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+
+  namespace = "platform"
+  name      = var.cluster_name
+  tags = {
+    "app.kubernetes.io/managed-by" = "terraform"
+    "app.kubernetes.io/part-of"    = "terraform-minikube-platform"
+  }
+}

--- a/config/.scrub-list.example
+++ b/config/.scrub-list.example
@@ -1,0 +1,35 @@
+# Operator-private identifiers the pre-commit scrub check
+# (`tools/check-scrub.sh`) will refuse to commit. Copy to
+# `config/.scrub-list` (gitignored) and fill in the values that are
+# specific to YOUR setup — tenant slugs, app names, internal node
+# names, public IPs you own. The live file never lands in the public
+# repo; this `.example` ships only the format.
+#
+# Format:
+#   - one regex per line (extended POSIX, case-insensitive at match time)
+#   - `#` starts a comment
+#   - blank lines ignored
+#
+# Examples (delete and replace with your real values):
+
+# Tenant slugs / app names — never bake these into engine .tf, .md,
+# .example, or .gitignore. Engine stays generic; operator config
+# (gitignored) carries the real names.
+# my-app
+# my-tenant
+# acme-frontend
+
+# Internal node names visible only inside the operator's cluster.
+# bigbox
+# edge-node-7
+
+# Public IPs the operator owns. Listing them here keeps them out of
+# README diagrams, .tf comments, PR descriptions.
+# 203\.0\.113\.42
+# 198\.51\.100\.7
+
+# Subdomains that double as tenant identifiers (e.g. `<tenant>.dev` /
+# `<tenant>-staging`). Engine never spells these out; route maps in
+# gitignored domain yaml carry them.
+# my-app-dev
+# my-app-staging

--- a/main.tf
+++ b/main.tf
@@ -150,6 +150,14 @@ module "project" {
   default_limits   = local.default_limits
   volume_base_path = var.host_volume_path
 
+  # Serialised parent context from `terraform-null-label` (see
+  # `_label.tf`). The project module chains its own `project_label`
+  # off this context, and per-feature labels inside the module
+  # (chart_oidc, pg credentials, postgres extras, …) chain in turn
+  # off the project label. Tags accumulate down the tree; ids stay
+  # under per-module explicit control.
+  context = module.platform_label.context
+
   # Argo CD wiring — the project module emits an AppProject + one
   # bootstrap Application per `argocd_bootstraps:` entry in the domain
   # yaml, plus DNS+tunnel records per `argocd_hostnames:` entry. All

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -290,29 +290,49 @@ locals {
   redis_key_prefix = "${local.namespace}:"
 }
 
-# `terraform-null-label` instance for the project's tenant-credential
-# identifiers (Postgres + MySQL DB / role names). Postgres-safe `_`
-# delimiter and length cap (`NAMEDATALEN - 1 = 63`) match what the
-# `pg_extra_label` adoption in PR #102 already does for the
-# `extra_databases` path; this brings the legacy single-DB path under
-# the same engine convention.
+# Project-tier label — the keystone for every per-feature label
+# instance below. Chains off `var.context` (root passes
+# `module.platform_label.context` from `_label.tf`), so any tag the
+# operator adds at the platform tier propagates here and downstream.
 #
-# `name = local.namespace` produces `id = "phost_<slug>_<env>"` after
-# the underscore delimiter — byte-for-byte identical to the prior
-# `replace(local.namespace, "-", "_")`. Plan diff is zero for any
-# existing tenant. The `tags` output is wired up here and ready for
-# downstream `metadata.labels` adoption — kept unconsumed in this PR
-# so the foundation lands cleanly first; the per-resource label sweep
-# is a follow-up PR.
+# `namespace = local.namespace` overrides the inherited
+# `namespace = "platform"` from the root context — at this tier the
+# k8s namespace IS the tenant identifier. `environment = local.env`
+# specialises the inherited (empty) env. Other context fields
+# (operator-added tags) inherit unchanged.
+#
+# Per-feature labels below pass `context = module.project_label.context`
+# so they pick up the same tag set + can override only what they
+# specifically need (delimiter, label_order, length cap).
+module "project_label" {
+  source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+
+  context     = var.context
+  namespace   = local.namespace
+  environment = local.env
+  name        = local.namespace
+  tags = {
+    "domain" = local.domain
+  }
+}
+
+# Per-tenant Postgres / MySQL credential identifiers (DB + role
+# names). Postgres-safe `_` delimiter and length cap
+# (`NAMEDATALEN - 1 = 63`) match what `pg_extra_label` does for the
+# `extra_databases` path so legacy and extras paths produce
+# uniformly-shaped names.
+#
+# `replace(local.namespace, "-", "_")` is required because
+# null-label's `delimiter` joins label components but does not
+# transform character sets within a single component — the
+# delimiter only matters when `label_order` has multiple entries.
+# Output `id = "phost_<slug>_<env>"` is byte-for-byte identical to
+# the prior inline `replace(...)`. Plan diff is zero for any
+# existing tenant.
 module "pg_credentials_label" {
   source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
 
-  namespace   = local.namespace
-  environment = local.env
-  # `replace(local.namespace, "-", "_")` because null-label's `delimiter`
-  # joins label components but does not transform character sets within
-  # a single component. The delimiter below would only matter when
-  # `label_order` had multiple entries.
+  context       = module.project_label.context
   name          = replace(local.namespace, "-", "_")
   delimiter     = "_"
   label_order   = ["name"]
@@ -665,16 +685,15 @@ module "pg_extra_label" {
 
   source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
 
-  namespace     = replace(local.namespace, "-", "_") # "phost_<slug>_<env>"
+  context       = module.project_label.context
+  namespace     = replace(local.namespace, "-", "_") # "phost_<slug>_<env>" — overrides parent dashed form
   name          = each.key                           # the extra-database key
   delimiter     = "_"
   label_order   = ["namespace", "name"]
   id_max_length = 63
   tags = {
-    "app.kubernetes.io/managed-by" = "terraform"
-    "app.kubernetes.io/component"  = "postgres-extra-db"
-    "project-namespace"            = local.namespace
-    "extra-database"               = each.key
+    "app.kubernetes.io/component" = "postgres-extra-db"
+    "extra-database"              = each.key
   }
 }
 
@@ -1079,9 +1098,18 @@ check "zitadel_provider_authenticated_when_chart_oidc_used" {
 module "chart_oidc_label" {
   for_each = var.chart_oidc_apps
 
-  source     = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
-  name       = trimsuffix(each.key, "-oidc")
-  attributes = [local.env]
+  source  = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+  context = module.project_label.context
+  name    = trimsuffix(each.key, "-oidc")
+  # Explicit `label_order` shrinks the id to `<name>-<attributes>`
+  # so the Zitadel project name stays the operator's chosen
+  # `<key-without-oidc-suffix>-<env>` shape. Without this override
+  # the inherited default `["namespace", "environment", "name",
+  # "attributes"]` from `module.project_label.context` would prefix
+  # the id with the tenant namespace + env, renaming every existing
+  # Zitadel project — destructive.
+  label_order = ["name", "attributes"]
+  attributes  = [local.env]
 }
 
 module "chart_oidc" {

--- a/modules/project/variables.tf
+++ b/modules/project/variables.tf
@@ -1,3 +1,9 @@
+variable "context" {
+  description = "Serialised parent context from `terraform-null-label`. Caller passes `module.platform_label.context` from the root stack so this module can chain its own `project_label` off the platform-wide context — tags propagate down, ids stay under per-feature explicit control. Default `null` means the project module produces a label with no inherited context (still works, just doesn't carry the platform-tier tags)."
+  type        = string
+  default     = null
+}
+
 variable "project_config" {
   description = "Expanded project/env entry from locals.projects"
   type        = any

--- a/tools/check-scrub.sh
+++ b/tools/check-scrub.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Pre-commit scrub check — guards committed engine code, docs, and
+# `.example` files against operator-private identifiers (tenant slugs,
+# app names, internal node names, public IPs the operator owns).
+#
+# The engine itself stays generic; the operator-private list lives
+# OUTSIDE the repo at `config/.scrub-list` (gitignored). This script
+# is the engine's framework — it knows HOW to check, the gitignored
+# list knows WHAT to flag. Same separation the rest of `config/`
+# follows (engine ships `.example` templates, operator's live values
+# are gitignored).
+#
+# Format of `config/.scrub-list`:
+#   - one regex per line (extended POSIX)
+#   - lines starting with `#` are comments
+#   - blank lines ignored
+#   - patterns are case-insensitive
+#
+# Exit:
+#   0 — no matches OR scrub-list missing (gitignored, operator opt-in)
+#   1 — at least one match found (offending lines printed)
+#
+# Wiring as a pre-commit hook:
+#   ln -s ../../tools/check-scrub.sh .git/hooks/pre-commit
+#   # or for `pre-commit` framework, add a `local` repo hook pointing here
+#
+# Manual invocation (run-as-needed without commit gate):
+#   ./tools/check-scrub.sh
+
+set -euo pipefail
+
+SCRUB_LIST="${SCRUB_LIST:-config/.scrub-list}"
+
+if [ ! -f "$SCRUB_LIST" ]; then
+  # Operator hasn't opted in yet — silently pass. Print a hint only
+  # when run interactively (no STDIN piped from a hook).
+  if [ -t 0 ]; then
+    echo "scrub: $SCRUB_LIST not found — operator opt-in. See" \
+         "config/.scrub-list.example for the format." >&2
+  fi
+  exit 0
+fi
+
+# Build the alternation regex from non-comment / non-blank lines.
+PATTERN="$(grep -vE '^\s*(#|$)' "$SCRUB_LIST" | paste -sd '|' -)"
+
+if [ -z "$PATTERN" ]; then
+  exit 0
+fi
+
+# Filter to staged-but-not-yet-committed changes when run as a
+# pre-commit hook; fall back to the full working-tree diff when
+# invoked manually with no staged changes.
+DIFF_ARGS="--cached"
+if [ -z "$(git diff --cached --name-only)" ]; then
+  DIFF_ARGS=""
+fi
+
+# Limit scrub to file types where leaks have actually bitten before:
+# .tf (engine code + comments), .md (READMEs, PR-body templates,
+# CHANGELOGs), .example (committed schema templates), .gitignore
+# (the `config/components/<tenant>.yaml` shape), shell scripts under
+# tools/.
+PATHS=(
+  '*.tf'
+  '*.md'
+  '*.example'
+  '.gitignore'
+  'tools/*.sh'
+)
+
+# `git diff` exits 0 when there are no changes; capture it without
+# tripping `set -e` and let the grep determine the final exit.
+ADDED_LINES="$(git diff $DIFF_ARGS -- "${PATHS[@]}" 2>/dev/null \
+                | grep -E '^\+' \
+                | grep -vE '^\+\+\+' || true)"
+
+if [ -z "$ADDED_LINES" ]; then
+  exit 0
+fi
+
+MATCHES="$(printf '%s\n' "$ADDED_LINES" | grep -iE -- "$PATTERN" || true)"
+
+if [ -z "$MATCHES" ]; then
+  exit 0
+fi
+
+cat >&2 <<EOF
+scrub: operator-private identifiers detected in staged diff
+─────────────────────────────────────────────────────────
+The patterns in \`$SCRUB_LIST\` matched lines being committed.
+Either scrub them out (use generic placeholders like
+\`<tenant>\`, \`<env>\`, \`<key>-<env>\`, \`example.com\`) or
+update the scrub list if a pattern is too aggressive.
+
+Offending lines:
+EOF
+printf '%s\n' "$MATCHES" >&2
+exit 1


### PR DESCRIPTION
## Summary

Two related foundations in one PR.

### 1. `platform_label` keystone (Phase 1 of null-label adoption)

Establishes the parent null-label context every per-feature label chains off:

```
root: module "platform_label"               (in _label.tf)
    │ context →
modules/project: module "project_label"     (chains via var.context)
    │ context →
per-feature labels: pg_credentials_label,
                   pg_extra_label[*],
                   chart_oidc_label[*]
                                             (chain via project_label.context)
```

**Phase 1 = foundation only.** No resource-level `metadata.labels` consumption yet — the per-resource label sweep is a follow-up so this PR's diff stays trivially reviewable.

Per-feature labels keep their explicit overrides (`label_order`, `namespace`, `name`, `delimiter`) so their `.id` outputs are **byte-for-byte unchanged**. `chart_oidc_label` specifically pins `label_order = ["name", "attributes"]` to prevent the inherited default from prefixing the Zitadel project name with the tenant ns + env (would have triggered destructive renames).

### 2. Pre-commit scrub framework

Generic pre-commit scrub check at `tools/check-scrub.sh`.

| Layer | What it owns | Where it lives |
|---|---|---|
| **Engine** | Framework: knows HOW to grep `git diff --cached` against patterns | `tools/check-scrub.sh` (committed), `config/.scrub-list.example` (committed) |
| **Operator** | Inventory: WHAT patterns to flag — tenant slugs, app names, internal node names, public IPs | `config/.scrub-list` (gitignored) |

Same separation the rest of `config/` already follows: engine ships `.example` template, operator's live values stay gitignored. Engine never names a tenant.

The script silently passes when the scrub list is absent (operator opt-in). Operator wires it as a real pre-commit hook with:

```bash
ln -s ../../tools/check-scrub.sh .git/hooks/pre-commit
```

Or invokes manually as a sanity check:

```bash
./tools/check-scrub.sh
```

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform validate` — Success
- [x] `terraform plan` — `3 to add, 0 to change, 0 to destroy, 0 to replace` (three always-created idempotent provisioner Jobs only); zero project-module churn for any of the 5 existing tenants; per-feature label `.id` outputs preserved exactly
- [x] `tools/check-scrub.sh` self-check — script's own diff scrubbed against a synthetic pattern list, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)