### PR TITLE
fix(platform-dash): drop redundant local labels, let root tags propagate cleanly

### DIFF
--- a/modules/platform-dash/main.tf
+++ b/modules/platform-dash/main.tf
@@ -41,16 +41,26 @@ locals {
   cluster_role   = "${var.namespace}-${local.app_name}"
   port_container = 3000
   port_service   = 80
-  # The local labels block is consumed by every k8s resource this
-  # module emits AND by the Deployment's pod-template selector.
-  # `merge(module.label.tags, <existing>)` adds the propagated
-  # null-label tag set with existing keys winning on collision —
-  # `app.kubernetes.io/name` (the Service selector key) and
-  # `app.kubernetes.io/managed-by` are explicitly preserved.
+  # Local labels merged with the propagated null-label tag set
+  # (root → platform_label → module.label). Local-side hardcoding is
+  # kept ONLY for keys that null-label doesn't naturally cover or
+  # whose value is module-specific:
+  #   - `app.kubernetes.io/name` = the in-cluster name of THIS app
+  #     (k8s convention; null-label uses the bare `name` key, a
+  #     different label namespace, so both coexist intentionally —
+  #     the Service selector binds on `app.kubernetes.io/name`, the
+  #     null-label `name` is for cross-tier filtering)
+  #
+  # Removed (now sourced from `module.platform_label.tags`):
+  #   - `app.kubernetes.io/managed-by` — root tag, never varies
+  #   - `app.kubernetes.io/part-of`    — root tag set to
+  #     `terraform-minikube-platform` so a single
+  #     `kubectl … -l 'app.kubernetes.io/part-of=terraform-minikube-platform'`
+  #     filter catches every engine-managed resource. Previously
+  #     hardcoded to `platform` here, which broke the unified
+  #     filter for this module.
   labels = merge(module.label.tags, {
-    "app.kubernetes.io/name"       = local.app_name
-    "app.kubernetes.io/managed-by" = "terraform"
-    "app.kubernetes.io/part-of"    = "platform"
+    "app.kubernetes.io/name" = local.app_name
   })
 }
 


### PR DESCRIPTION
## Summary

After PR #108 wired `module.platform_label.context` through to platform-dash, the local `labels` block kept hardcoding `app.kubernetes.io/managed-by` and `app.kubernetes.io/part-of` from the pre-null-label era. With merge order `merge(module.label.tags, <existing>)` the existing-wins semantics caused those local hardcodes to override the propagated root tags — specifically, `app.kubernetes.io/part-of: platform` survived instead of letting the root-propagated `terraform-minikube-platform` flow through.

**Net effect**: `kubectl get … -l 'app.kubernetes.io/part-of=terraform-minikube-platform'` did NOT find the platform-dash resources, even though every other engine-managed resource on the cluster was discoverable that way.

## Why "drop the redundancy" is the right shape (vs swap merge order)

- **Don't swap merge order** — would silently overwrite legitimate local-specific values elsewhere in the engine on future similar adoptions.
- **Don't add a special-case exception** — extra knob without a reason.
- **Drop the redundant hardcodes** — the local labels block now keeps only the keys it has a module-specific reason to set. Propagation happens naturally; null-label is the single source of truth for cross-tier tags.

## After

The local `labels` block keeps only:

```hcl
labels = merge(module.label.tags, {
  "app.kubernetes.io/name" = local.app_name
})
```

`app.kubernetes.io/name` is the chart-app convention key the Service selector binds on — distinct from null-label's bare `name` (different label namespace; both intentionally coexist).

Removed (now sourced from `module.platform_label.tags`):
- `app.kubernetes.io/managed-by` — root tag, never varies
- `app.kubernetes.io/part-of` — root tag set to `terraform-minikube-platform`

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform validate` — Success
- [x] `terraform plan` — 5 in-place `metadata.labels` updates on platform-dash's SA / ClusterRole / ClusterRoleBinding / Deployment / Service. **Zero destroy, zero replace.**
- [x] Pre-commit scrub — clean
- [ ] After apply: single `kubectl … -l 'app.kubernetes.io/part-of=terraform-minikube-platform'` filter catches the full engine fleet (was leaking platform-dash before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)