### PR TITLE
feat(project): consume project_label tags into k8s resource metadata.labels

### DIFF
--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -399,11 +399,11 @@ check "oauth2_proxy_available_when_zitadel_auth_used" {
 resource "kubernetes_namespace_v1" "this" {
   metadata {
     name = local.namespace
-    labels = {
+    labels = merge(module.project_label.tags, {
       "app.kubernetes.io/managed-by" = "terraform"
       "project"                      = local.domain
       "environment"                  = local.env
-    }
+    })
   }
 }
 
@@ -413,6 +413,7 @@ resource "kubernetes_resource_quota_v1" "limits" {
   metadata {
     name      = "limits"
     namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels    = module.project_label.tags
   }
 
   spec {
@@ -445,10 +446,10 @@ resource "kubernetes_job_v1" "mysql_setup" {
   metadata {
     name      = "db-setup-${local.namespace}"
     namespace = var.mysql_namespace
-    labels = {
+    labels = merge(module.project_label.tags, {
       "app.kubernetes.io/managed-by" = "terraform"
       "project-namespace"            = local.namespace
-    }
+    })
   }
 
   spec {
@@ -520,6 +521,7 @@ resource "kubernetes_secret_v1" "db_credentials" {
   metadata {
     name      = "db-credentials"
     namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels    = module.project_label.tags
   }
 
   data = {
@@ -551,10 +553,10 @@ resource "kubernetes_job_v1" "postgres_setup" {
   metadata {
     name      = "postgres-setup-${local.namespace}"
     namespace = var.postgres_namespace
-    labels = {
+    labels = merge(module.project_label.tags, {
       "app.kubernetes.io/managed-by" = "terraform"
       "project-namespace"            = local.namespace
-    }
+    })
   }
 
   spec {
@@ -633,6 +635,7 @@ resource "kubernetes_secret_v1" "postgres_credentials" {
   metadata {
     name      = "postgres-credentials"
     namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels    = module.project_label.tags
   }
 
   data = {
@@ -828,10 +831,10 @@ resource "kubernetes_job_v1" "redis_setup" {
     # the Job — historic flake source documented 2026-05-09.
     name      = "redis-setup-${local.namespace}-rev${var.redis_helm_revision}"
     namespace = var.redis_namespace
-    labels = {
+    labels = merge(module.project_label.tags, {
       "app.kubernetes.io/managed-by" = "terraform"
       "project-namespace"            = local.namespace
-    }
+    })
   }
 
   spec {
@@ -937,6 +940,7 @@ resource "kubernetes_secret_v1" "redis_credentials" {
   metadata {
     name      = "redis-credentials"
     namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels    = module.project_label.tags
   }
 
   data = {
@@ -962,6 +966,7 @@ resource "kubernetes_secret_v1" "ollama_endpoint" {
   metadata {
     name      = "ollama-endpoint"
     namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels    = module.project_label.tags
   }
 
   # Different Ollama clients read different env names: the official
@@ -1026,10 +1031,10 @@ resource "kubernetes_secret_v1" "operator_secret" {
   metadata {
     name      = each.key
     namespace = kubernetes_namespace_v1.this.metadata[0].name
-    labels = {
+    labels = merge(module.project_label.tags, {
       "app.kubernetes.io/managed-by" = "terraform"
       "app.kubernetes.io/part-of"    = local.namespace
-    }
+    })
   }
 
   data = (
@@ -1340,6 +1345,7 @@ resource "kubernetes_secret_v1" "basic_auth" {
   metadata {
     name      = "${each.key}-basic-auth"
     namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels    = module.project_label.tags
   }
 
   data = {
@@ -1398,6 +1404,7 @@ resource "kubernetes_secret_v1" "env_random" {
   metadata {
     name      = "${each.key}-random-env"
     namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels    = module.project_label.tags
   }
 
   data = {


### PR DESCRIPTION
## Summary

Phase 2 of null-label adoption. Wires `module.project_label.tags` (established as foundation in PR #104) into the `metadata.labels` of every `kubernetes_*` resource the project module emits. Tags merge on top of existing per-resource labels with **existing values winning on key collision** (preserves any operator-side / chart-side labels that other machinery may already filter on).

## Touched

12 resource definitions, ~37 instance updates across 5 tenants.

| Pattern | Resources |
| --- | --- |
| Add `labels = module.project_label.tags` (no existing block) | `kubernetes_resource_quota_v1.limits`, `kubernetes_secret_v1.{db_credentials,postgres_credentials,redis_credentials,ollama_endpoint,basic_auth,env_random}` |
| `merge(label.tags, existing)` (had ad-hoc labels) | `kubernetes_namespace_v1.this`, `kubernetes_job_v1.{mysql,postgres,redis}_setup`, `kubernetes_secret_v1.operator_secret` |

Already labelled via per-feature labels — unchanged:
- `postgres_setup_extra` / `postgres_credentials_extra` use `module.pg_extra_label[each.key].tags` (which chains off `module.project_label.context`, so propagation works via the chain).

## Out of scope (different idiom, separate follow-up PR)

- `kubectl_manifest.basic_auth_middleware` — labels live inside `yaml_body` (Traefik Middleware CRD); needs `yamlencode`-side edit.
- `kubectl_manifest.argocd_app_project` / `argocd_bootstrap` — same shape.
- `kubectl_manifest.ingressroute` — same.

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform validate` — Success
- [x] `terraform plan` — `3 to add, 37 to change, 1 to destroy`:
  - 37 `update in-place` (label additions, no destruction)
  - 1 destroy/replace = `module.minio.kubernetes_job_v1.buckets` (always-recreated baseline idempotent Job, unrelated to this PR)
  - 3 adds = standard idempotent provisioner Jobs
- [x] Pre-commit scrub check — clean (synthetic pattern list of current tenant slugs, exit 0)
- [ ] Apply impact: 37 in-place `metadata.labels` merges; no pod restarts, no Service downtime, no destruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)