### PR TITLE
feat(buildkitd): adopt null-label context + tag sweep

### DIFF
--- a/buildkitd.tf
+++ b/buildkitd.tf
@@ -9,6 +9,7 @@
 module "buildkitd" {
   source = "./modules/buildkitd"
 
+  context        = module.platform_label.context
   enabled        = local.platform.services.buildkitd.enabled
   image_tag      = local.platform.services.buildkitd.image_tag
   host_path      = local.platform.services.buildkitd.host_path

--- a/modules/buildkitd/main.tf
+++ b/modules/buildkitd/main.tf
@@ -58,12 +58,28 @@ locals {
   instances = var.enabled ? toset(["enabled"]) : toset([])
 }
 
+# Module-tier label, chained off `var.context` (root passes
+# `module.platform_label.context` from `_label.tf`). Tags propagate
+# down — operator-stamped tags at the platform tier land on every
+# resource this module emits via `module.label.tags` in
+# `metadata.labels`.
+module "label" {
+  source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+
+  context   = var.context
+  namespace = var.namespace
+  name      = "buildkitd"
+  tags = {
+    "app.kubernetes.io/component" = "buildkitd"
+  }
+}
+
 resource "kubernetes_namespace_v1" "this" {
   for_each = local.instances
 
   metadata {
     name = var.namespace
-    labels = {
+    labels = merge(module.label.tags, {
       "app.kubernetes.io/managed-by" = "terraform"
       "app.kubernetes.io/component"  = "buildkitd"
       # Privileged because the container sets `privileged: true`.
@@ -71,7 +87,7 @@ resource "kubernetes_namespace_v1" "this" {
       # (kernel userns remapping), not by PSA — see file header
       # for the trust model.
       "pod-security.kubernetes.io/enforce" = "privileged"
-    }
+    })
   }
 }
 
@@ -84,10 +100,10 @@ resource "kubectl_manifest" "this" {
     metadata = {
       name      = "buildkitd"
       namespace = kubernetes_namespace_v1.this["enabled"].metadata[0].name
-      labels = {
+      labels = merge(module.label.tags, {
         "app.kubernetes.io/name"      = "buildkitd"
         "app.kubernetes.io/component" = "buildkitd"
-      }
+      })
     }
     spec = {
       # Single replica — one shared cache. Scaling out fragments
@@ -175,10 +191,10 @@ resource "kubernetes_service_v1" "this" {
   metadata {
     name      = "buildkitd"
     namespace = kubernetes_namespace_v1.this["enabled"].metadata[0].name
-    labels = {
+    labels = merge(module.label.tags, {
       "app.kubernetes.io/name"      = "buildkitd"
       "app.kubernetes.io/component" = "buildkitd"
-    }
+    })
   }
 
   spec {

--- a/modules/buildkitd/variables.tf
+++ b/modules/buildkitd/variables.tf
@@ -1,3 +1,9 @@
+variable "context" {
+  description = "Serialised parent context from `terraform-null-label`. Caller passes `module.platform_label.context` from the root stack so this module can chain its own label off the platform-wide context — tags propagate down, keeping every k8s resource the module emits consistent with the rest of the engine. Default `null` means the module produces a label with no inherited context (still works, just doesn't carry the platform-tier tags)."
+  type        = string
+  default     = null
+}
+
 variable "enabled" {
   description = "Whether to install the buildkitd Pod + Service. False collapses every resource to zero — namespace, kubectl_manifest Deployment, and ClusterIP all disappear, and the `endpoint` output resolves to an empty string."
   type        = bool


### PR DESCRIPTION
## Summary

Mirrors the `modules/project` null-label adoption (PR #104 foundation + PR #105/#106 tag sweep) for the `modules/buildkitd` module.

## Engine-side change

- `modules/buildkitd/variables.tf` — new `var.context` input (caller passes `module.platform_label.context`)
- `modules/buildkitd/main.tf`:
  - `module "label"` instance, chained off `var.context`, named `buildkitd`, plus `app.kubernetes.io/component = buildkitd` tag
  - `merge(module.label.tags, <existing>)` on every emitted k8s resource's `metadata.labels`:
    - `kubernetes_namespace_v1.this`
    - `kubectl_manifest.this` (Deployment via yaml_body)
    - `kubernetes_service_v1.this`

## Root wiring

`buildkitd.tf` — passes `context = module.platform_label.context` to the module call.

## After this PR

The buildkitd Pod / Service / namespace carry the propagated null-label tag set (`app.kubernetes.io/part-of=terraform-minikube-platform`, `name=buildkitd`, `namespace=arc-buildkitd`, plus the platform_label root tags). Filters like `kubectl get all -A -l 'app.kubernetes.io/component=buildkitd'` or `... -l 'app.kubernetes.io/part-of=terraform-minikube-platform'` pick it up consistently with every other engine-managed resource.

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform init` — null-label module cached (already from PR #101 adoption)
- [x] `terraform validate` — Success
- [x] `terraform plan` — `3 to add, 3 to change, 1 to destroy`:
  - 3 in-place `metadata.labels` merges on buildkitd's namespace + Deployment + Service
  - 1 destroy/replace = baseline `module.minio.kubernetes_job_v1.buckets` idempotent Job (unrelated)
  - 3 adds = baseline idempotent provisioner Jobs (unrelated)
- [x] Pre-commit scrub — clean
- [ ] Apply impact: 3 in-place metadata.labels merges; no pod restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)