### PR TITLE
feat(backup): adopt null-label context + tag sweep

### DIFF
--- a/backup.tf
+++ b/backup.tf
@@ -188,6 +188,7 @@ data "kubernetes_secret_v1" "vault_bootstrap" {
 module "backup" {
   source = "./modules/backup"
 
+  context = module.platform_label.context
   enabled = local.platform.services.backup.enabled
 
   b2_bucket            = var.backup_b2_bucket

--- a/modules/backup/main.tf
+++ b/modules/backup/main.tf
@@ -68,6 +68,15 @@ terraform {
 locals {
   instances = var.enabled ? toset(["enabled"]) : toset([])
 
+  # Shorthand for the propagated null-label tag set used by every
+  # backup-emitted k8s resource via `merge(local.tags, { … })`. The
+  # per-resource block keeps its `app.kubernetes.io/component`
+  # discriminator (`backup`, `backup-init`, `backup-postgres`,
+  # `backup-mysql`, `backup-redis`, `backup-vault`, `backup-pv`,
+  # `backup-prune`) — existing-wins on key collision so the
+  # discriminator never gets overwritten.
+  tags = module.label.tags
+
   passphrase = var.passphrase != "" ? var.passphrase : (
     var.enabled ? values(random_password.backup_passphrase)[0].result : ""
   )
@@ -126,6 +135,21 @@ resource "random_password" "backup_passphrase" {
   }
 }
 
+# Module-tier label, chained off `var.context` (root passes
+# `module.platform_label.context` from `_label.tf`). Output `tags`
+# is exposed via `local.tags` (above) for every resource in the
+# module.
+module "label" {
+  source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+
+  context   = var.context
+  namespace = var.namespace
+  name      = "backup"
+  tags = {
+    "app.kubernetes.io/component" = "backup"
+  }
+}
+
 # ── Namespace + Secret ────────────────────────────────────────────────────
 
 resource "kubernetes_namespace_v1" "backup" {
@@ -133,10 +157,10 @@ resource "kubernetes_namespace_v1" "backup" {
 
   metadata {
     name = var.namespace
-    labels = {
+    labels = merge(local.tags, {
       "app.kubernetes.io/managed-by" = "terraform"
       "app.kubernetes.io/component"  = "backup"
-    }
+    })
   }
 }
 
@@ -150,6 +174,7 @@ resource "kubernetes_secret_v1" "backup_creds" {
   metadata {
     name      = "backup-creds"
     namespace = kubernetes_namespace_v1.backup["enabled"].metadata[0].name
+    labels    = local.tags
   }
 
   data = {
@@ -170,6 +195,7 @@ resource "kubernetes_config_map_v1" "restore_scripts" {
   metadata {
     name      = "backup-restore-scripts"
     namespace = kubernetes_namespace_v1.backup["enabled"].metadata[0].name
+    labels    = local.tags
   }
 
   data = local.restore_scripts
@@ -189,9 +215,9 @@ resource "kubernetes_job_v1" "restic_init" {
   metadata {
     name      = "backup-restic-init"
     namespace = kubernetes_namespace_v1.backup["enabled"].metadata[0].name
-    labels = {
+    labels = merge(local.tags, {
       "app.kubernetes.io/component" = "backup-init"
-    }
+    })
   }
 
   spec {
@@ -200,7 +226,7 @@ resource "kubernetes_job_v1" "restic_init" {
 
     template {
       metadata {
-        labels = { "app.kubernetes.io/component" = "backup-init" }
+        labels = merge(local.tags, { "app.kubernetes.io/component" = "backup-init" })
       }
 
       spec {
@@ -281,7 +307,7 @@ resource "kubernetes_cron_job_v1" "postgres" {
 
     job_template {
       metadata {
-        labels = { "app.kubernetes.io/component" = "backup-postgres" }
+        labels = merge(local.tags, { "app.kubernetes.io/component" = "backup-postgres" })
       }
       spec {
         backoff_limit              = 2
@@ -289,7 +315,7 @@ resource "kubernetes_cron_job_v1" "postgres" {
 
         template {
           metadata {
-            labels = { "app.kubernetes.io/component" = "backup-postgres" }
+            labels = merge(local.tags, { "app.kubernetes.io/component" = "backup-postgres" })
           }
           spec {
             restart_policy = "OnFailure"
@@ -383,7 +409,7 @@ resource "kubernetes_cron_job_v1" "mysql" {
 
     job_template {
       metadata {
-        labels = { "app.kubernetes.io/component" = "backup-mysql" }
+        labels = merge(local.tags, { "app.kubernetes.io/component" = "backup-mysql" })
       }
       spec {
         backoff_limit              = 2
@@ -391,7 +417,7 @@ resource "kubernetes_cron_job_v1" "mysql" {
 
         template {
           metadata {
-            labels = { "app.kubernetes.io/component" = "backup-mysql" }
+            labels = merge(local.tags, { "app.kubernetes.io/component" = "backup-mysql" })
           }
           spec {
             restart_policy = "OnFailure"
@@ -497,7 +523,7 @@ resource "kubernetes_cron_job_v1" "redis" {
 
     job_template {
       metadata {
-        labels = { "app.kubernetes.io/component" = "backup-redis" }
+        labels = merge(local.tags, { "app.kubernetes.io/component" = "backup-redis" })
       }
       spec {
         backoff_limit              = 2
@@ -505,7 +531,7 @@ resource "kubernetes_cron_job_v1" "redis" {
 
         template {
           metadata {
-            labels = { "app.kubernetes.io/component" = "backup-redis" }
+            labels = merge(local.tags, { "app.kubernetes.io/component" = "backup-redis" })
           }
           spec {
             restart_policy = "OnFailure"
@@ -585,7 +611,7 @@ resource "kubernetes_cron_job_v1" "vault" {
 
     job_template {
       metadata {
-        labels = { "app.kubernetes.io/component" = "backup-vault" }
+        labels = merge(local.tags, { "app.kubernetes.io/component" = "backup-vault" })
       }
       spec {
         backoff_limit              = 2
@@ -593,7 +619,7 @@ resource "kubernetes_cron_job_v1" "vault" {
 
         template {
           metadata {
-            labels = { "app.kubernetes.io/component" = "backup-vault" }
+            labels = merge(local.tags, { "app.kubernetes.io/component" = "backup-vault" })
           }
           spec {
             restart_policy = "OnFailure"
@@ -673,7 +699,7 @@ resource "kubernetes_cron_job_v1" "pv" {
 
     job_template {
       metadata {
-        labels = { "app.kubernetes.io/component" = "backup-pv" }
+        labels = merge(local.tags, { "app.kubernetes.io/component" = "backup-pv" })
       }
       spec {
         backoff_limit              = 2
@@ -681,7 +707,7 @@ resource "kubernetes_cron_job_v1" "pv" {
 
         template {
           metadata {
-            labels = { "app.kubernetes.io/component" = "backup-pv" }
+            labels = merge(local.tags, { "app.kubernetes.io/component" = "backup-pv" })
           }
           spec {
             restart_policy = "OnFailure"
@@ -808,7 +834,7 @@ resource "kubernetes_cron_job_v1" "prune" {
 
     job_template {
       metadata {
-        labels = { "app.kubernetes.io/component" = "backup-prune" }
+        labels = merge(local.tags, { "app.kubernetes.io/component" = "backup-prune" })
       }
       spec {
         backoff_limit              = 2
@@ -816,7 +842,7 @@ resource "kubernetes_cron_job_v1" "prune" {
 
         template {
           metadata {
-            labels = { "app.kubernetes.io/component" = "backup-prune" }
+            labels = merge(local.tags, { "app.kubernetes.io/component" = "backup-prune" })
           }
           spec {
             restart_policy = "OnFailure"

--- a/modules/backup/variables.tf
+++ b/modules/backup/variables.tf
@@ -1,3 +1,9 @@
+variable "context" {
+  description = "Serialised parent context from `terraform-null-label`. Caller passes `module.platform_label.context` from the root stack so this module can chain its own label off the platform-wide context — tags propagate down, keeping every k8s resource the module emits consistent with the rest of the engine. Default `null` means the module produces a label with no inherited context."
+  type        = string
+  default     = null
+}
+
 variable "enabled" {
   description = "Whether to provision backup CronJobs + restic init Job. False collapses every resource — fresh clones stay clean."
   type        = bool


### PR DESCRIPTION
## Summary

Mirrors the pattern from PRs #107/#108/#110 for the `modules/backup` module — adds `var.context` input, chains a `module.label` off it, and merges its `tags` into every emitted k8s resource's `metadata.labels` (existing-wins on key collision so per-target discriminators like `app.kubernetes.io/component=backup-postgres` survive intact).

## Engine-side change

- `modules/backup/variables.tf` — new `var.context` input
- `modules/backup/main.tf`:
  - `module "label"` instance, named `backup`, chained off `var.context`, plus `app.kubernetes.io/component = backup` tag
  - `local.tags = module.label.tags` shorthand consumed by every resource's metadata.labels merge
  - **9 emitted resources updated**:
    - namespace + backup-creds Secret + restore-scripts ConfigMap
    - restic-init Job + 6 CronJobs (postgres / mysql / redis / vault / pv / prune)
    - Each CronJob carries the per-target discriminator (e.g. `backup-postgres`); pod-template metadata also gets the merged labels for cross-tier kubectl filtering

## Root wiring

`backup.tf` — passes `context = module.platform_label.context`.

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform validate` — Success
- [x] `terraform plan` — `3 to add, 9 to change, 1 to destroy`:
  - 9 in-place `metadata.labels` merges on backup namespace + Secret + ConfigMap + restic-init Job + 6 CronJobs
  - 1 destroy/replace = baseline `module.minio.kubernetes_job_v1.buckets` idempotent Job (unrelated)
  - 3 adds = baseline idempotent provisioner Jobs (unrelated)
- [x] Pre-commit scrub — clean
- [ ] Apply impact: 9 in-place metadata.labels merges; no Job/CronJob recreation, no pod restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)