### PR TITLE
feat(project): consume project_label tags into kubectl_manifest CRD labels

### DIFF
--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -1368,6 +1368,7 @@ resource "kubectl_manifest" "basic_auth_middleware" {
     metadata = {
       name      = "${each.key}-basic-auth"
       namespace = local.namespace
+      labels    = module.project_label.tags
     }
     spec = {
       basicAuth = {
@@ -1470,10 +1471,10 @@ resource "kubectl_manifest" "argocd_app_project" {
     metadata = {
       name      = local.namespace
       namespace = var.argocd_namespace
-      labels = {
+      labels = merge(module.project_label.tags, {
         "app.kubernetes.io/managed-by" = "terraform"
         "platform.tenant"              = local.namespace
-      }
+      })
     }
     spec = {
       description = "Auto-managed AppProject for TF project ${local.namespace}. Pins Application destinations to this namespace and source repos to every operator deploy repo declared under `argocd_bootstraps:`."
@@ -1527,12 +1528,12 @@ resource "kubectl_manifest" "argocd_bootstrap" {
       finalizers = [
         "resources-finalizer.argocd.argoproj.io",
       ]
-      labels = {
+      labels = merge(module.project_label.tags, {
         "app.kubernetes.io/managed-by" = "terraform"
         "platform.tenant"              = local.namespace
         "platform.role"                = "bootstrap"
         "platform.bootstrap.key"       = each.key
-      }
+      })
     }
     spec = {
       project = local.namespace
@@ -1596,6 +1597,7 @@ resource "kubectl_manifest" "ingressroute" {
     metadata = {
       name      = each.key
       namespace = local.namespace
+      labels    = module.project_label.tags
     }
     spec = merge(
       {


### PR DESCRIPTION
## Summary

Phase 2 follow-up — extends the `module.project_label.tags` adoption from PR #105 (`kubernetes_*` resources) to the four `kubectl_manifest` CRD resources. Same `merge(label.tags, existing)` with-existing-wins pattern, just inside `yaml_body = yamlencode({...})` instead of a direct `metadata { labels = {...} }` block.

## Touched

4 resource definitions, 20 instance updates across 5 tenants.

| Pattern | Resources |
|---|---|
| Add `labels = module.project_label.tags` (no existing block) | `kubectl_manifest.basic_auth_middleware`, `kubectl_manifest.ingressroute` |
| `merge(label.tags, existing)` (had ad-hoc labels) | `kubectl_manifest.argocd_app_project`, `kubectl_manifest.argocd_bootstrap` |

## Coverage achieved after this PR

Every project-emitted k8s resource — `kubernetes_*` AND `kubectl_manifest` — carries the propagated null-label tag set.

```bash
kubectl get \
  ns,resourcequota,secret,job,middleware.traefik.io,ingressroute.traefik.io,appproject.argoproj.io,application.argoproj.io \
  -A -l 'app.kubernetes.io/part-of=terraform-minikube-platform'
```

— picks up every engine-managed object across the cluster, including Traefik Middlewares, IngressRoutes, ArgoCD AppProjects, and Applications.

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform validate` — Success
- [x] `terraform plan` — `1 to add, 20 to change, 1 to destroy`:
  - 20 `update in-place` (label additions inside `yaml_body`; gavinbunney/kubectl provider handles CRD labels in-place)
  - 1 destroy/replace = `module.minio.kubernetes_job_v1.buckets` (baseline idempotent Job, unrelated to this PR)
  - 1 add = baseline idempotent provisioner Job
- [x] Pre-commit scrub check — clean
- [ ] Apply impact: 20 in-place CRD label-merges; no resource recreation

🤖 Generated with [Claude Code](https://claude.com/claude-code)