### PR TITLE
feat(platform-dash): adopt null-label context + tag sweep

### DIFF
--- a/modules/platform-dash/main.tf
+++ b/modules/platform-dash/main.tf
@@ -41,10 +41,29 @@ locals {
   cluster_role   = "${var.namespace}-${local.app_name}"
   port_container = 3000
   port_service   = 80
-  labels = {
+  # The local labels block is consumed by every k8s resource this
+  # module emits AND by the Deployment's pod-template selector.
+  # `merge(module.label.tags, <existing>)` adds the propagated
+  # null-label tag set with existing keys winning on collision —
+  # `app.kubernetes.io/name` (the Service selector key) and
+  # `app.kubernetes.io/managed-by` are explicitly preserved.
+  labels = merge(module.label.tags, {
     "app.kubernetes.io/name"       = local.app_name
     "app.kubernetes.io/managed-by" = "terraform"
     "app.kubernetes.io/part-of"    = "platform"
+  })
+}
+
+# Module-tier label, chained off `var.context` (root passes
+# `module.platform_label.context` from `_label.tf`).
+module "label" {
+  source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+
+  context   = var.context
+  namespace = var.namespace
+  name      = local.app_name
+  tags = {
+    "app.kubernetes.io/component" = "platform-dash"
   }
 }
 

--- a/modules/platform-dash/variables.tf
+++ b/modules/platform-dash/variables.tf
@@ -1,3 +1,9 @@
+variable "context" {
+  description = "Serialised parent context from `terraform-null-label`. Caller passes `module.platform_label.context` from the root stack so this module can chain its own label off the platform-wide context — tags propagate down, keeping every k8s resource the module emits consistent with the rest of the engine. Default `null` means the module produces a label with no inherited context."
+  type        = string
+  default     = null
+}
+
 variable "enabled" {
   description = "Whether to deploy the dashboard. Off → all resources count = 0."
   type        = bool

--- a/platform_dash.tf
+++ b/platform_dash.tf
@@ -99,6 +99,7 @@ module "platform_dash" {
   source     = "./modules/platform-dash"
   depends_on = [module.platform_dash_oidc]
 
+  context              = module.platform_label.context
   enabled              = local.platform.services.platform_dash.enabled
   namespace            = kubernetes_namespace_v1.platform.metadata[0].name
   image                = local.platform.services.platform_dash.image


### PR DESCRIPTION
## Summary

Mirrors the buildkitd null-label adoption (PR #107) for the `platform-dash` module. Same shape: `var.context` input, `module "label"` chained off it, downstream resources inherit the propagated tag set.

The platform-dash module conveniently centralised label generation through a single `local.labels` block consumed by all five resources (ServiceAccount, ClusterRole, ClusterRoleBinding, Deployment, Service) plus the Deployment's pod-template metadata. That made adoption a one-line change to the local — every consumer inherits the merged tag set automatically.

## Engine-side change

- `modules/platform-dash/variables.tf` — new `var.context` input (caller passes `module.platform_label.context`)
- `modules/platform-dash/main.tf`:
  - `module "label"` instance, named `platform-dash`, chained off `var.context`, plus `app.kubernetes.io/component = platform-dash` tag
  - `local.labels` wraps existing keys with `merge(module.label.tags, {…})` — existing-wins on key collision so the Service selector key `app.kubernetes.io/name` stays exactly as it was; Deployment pod-template selector match still resolves

## Root wiring

- `platform_dash.tf` — passes `context = module.platform_label.context`

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform init` — null-label cached
- [x] `terraform validate` — Success
- [x] `terraform plan` — 5 in-place `metadata.labels` merges on platform-dash's SA / ClusterRole / ClusterRoleBinding / Deployment / Service. **Zero destroy, zero replace.**
- [x] Pre-commit scrub — clean
- [ ] Apply impact: 5 in-place metadata.labels merges; no pod restart, no Service downtime. Service `selector` is unchanged (`app.kubernetes.io/name=platform-dash`); Deployment pod-template still carries that key

🤖 Generated with [Claude Code](https://claude.com/claude-code)