### PR TITLE
feat(oauth2-proxy): adopt null-label context + tag sweep

### DIFF
--- a/modules/oauth2-proxy/main.tf
+++ b/modules/oauth2-proxy/main.tf
@@ -36,6 +36,28 @@ locals {
 
   # Stable resource name; used for Service, Deployment, Secret, Middleware.
   app_name = "forward-auth"
+
+  # Local labels merged with the propagated null-label tag set
+  # (root → platform_label → module.label). Local-side keeps only
+  # `app = local.app_name` because the Service / Deployment selectors
+  # bind on that key — null-label uses different keys (`name`,
+  # `namespace`) so both intentionally coexist.
+  labels = merge(module.label.tags, {
+    app = local.app_name
+  })
+}
+
+# Module-tier label, chained off `var.context` (root passes
+# `module.platform_label.context` from `_label.tf`).
+module "label" {
+  source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+
+  context   = var.context
+  namespace = var.namespace
+  name      = local.app_name
+  tags = {
+    "app.kubernetes.io/component" = "oauth2-proxy"
+  }
 }
 
 # ── Zitadel project + application ─────────────────────────────────────────────
@@ -102,6 +124,7 @@ resource "kubernetes_secret_v1" "oauth2_proxy" {
   metadata {
     name      = local.app_name
     namespace = var.namespace
+    labels    = local.labels
   }
 
   data = {
@@ -119,7 +142,7 @@ resource "kubernetes_deployment_v1" "oauth2_proxy" {
   metadata {
     name      = local.app_name
     namespace = var.namespace
-    labels    = { app = local.app_name }
+    labels    = local.labels
   }
 
   spec {
@@ -131,7 +154,7 @@ resource "kubernetes_deployment_v1" "oauth2_proxy" {
 
     template {
       metadata {
-        labels = { app = local.app_name }
+        labels = local.labels
       }
 
       spec {
@@ -234,7 +257,7 @@ resource "kubernetes_service_v1" "oauth2_proxy" {
   metadata {
     name      = local.app_name
     namespace = var.namespace
-    labels    = { app = local.app_name }
+    labels    = local.labels
   }
 
   spec {
@@ -286,6 +309,7 @@ resource "kubectl_manifest" "middleware_proto" {
     metadata = {
       name      = "force-https-proto"
       namespace = var.namespace
+      labels    = local.labels
     }
     spec = {
       headers = {
@@ -306,6 +330,7 @@ resource "kubectl_manifest" "middleware_forward" {
     metadata = {
       name      = "zitadel-auth"
       namespace = var.namespace
+      labels    = local.labels
     }
     spec = {
       forwardAuth = {

--- a/modules/oauth2-proxy/variables.tf
+++ b/modules/oauth2-proxy/variables.tf
@@ -1,3 +1,9 @@
+variable "context" {
+  description = "Serialised parent context from `terraform-null-label`. Caller passes `module.platform_label.context` from the root stack so this module can chain its own label off the platform-wide context — tags propagate down, keeping every k8s resource the module emits consistent with the rest of the engine. Default `null` means the module produces a label with no inherited context."
+  type        = string
+  default     = null
+}
+
 variable "enabled" {
   description = "Deploy the auth gate. Should be tied to `services.zitadel.enabled` at the root — this module needs Zitadel as the OIDC provider."
   type        = bool

--- a/oauth2_proxy.tf
+++ b/oauth2_proxy.tf
@@ -40,6 +40,7 @@ module "oauth2_proxy" {
   # any plan that touched module.zitadel) is no longer needed.
   depends_on = [module.addons]
 
+  context                        = module.platform_label.context
   enabled                        = local.platform.services.zitadel.enabled
   namespace                      = "ingress-controller"
   zitadel_provider_authenticated = var.zitadel_pat != ""


### PR DESCRIPTION
## Summary

Mirrors the buildkitd / platform-dash null-label adoptions (PR #107 / #108) for the `modules/oauth2-proxy` module.

## Engine-side change

- `modules/oauth2-proxy/variables.tf` — new `var.context` input
- `modules/oauth2-proxy/main.tf`:
  - `module "label"` instance, named `forward-auth`, chained off `var.context`, plus `app.kubernetes.io/component = oauth2-proxy` tag
  - `local.labels = merge(module.label.tags, { app = local.app_name })` keeps the existing-wins safety on the `app` key (Service / Deployment selectors bind on it; null-label uses different keys so no collision)
  - All 5 emitted resources now apply `local.labels` to their `metadata.labels`: Secret, Deployment, Service, two Traefik Middlewares (`force-https-proto`, `zitadel-auth`)

## Root wiring

`oauth2_proxy.tf` — passes `context = module.platform_label.context`.

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform validate` — Success
- [x] `terraform plan` — 5 in-place metadata.labels merges (Secret + Deployment + Service + 2 Middleware). **Zero destroy, zero replace.**
- [x] Pre-commit scrub — clean
- [ ] Apply impact: 5 in-place metadata.labels merges; no pod restart, no Service downtime, Service+Deployment selectors bind on the unchanged `app=forward-auth` key

🤖 Generated with [Claude Code](https://claude.com/claude-code)