### PR TITLE
feat(metallb): adopt null-label context + tag sweep

### DIFF
--- a/metallb.tf
+++ b/metallb.tf
@@ -18,6 +18,7 @@ module "metallb" {
   source     = "./modules/metallb"
   depends_on = [module.addons]
 
+  context                  = module.platform_label.context
   enabled                  = local.platform.services.metallb.enabled
   controller_node_selector = local.platform.services.metallb.controller_node_selector
   controller_tolerations   = local.platform.services.metallb.controller_tolerations

--- a/modules/metallb/main.tf
+++ b/modules/metallb/main.tf
@@ -40,6 +40,26 @@ terraform {
 
 locals {
   instances = var.enabled ? toset(["enabled"]) : toset([])
+
+  # Shorthand for the propagated null-label tag set used by every
+  # non-Helm resource the module emits. Helm release delegates label
+  # generation to the chart (`metallb/metallb`), so we don't apply
+  # `metadata.labels` to the `helm_release` TF resource — the chart
+  # owns its own runtime labels.
+  tags = module.label.tags
+}
+
+# Module-tier label, chained off `var.context` (root passes
+# `module.platform_label.context` from `_label.tf`).
+module "label" {
+  source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+
+  context   = var.context
+  namespace = var.namespace
+  name      = "metallb"
+  tags = {
+    "app.kubernetes.io/component" = "metallb"
+  }
 }
 
 # ── Namespace ──────────────────────────────────────────────────────────────
@@ -49,12 +69,12 @@ resource "kubernetes_namespace_v1" "metallb" {
 
   metadata {
     name = var.namespace
-    labels = {
+    labels = merge(local.tags, {
       # MetalLB's webhook expects this label so its ValidatingAdmissionWebhook
       # can scope CRD validation correctly. Skipping it makes IPAddressPool /
       # L2Advertisement creates fail with "namespace not found by webhook".
       "pod-security.kubernetes.io/enforce" = "privileged"
-    }
+    })
   }
 }
 
@@ -110,6 +130,7 @@ resource "kubectl_manifest" "ip_pool" {
     metadata = {
       name      = each.key
       namespace = var.namespace
+      labels    = local.tags
     }
     spec = {
       addresses  = each.value.addresses
@@ -132,6 +153,7 @@ resource "kubectl_manifest" "l2_advertisement" {
     metadata = {
       name      = each.key
       namespace = var.namespace
+      labels    = local.tags
     }
     spec = {
       ipAddressPools = [each.key]

--- a/modules/metallb/variables.tf
+++ b/modules/metallb/variables.tf
@@ -1,3 +1,9 @@
+variable "context" {
+  description = "Serialised parent context from `terraform-null-label`. Caller passes `module.platform_label.context` from the root stack so this module can chain its own label off the platform-wide context — tags propagate down, keeping every k8s resource the module emits consistent with the rest of the engine. Default `null` means the module produces a label with no inherited context."
+  type        = string
+  default     = null
+}
+
 variable "enabled" {
   description = "Whether to deploy MetalLB. False collapses every resource."
   type        = bool


### PR DESCRIPTION
## Summary

Mirrors the pattern from PRs #107/#108/#110/#111/#112 for the `modules/metallb` module — adds `var.context` input, chains a `module.label` off it, and merges its `tags` into every emitted non-Helm k8s resource's `metadata.labels` (existing-wins on key collision so the namespace's `pod-security.kubernetes.io/enforce` value survives intact — that label is required by MetalLB's webhook to scope CRD validation).

## Engine-side change

- `modules/metallb/variables.tf` — new `var.context` input
- `modules/metallb/main.tf`:
  - `module "label"` instance, named `metallb`, chained off `var.context`, plus `app.kubernetes.io/component = metallb` tag
  - `local.tags = module.label.tags` shorthand
  - **3 emitted non-Helm resource definitions updated**:
    - `kubernetes_namespace_v1.metallb` — merges into existing `pod-security.kubernetes.io/enforce: privileged` block
    - `kubectl_manifest.ip_pool` — adds `metadata.labels` inside `yaml_body` for each pool (`for_each`)
    - `kubectl_manifest.l2_advertisement` — adds `metadata.labels` inside `yaml_body` for each advertisement (`for_each`)

## Why these are deliberately NOT labelled

- **`helm_release.metallb`** — chart-managed (`metallb/metallb`); chart owns its own `metadata.labels`.
- **`kubernetes_annotations.shared_ip`** — patches annotations on Services owned by other controllers (Helm/ArgoCD). Adding labels here would mean claiming ownership of the target Service's metadata, defeating the purpose of using `kubernetes_annotations` over `kubernetes_service_v1`.

## Root wiring

`metallb.tf` — passes `context = module.platform_label.context`.

## Test plan

- [x] `terraform fmt -recursive` — clean
- [x] `terraform validate` — Success
- [x] `terraform plan` — 7 metallb-specific in-place `metadata.labels` merges (1 namespace + N IPAddressPools + N L2Advertisements). **Zero destroy, zero replace.**
- [x] Pre-commit scrub — clean
- [ ] Apply impact: 7 in-place metadata.labels merges; no MetalLB controller restart, no VIP flap

🤖 Generated with [Claude Code](https://claude.com/claude-code)