### PR TITLE
feat(github-runners): adopt null-label context + tag sweep

### DIFF
--- a/github_runners.tf
+++ b/github_runners.tf
@@ -15,6 +15,7 @@ module "github_runners" {
   source     = "./modules/github-runners"
   depends_on = [module.addons]
 
+  context                  = module.platform_label.context
   enabled                  = local.platform.services.github_runners.enabled
   controller_node_selector = local.platform.services.github_runners.controller_node_selector
   controller_tolerations   = local.platform.services.github_runners.controller_tolerations

--- a/modules/github-runners/main.tf
+++ b/modules/github-runners/main.tf
@@ -44,6 +44,28 @@ locals {
   # Each scale set lands in its own namespace — engine creates them
   # idempotently rather than asking the operator to pre-create.
   scale_set_namespaces = distinct([for _, s in local.scale_set_targets : s.namespace])
+
+  # Shorthand for the propagated null-label tag set used by every
+  # non-Helm resource the module emits. Helm releases delegate label
+  # generation to their charts (gha-runner-scale-set-controller and
+  # gha-runner-scale-set), so we don't apply `metadata.labels` to the
+  # `helm_release` TF resource — the chart's own values block owns
+  # the runtime labels. Only the engine-emitted glue (namespaces +
+  # the engine-emitted PAT Secret) carries our null-label tags.
+  tags = module.label.tags
+}
+
+# Module-tier label, chained off `var.context` (root passes
+# `module.platform_label.context` from `_label.tf`).
+module "label" {
+  source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+
+  context   = var.context
+  namespace = var.namespace_controller
+  name      = "github-runners"
+  tags = {
+    "app.kubernetes.io/component" = "github-runners"
+  }
 }
 
 # ── Controller namespace + chart ───────────────────────────────────────────
@@ -53,10 +75,10 @@ resource "kubernetes_namespace_v1" "controller" {
 
   metadata {
     name = var.namespace_controller
-    labels = {
+    labels = merge(local.tags, {
       "app.kubernetes.io/managed-by" = "terraform"
       "app.kubernetes.io/component"  = "arc-controller"
-    }
+    })
   }
 }
 
@@ -83,10 +105,10 @@ resource "kubernetes_namespace_v1" "scale_set" {
 
   metadata {
     name = each.key
-    labels = {
+    labels = merge(local.tags, {
       "app.kubernetes.io/managed-by" = "terraform"
       "app.kubernetes.io/component"  = "arc-runners"
-    }
+    })
   }
 }
 
@@ -114,11 +136,11 @@ resource "kubernetes_secret_v1" "github_pat" {
   metadata {
     name      = "${each.key}-github-pat"
     namespace = each.value.namespace
-    labels = {
+    labels = merge(local.tags, {
       "app.kubernetes.io/managed-by" = "terraform"
       "app.kubernetes.io/component"  = "arc-github-pat"
       "platform.scale-set"           = each.key
-    }
+    })
   }
 
   data = {

--- a/modules/github-runners/variables.tf
+++ b/modules/github-runners/variables.tf
@@ -1,3 +1,9 @@
+variable "context" {
+  description = "Serialised parent context from `terraform-null-label`. Caller passes `module.platform_label.context` from the root stack so this module can chain its own label off the platform-wide context — tags propagate down, keeping every k8s resource the module emits consistent with the rest of the engine. Default `null` means the module produces a label with no inherited context."
+  type        = string
+  default     = null
+}
+
 variable "enabled" {
   description = "Whether to install ARC controller + any scale sets. False collapses every resource."
   type        = bool


### PR DESCRIPTION
## Summary

Mirrors the pattern from PRs #107/#108/#110/#111 for the `modules/github-runners` module — adds `var.context` input, chains a `module.label` off it, and merges its `tags` into every emitted non-Helm k8s resource's `metadata.labels` (existing-wins on key collision).

## Engine-side change

- `modules/github-runners/variables.tf` — new `var.context` input
- `modules/github-runners/main.tf`:
  - `module "label"` instance, named `github-runners`, chained off `var.context`, plus `app.kubernetes.io/component = github-runners` tag
  - `local.tags = module.label.tags` shorthand
  - **3 emitted non-Helm resources updated**:
    - controller namespace (`arc-system` by default)
    - per-scale-set namespace (`for_each`; one per declared `scale_sets[*].namespace` value)
    - per-scale-set engine-emitted PAT Secret (`for_each`)

## Why Helm releases are deliberately NOT labelled here

`helm_release.controller` and `helm_release.scale_set` ship their downstream k8s objects via the gha-runner-scale-set-controller / gha-runner-scale-set charts which manage their own `metadata.labels`. Adding `metadata.labels` to the `helm_release` TF resource itself doesn't propagate to chart-managed resources, so it'd be visual noise.

## Root wiring

`github_runners.tf` — passes `context = module.platform_label.context`.

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform validate` — Success
- [x] `terraform plan` — 5 in-place `metadata.labels` merges from this PR (controller ns + N scale-set namespaces + N PAT Secrets). **Zero destroy, zero replace.**
- [x] Pre-commit scrub — clean
- [ ] Apply impact: 5 in-place metadata.labels merges; no Helm release reroll, no Pod restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)