### PR TITLE
feat(modules): null-label across mysql/postgres/redis/ollama/vault/zitadel/stalwart/roundcube/longhorn

### DIFF
--- a/longhorn.tf
+++ b/longhorn.tf
@@ -17,6 +17,7 @@ module "longhorn" {
   source     = "./modules/longhorn"
   depends_on = [module.addons]
 
+  context               = module.platform_label.context
   enabled               = local.platform.services.longhorn.enabled
   default_replica_count = local.platform.services.longhorn.replica_count
   tolerations           = local.platform.services.longhorn.tolerations

--- a/mail.tf
+++ b/mail.tf
@@ -65,6 +65,7 @@ module "stalwart" {
   source     = "./modules/stalwart"
   depends_on = [module.addons, module.zitadel, kubernetes_resource_quota_v1.mail]
 
+  context          = module.platform_label.context
   enabled          = local.mail != null
   namespace        = local.mail == null ? "" : kubernetes_namespace_v1.mail["enabled"].metadata[0].name
   volume_base_path = var.host_volume_path
@@ -126,6 +127,7 @@ module "roundcube" {
   source     = "./modules/roundcube"
   depends_on = [module.stalwart]
 
+  context          = module.platform_label.context
   enabled          = local.mail != null && local.platform.services.zitadel.enabled
   namespace        = local.mail == null ? "" : kubernetes_namespace_v1.mail["enabled"].metadata[0].name
   hostname         = try(local.mail.hostname, "")

--- a/modules/longhorn/main.tf
+++ b/modules/longhorn/main.tf
@@ -37,6 +37,9 @@ terraform {
 locals {
   instances = var.enabled ? toset(["enabled"]) : toset([])
 
+  # Shorthand for the propagated null-label tag set.
+  tags = module.label.tags
+
   # Only check the non-sensitive vars in this derivation —
   # `for_each` rejects values derived from sensitive inputs.
   # The check block at the root level confirms the matching
@@ -126,6 +129,19 @@ locals {
   })
 }
 
+# Module-tier label, chained off `var.context` (root passes
+# `module.platform_label.context` from `_label.tf`).
+module "label" {
+  source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+
+  context   = var.context
+  namespace = var.namespace
+  name      = "longhorn"
+  tags = {
+    "app.kubernetes.io/component" = "longhorn"
+  }
+}
+
 # ── Resources ─────────────────────────────────────────────────────────────
 
 # Backup credentials Secret. Format mandated by Longhorn:
@@ -140,10 +156,10 @@ resource "kubernetes_secret_v1" "backup_credentials" {
   metadata {
     name      = "longhorn-backup-credentials"
     namespace = var.namespace
-    labels = {
+    labels = merge(local.tags, {
       "app.kubernetes.io/managed-by" = "terraform"
       "app.kubernetes.io/component"  = "longhorn-backup"
-    }
+    })
   }
 
   data = {
@@ -199,7 +215,8 @@ resource "kubernetes_storage_class_v1" "tag_pool" {
   depends_on = [helm_release.longhorn]
 
   metadata {
-    name = "longhorn-${each.key}"
+    name   = "longhorn-${each.key}"
+    labels = local.tags
   }
   storage_provisioner    = "driver.longhorn.io"
   reclaim_policy         = each.value.reclaim_policy
@@ -233,6 +250,7 @@ resource "kubectl_manifest" "recurring_backup" {
     metadata = {
       name      = "platform-default-backup"
       namespace = var.namespace
+      labels    = local.tags
     }
     spec = {
       name        = "platform-default-backup"

--- a/modules/longhorn/variables.tf
+++ b/modules/longhorn/variables.tf
@@ -1,3 +1,9 @@
+variable "context" {
+  description = "Serialised parent context from `terraform-null-label`. Caller passes `module.platform_label.context` from the root stack so this module can chain its own label off the platform-wide context — tags propagate down, keeping every k8s resource the module emits consistent with the rest of the engine. Default `null` means the module produces a label with no inherited context."
+  type        = string
+  default     = null
+}
+
 variable "enabled" {
   description = "Whether to deploy Longhorn. False collapses every resource."
   type        = bool

--- a/modules/mysql/main.tf
+++ b/modules/mysql/main.tf
@@ -19,6 +19,25 @@ locals {
   # sibling terraform-k8s-addons module so `terraform state list`
   # looks uniform across the platform stack.
   instances = var.enabled ? toset(["enabled"]) : toset([])
+
+  # Shorthand for the propagated null-label tag set used by every
+  # k8s resource the module emits via `merge(local.tags, { … })`.
+  # Existing-wins on key collision so the StatefulSet/Service
+  # selector key `app=mysql` survives intact.
+  tags = module.label.tags
+}
+
+# Module-tier label, chained off `var.context` (root passes
+# `module.platform_label.context` from `_label.tf`).
+module "label" {
+  source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+
+  context   = var.context
+  namespace = var.namespace
+  name      = "mysql"
+  tags = {
+    "app.kubernetes.io/component" = "mysql"
+  }
 }
 
 # ── Root password ─────────────────────────────────────────────────────────────
@@ -36,6 +55,7 @@ resource "kubernetes_secret_v1" "mysql_root" {
   metadata {
     name      = "mysql-root"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   data = {
@@ -49,7 +69,8 @@ resource "kubernetes_persistent_volume_v1" "mysql" {
   for_each = local.instances
 
   metadata {
-    name = "platform-mysql-data"
+    name   = "platform-mysql-data"
+    labels = local.tags
   }
 
   spec {
@@ -75,6 +96,7 @@ resource "kubernetes_persistent_volume_claim_v1" "mysql" {
   metadata {
     name      = "mysql-data"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   spec {
@@ -98,7 +120,7 @@ resource "kubernetes_stateful_set_v1" "mysql" {
   metadata {
     name      = "mysql"
     namespace = var.namespace
-    labels    = { app = "mysql" }
+    labels    = merge(local.tags, { app = "mysql" })
   }
 
   spec {
@@ -111,7 +133,7 @@ resource "kubernetes_stateful_set_v1" "mysql" {
 
     template {
       metadata {
-        labels = { app = "mysql" }
+        labels = merge(local.tags, { app = "mysql" })
       }
 
       spec {
@@ -215,7 +237,7 @@ resource "kubernetes_service_v1" "mysql" {
   metadata {
     name      = "mysql"
     namespace = var.namespace
-    labels    = { app = "mysql" }
+    labels    = merge(local.tags, { app = "mysql" })
   }
 
   spec {

--- a/modules/mysql/variables.tf
+++ b/modules/mysql/variables.tf
@@ -1,3 +1,9 @@
+variable "context" {
+  description = "Serialised parent context from `terraform-null-label`. Caller passes `module.platform_label.context` from the root stack so this module can chain its own label off the platform-wide context — tags propagate down, keeping every k8s resource the module emits consistent with the rest of the engine. Default `null` means the module produces a label with no inherited context."
+  type        = string
+  default     = null
+}
+
 variable "enabled" {
   description = "Deploy the MySQL StatefulSet. When `false`, no resources are created and every output collapses to null — a disabled MySQL cleanly cascades into `modules/project` (components with `db: true` fail a precondition instead of silently deploying a broken StatefulSet)."
   type        = bool

--- a/modules/ollama/main.tf
+++ b/modules/ollama/main.tf
@@ -30,6 +30,22 @@ locals {
   # Model-pull Job is separately gated — skipped when the module is off
   # OR when the operator explicitly supplies an empty models list.
   pull_instances = var.enabled && length(var.models) > 0 ? toset(["enabled"]) : toset([])
+
+  # Shorthand for the propagated null-label tag set.
+  tags = module.label.tags
+}
+
+# Module-tier label, chained off `var.context` (root passes
+# `module.platform_label.context` from `_label.tf`).
+module "label" {
+  source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+
+  context   = var.context
+  namespace = var.namespace
+  name      = "ollama"
+  tags = {
+    "app.kubernetes.io/component" = "ollama"
+  }
 }
 
 # ── Persistent storage (models cache) ─────────────────────────────────────────
@@ -38,7 +54,8 @@ resource "kubernetes_persistent_volume_v1" "ollama" {
   for_each = local.instances
 
   metadata {
-    name = "platform-ollama-data"
+    name   = "platform-ollama-data"
+    labels = local.tags
   }
 
   spec {
@@ -64,6 +81,7 @@ resource "kubernetes_persistent_volume_claim_v1" "ollama" {
   metadata {
     name      = "ollama-data"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   spec {
@@ -87,7 +105,7 @@ resource "kubernetes_stateful_set_v1" "ollama" {
   metadata {
     name      = "ollama"
     namespace = var.namespace
-    labels    = { app = "ollama" }
+    labels    = merge(local.tags, { app = "ollama" })
   }
 
   spec {
@@ -100,7 +118,7 @@ resource "kubernetes_stateful_set_v1" "ollama" {
 
     template {
       metadata {
-        labels = { app = "ollama" }
+        labels = merge(local.tags, { app = "ollama" })
       }
 
       spec {
@@ -344,7 +362,7 @@ resource "kubernetes_service_v1" "ollama" {
   metadata {
     name      = "ollama"
     namespace = var.namespace
-    labels    = { app = "ollama" }
+    labels    = merge(local.tags, { app = "ollama" })
   }
 
   spec {
@@ -381,10 +399,10 @@ resource "kubernetes_job_v1" "pull_models" {
     # otherwise produce `field is immutable` errors.
     name      = "ollama-pull-${substr(sha1(join(",", var.models)), 0, 10)}"
     namespace = var.namespace
-    labels = {
+    labels = merge(local.tags, {
       "app.kubernetes.io/managed-by" = "terraform"
       "app"                          = "ollama-pull"
-    }
+    })
   }
 
   spec {
@@ -392,7 +410,7 @@ resource "kubernetes_job_v1" "pull_models" {
 
     template {
       metadata {
-        labels = { job = "ollama-pull" }
+        labels = merge(local.tags, { job = "ollama-pull" })
       }
 
       spec {

--- a/modules/ollama/variables.tf
+++ b/modules/ollama/variables.tf
@@ -1,3 +1,9 @@
+variable "context" {
+  description = "Serialised parent context from `terraform-null-label`. Caller passes `module.platform_label.context` from the root stack so this module can chain its own label off the platform-wide context — tags propagate down, keeping every k8s resource the module emits consistent with the rest of the engine. Default `null` means the module produces a label with no inherited context."
+  type        = string
+  default     = null
+}
+
 variable "enabled" {
   description = "Deploy the Ollama StatefulSet + model-pull Job. When `false`, no resources are created and every output collapses to null."
   type        = bool

--- a/modules/postgres/main.tf
+++ b/modules/postgres/main.tf
@@ -14,6 +14,25 @@ terraform {
 
 locals {
   instances = var.enabled ? toset(["enabled"]) : toset([])
+
+  # Shorthand for the propagated null-label tag set used by every
+  # k8s resource the module emits via `merge(local.tags, { … })`.
+  # Existing-wins on key collision so the StatefulSet/Service
+  # selector key `app=postgres` survives intact.
+  tags = module.label.tags
+}
+
+# Module-tier label, chained off `var.context` (root passes
+# `module.platform_label.context` from `_label.tf`).
+module "label" {
+  source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+
+  context   = var.context
+  namespace = var.namespace
+  name      = "postgres"
+  tags = {
+    "app.kubernetes.io/component" = "postgres"
+  }
 }
 
 # ── Superuser password ────────────────────────────────────────────────────────
@@ -31,6 +50,7 @@ resource "kubernetes_secret_v1" "superuser" {
   metadata {
     name      = "postgres-superuser"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   # `postgres:` image entrypoint reads `POSTGRES_PASSWORD` for the
@@ -47,7 +67,8 @@ resource "kubernetes_persistent_volume_v1" "postgres" {
   for_each = local.instances
 
   metadata {
-    name = "platform-postgres-data"
+    name   = "platform-postgres-data"
+    labels = local.tags
   }
 
   spec {
@@ -73,6 +94,7 @@ resource "kubernetes_persistent_volume_claim_v1" "postgres" {
   metadata {
     name      = "postgres-data"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   spec {
@@ -96,7 +118,7 @@ resource "kubernetes_stateful_set_v1" "postgres" {
   metadata {
     name      = "postgres"
     namespace = var.namespace
-    labels    = { app = "postgres" }
+    labels    = merge(local.tags, { app = "postgres" })
   }
 
   spec {
@@ -109,7 +131,7 @@ resource "kubernetes_stateful_set_v1" "postgres" {
 
     template {
       metadata {
-        labels = { app = "postgres" }
+        labels = merge(local.tags, { app = "postgres" })
       }
 
       spec {
@@ -274,7 +296,7 @@ resource "kubernetes_job_v1" "pg_extensions" {
   metadata {
     name      = "postgres-pg-extensions"
     namespace = var.namespace
-    labels    = { app = "postgres" }
+    labels    = merge(local.tags, { app = "postgres" })
   }
 
   spec {
@@ -283,7 +305,7 @@ resource "kubernetes_job_v1" "pg_extensions" {
 
     template {
       metadata {
-        labels = { app = "postgres", job = "pg-extensions" }
+        labels = merge(local.tags, { app = "postgres", job = "pg-extensions" })
       }
 
       spec {
@@ -349,7 +371,7 @@ resource "kubernetes_service_v1" "postgres" {
   metadata {
     name      = "postgres"
     namespace = var.namespace
-    labels    = { app = "postgres" }
+    labels    = merge(local.tags, { app = "postgres" })
   }
 
   spec {

--- a/modules/postgres/variables.tf
+++ b/modules/postgres/variables.tf
@@ -1,3 +1,9 @@
+variable "context" {
+  description = "Serialised parent context from `terraform-null-label`. Caller passes `module.platform_label.context` from the root stack so this module can chain its own label off the platform-wide context — tags propagate down, keeping every k8s resource the module emits consistent with the rest of the engine. Default `null` means the module produces a label with no inherited context."
+  type        = string
+  default     = null
+}
+
 variable "enabled" {
   description = "Deploy the PostgreSQL StatefulSet. When `false`, no resources are created and every output collapses to null."
   type        = bool

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -20,6 +20,22 @@ locals {
   instances          = var.enabled ? toset(["enabled"]) : toset([])
   single_instances   = (var.enabled && !var.sentinel.enabled) ? toset(["enabled"]) : toset([])
   sentinel_instances = (var.enabled && var.sentinel.enabled) ? toset(["enabled"]) : toset([])
+
+  # Shorthand for the propagated null-label tag set.
+  tags = module.label.tags
+}
+
+# Module-tier label, chained off `var.context` (root passes
+# `module.platform_label.context` from `_label.tf`).
+module "label" {
+  source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+
+  context   = var.context
+  namespace = var.namespace
+  name      = "redis"
+  tags = {
+    "app.kubernetes.io/component" = "redis"
+  }
 }
 
 # ── Default (root) password ───────────────────────────────────────────────────
@@ -41,6 +57,7 @@ resource "kubernetes_secret_v1" "default" {
   metadata {
     name      = "redis-default"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   data = {
@@ -70,6 +87,7 @@ resource "kubernetes_persistent_volume_claim_v1" "redis" {
   metadata {
     name      = "redis-data"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   spec {
@@ -92,7 +110,7 @@ resource "kubernetes_stateful_set_v1" "redis" {
   metadata {
     name      = "redis"
     namespace = var.namespace
-    labels    = { app = "redis" }
+    labels    = merge(local.tags, { app = "redis" })
   }
 
   spec {
@@ -105,7 +123,7 @@ resource "kubernetes_stateful_set_v1" "redis" {
 
     template {
       metadata {
-        labels = { app = "redis" }
+        labels = merge(local.tags, { app = "redis" })
       }
 
       spec {
@@ -288,7 +306,7 @@ resource "kubernetes_service_v1" "redis" {
   metadata {
     name      = "redis"
     namespace = var.namespace
-    labels    = { app = "redis" }
+    labels    = merge(local.tags, { app = "redis" })
   }
 
   spec {
@@ -426,6 +444,7 @@ resource "kubernetes_config_map_v1" "haproxy_config" {
   metadata {
     name      = "redis-haproxy-config"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   data = {
@@ -475,7 +494,7 @@ resource "kubernetes_deployment_v1" "haproxy" {
   metadata {
     name      = "redis-haproxy"
     namespace = var.namespace
-    labels    = { app = "redis", component = "haproxy" }
+    labels    = merge(local.tags, { app = "redis", component = "haproxy" })
   }
 
   spec {
@@ -487,7 +506,7 @@ resource "kubernetes_deployment_v1" "haproxy" {
 
     template {
       metadata {
-        labels = { app = "redis", component = "haproxy" }
+        labels = merge(local.tags, { app = "redis", component = "haproxy" })
       }
 
       spec {

--- a/modules/redis/variables.tf
+++ b/modules/redis/variables.tf
@@ -1,3 +1,9 @@
+variable "context" {
+  description = "Serialised parent context from `terraform-null-label`. Caller passes `module.platform_label.context` from the root stack so this module can chain its own label off the platform-wide context — tags propagate down, keeping every k8s resource the module emits consistent with the rest of the engine. Default `null` means the module produces a label with no inherited context."
+  type        = string
+  default     = null
+}
+
 variable "enabled" {
   description = "Deploy the Redis StatefulSet. When `false`, no resources are created and every output collapses to null."
   type        = bool

--- a/modules/roundcube/main.tf
+++ b/modules/roundcube/main.tf
@@ -42,6 +42,9 @@ locals {
   client_secret   = local.oidc_enabled ? zitadel_application_oidc.roundcube["enabled"].client_secret : ""
   config_inc_hash = sha256(local.config_inc_php)
 
+  # Shorthand for the propagated null-label tag set.
+  tags = module.label.tags
+
   # Roundcube `config.inc.php` rendered from TF. Three concerns:
   # 1. IMAP/SMTP point at Stalwart in-cluster (TLS, self-signed
   #    cert ignored — the cluster boundary is the trust boundary).
@@ -126,6 +129,19 @@ locals {
   EOT
 }
 
+# Module-tier label, chained off `var.context` (root passes
+# `module.platform_label.context` from `_label.tf`).
+module "label" {
+  source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+
+  context   = var.context
+  namespace = var.namespace
+  name      = "roundcube"
+  tags = {
+    "app.kubernetes.io/component" = "roundcube"
+  }
+}
+
 # ── Zitadel project + application — Roundcube as PKCE OIDC client ─────────────
 resource "zitadel_application_oidc" "roundcube" {
   for_each = local.oidc_set
@@ -185,7 +201,7 @@ resource "kubernetes_secret_v1" "roundcube_secrets" {
   metadata {
     name      = "roundcube-secrets"
     namespace = var.namespace
-    labels    = { app = "roundcube" }
+    labels    = merge(local.tags, { app = "roundcube" })
   }
 
   data = {
@@ -201,7 +217,7 @@ resource "kubernetes_config_map_v1" "roundcube_config" {
   metadata {
     name      = "roundcube-config"
     namespace = var.namespace
-    labels    = { app = "roundcube" }
+    labels    = merge(local.tags, { app = "roundcube" })
   }
 
   data = {
@@ -215,10 +231,9 @@ resource "kubernetes_persistent_volume_v1" "roundcube" {
 
   metadata {
     name = "roundcube-db"
-    labels = {
-      "app.kubernetes.io/name"    = "roundcube"
-      "app.kubernetes.io/part-of" = "platform"
-    }
+    labels = merge(local.tags, {
+      "app.kubernetes.io/name" = "roundcube"
+    })
   }
 
   spec {
@@ -252,7 +267,7 @@ resource "kubernetes_persistent_volume_claim_v1" "roundcube" {
   metadata {
     name      = "roundcube-db"
     namespace = var.namespace
-    labels    = { app = "roundcube" }
+    labels    = merge(local.tags, { app = "roundcube" })
   }
 
   spec {
@@ -273,7 +288,7 @@ resource "kubernetes_service_v1" "roundcube" {
   metadata {
     name      = "roundcube"
     namespace = var.namespace
-    labels    = { app = "roundcube" }
+    labels    = merge(local.tags, { app = "roundcube" })
   }
 
   spec {
@@ -295,7 +310,7 @@ resource "kubernetes_deployment_v1" "roundcube" {
   metadata {
     name      = "roundcube"
     namespace = var.namespace
-    labels    = { app = "roundcube" }
+    labels    = merge(local.tags, { app = "roundcube" })
 
     annotations = {
       "platform.local/config-hash" = local.config_inc_hash
@@ -313,7 +328,7 @@ resource "kubernetes_deployment_v1" "roundcube" {
 
     template {
       metadata {
-        labels = { app = "roundcube" }
+        labels = merge(local.tags, { app = "roundcube" })
         annotations = {
           "platform.local/config-hash" = local.config_inc_hash
 

--- a/modules/roundcube/variables.tf
+++ b/modules/roundcube/variables.tf
@@ -1,3 +1,9 @@
+variable "context" {
+  description = "Serialised parent context from `terraform-null-label`. Caller passes `module.platform_label.context` from the root stack so this module can chain its own label off the platform-wide context — tags propagate down, keeping every k8s resource the module emits consistent with the rest of the engine. Default `null` means the module produces a label with no inherited context."
+  type        = string
+  default     = null
+}
+
 variable "enabled" {
   type    = bool
   default = true

--- a/modules/stalwart/main.tf
+++ b/modules/stalwart/main.tf
@@ -60,6 +60,9 @@ terraform {
 locals {
   instances = var.enabled ? toset(["enabled"]) : toset([])
 
+  # Shorthand for the propagated null-label tag set.
+  tags = module.label.tags
+
   # Match Stalwart's auto-bootstrapped default listeners — saves the
   # plan from having to manage NetworkListener objects (which is
   # awkward because destroying the http listener mid-apply would
@@ -471,6 +474,19 @@ locals {
   plan_ndjson = join("\n", local.plan_lines)
 }
 
+# Module-tier label, chained off `var.context` (root passes
+# `module.platform_label.context` from `_label.tf`).
+module "label" {
+  source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+
+  context   = var.context
+  namespace = var.namespace
+  name      = "stalwart"
+  tags = {
+    "app.kubernetes.io/component" = "stalwart"
+  }
+}
+
 # ── Zitadel project + application + role ──────────────────────────────────────
 #
 # Single project per Stalwart tenant. PKCE / SPA OIDC application —
@@ -668,6 +684,7 @@ resource "kubernetes_secret_v1" "recovery_admin" {
   metadata {
     name      = "stalwart-recovery-admin"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   data = {
@@ -694,6 +711,7 @@ resource "kubernetes_secret_v1" "stalwart_seed" {
   metadata {
     name      = "stalwart-seed"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   data = {
@@ -708,7 +726,8 @@ resource "kubernetes_persistent_volume_v1" "stalwart" {
   for_each = local.instances
 
   metadata {
-    name = "platform-stalwart-data"
+    name   = "platform-stalwart-data"
+    labels = local.tags
   }
 
   spec {
@@ -734,6 +753,7 @@ resource "kubernetes_persistent_volume_claim_v1" "stalwart" {
   metadata {
     name      = "stalwart-data"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   spec {
@@ -757,7 +777,7 @@ resource "kubernetes_service_v1" "stalwart_http" {
   metadata {
     name      = "stalwart"
     namespace = var.namespace
-    labels    = { app = "stalwart" }
+    labels    = merge(local.tags, { app = "stalwart" })
   }
 
   spec {
@@ -809,7 +829,7 @@ resource "kubernetes_service_v1" "stalwart_smtp" {
   metadata {
     name      = "stalwart-smtp"
     namespace = var.namespace
-    labels    = { app = "stalwart" }
+    labels    = merge(local.tags, { app = "stalwart" })
   }
 
   spec {
@@ -841,6 +861,7 @@ resource "kubectl_manifest" "stalwart_admin_ingressroute" {
     metadata = {
       name      = "stalwart-admin"
       namespace = var.namespace
+      labels    = local.tags
     }
     spec = {
       entryPoints = ["web"]
@@ -866,6 +887,7 @@ resource "kubectl_manifest" "stalwart_account_ingressroute" {
     metadata = {
       name      = "stalwart-account"
       namespace = var.namespace
+      labels    = local.tags
     }
     spec = {
       entryPoints = ["web"]
@@ -890,7 +912,7 @@ resource "kubernetes_deployment_v1" "stalwart" {
   metadata {
     name      = "stalwart"
     namespace = var.namespace
-    labels    = { app = "stalwart" }
+    labels    = merge(local.tags, { app = "stalwart" })
 
     annotations = {
       # Force Pod restart when seed changes — without this, a
@@ -915,7 +937,7 @@ resource "kubernetes_deployment_v1" "stalwart" {
 
     template {
       metadata {
-        labels = { app = "stalwart" }
+        labels = merge(local.tags, { app = "stalwart" })
 
         annotations = {
           "platform.local/seed-hash" = sha256(nonsensitive("${local.config_json}|${local.plan_ndjson}|${local.webui_client_id}"))
@@ -1331,7 +1353,7 @@ resource "kubernetes_deployment_v1" "stalwart_smtp_relay" {
   metadata {
     name      = "stalwart-smtp-relay"
     namespace = var.namespace
-    labels    = { app = "stalwart-smtp-relay" }
+    labels    = merge(local.tags, { app = "stalwart-smtp-relay" })
   }
 
   spec {
@@ -1347,7 +1369,7 @@ resource "kubernetes_deployment_v1" "stalwart_smtp_relay" {
 
     template {
       metadata {
-        labels = { app = "stalwart-smtp-relay" }
+        labels = merge(local.tags, { app = "stalwart-smtp-relay" })
       }
 
       spec {

--- a/modules/stalwart/variables.tf
+++ b/modules/stalwart/variables.tf
@@ -1,3 +1,9 @@
+variable "context" {
+  description = "Serialised parent context from `terraform-null-label`. Caller passes `module.platform_label.context` from the root stack so this module can chain its own label off the platform-wide context — tags propagate down, keeping every k8s resource the module emits consistent with the rest of the engine. Default `null` means the module produces a label with no inherited context."
+  type        = string
+  default     = null
+}
+
 variable "enabled" {
   description = "Deploy the Stalwart mail server. When false, no resources are created."
   type        = bool

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -57,8 +57,16 @@ terraform {
 # Locals
 # -----------------------------------------------------------------------------
 
+module "label" {
+  source  = "github.com/rromenskyi/terraform-null-label?ref=v0.1.0"
+  context = var.context
+  name    = "vault"
+}
+
 locals {
   instances = var.enabled ? toset(["enabled"]) : toset([])
+
+  tags = module.label.tags
 
   data_path = "${var.volume_base_path}/${var.namespace}/vault/data"
 
@@ -102,7 +110,7 @@ resource "kubernetes_service_account_v1" "vault" {
   metadata {
     name      = "vault"
     namespace = var.namespace
-    labels    = { app = "vault" }
+    labels    = merge(local.tags, { app = "vault" })
   }
 }
 
@@ -112,6 +120,7 @@ resource "kubernetes_role_v1" "vault_bootstrap" {
   metadata {
     name      = "vault-bootstrap"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   rule {
@@ -128,6 +137,7 @@ resource "kubernetes_role_binding_v1" "vault_bootstrap" {
   metadata {
     name      = "vault-bootstrap"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   role_ref {
@@ -157,10 +167,10 @@ resource "kubernetes_secret_v1" "vault_bootstrap" {
   metadata {
     name      = "vault-bootstrap"
     namespace = var.namespace
-    labels = {
+    labels = merge(local.tags, {
       "app.kubernetes.io/managed-by" = "terraform"
       "app"                          = "vault"
-    }
+    })
   }
 
   # Placeholder keys — the init Job overwrites both with the real
@@ -182,6 +192,7 @@ resource "kubernetes_config_map_v1" "vault_config" {
   metadata {
     name      = "vault-config"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   data = {
@@ -197,7 +208,8 @@ resource "kubernetes_persistent_volume_v1" "vault" {
   for_each = local.instances
 
   metadata {
-    name = "vault-data"
+    name   = "vault-data"
+    labels = local.tags
   }
 
   spec {
@@ -228,6 +240,7 @@ resource "kubernetes_persistent_volume_claim_v1" "vault" {
   metadata {
     name      = "vault-data"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   spec {
@@ -264,7 +277,7 @@ resource "kubernetes_stateful_set_v1" "vault" {
   metadata {
     name      = "vault"
     namespace = var.namespace
-    labels    = { app = "vault" }
+    labels    = merge(local.tags, { app = "vault" })
   }
 
   spec {
@@ -277,7 +290,7 @@ resource "kubernetes_stateful_set_v1" "vault" {
 
     template {
       metadata {
-        labels = { app = "vault" }
+        labels = merge(local.tags, { app = "vault" })
       }
 
       spec {
@@ -571,7 +584,7 @@ resource "kubernetes_service_v1" "vault" {
   metadata {
     name      = "vault"
     namespace = var.namespace
-    labels    = { app = "vault" }
+    labels    = merge(local.tags, { app = "vault" })
   }
 
   spec {
@@ -602,10 +615,10 @@ resource "kubernetes_job_v1" "vault_init" {
   metadata {
     name      = "vault-init"
     namespace = var.namespace
-    labels = {
+    labels = merge(local.tags, {
       "app.kubernetes.io/managed-by" = "terraform"
       "app"                          = "vault"
-    }
+    })
   }
 
   spec {
@@ -613,7 +626,7 @@ resource "kubernetes_job_v1" "vault_init" {
 
     template {
       metadata {
-        labels = { job = "vault-init" }
+        labels = merge(local.tags, { job = "vault-init" })
       }
 
       spec {

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -1,3 +1,9 @@
+variable "context" {
+  description = "Serialised parent context from `terraform-null-label`. Caller passes `module.platform_label.context` from the root stack so this module can chain its own label off the platform-wide context — tags propagate down, keeping every k8s resource the module emits consistent with the rest of the engine. Default `null` means the module produces a label with no inherited context."
+  type        = string
+  default     = null
+}
+
 variable "enabled" {
   description = "Deploy Vault. When false, no resources are created."
   type        = bool

--- a/modules/zitadel/main.tf
+++ b/modules/zitadel/main.tf
@@ -18,8 +18,16 @@ terraform {
 
 # ── Locals ────────────────────────────────────────────────────────────────────
 
+module "label" {
+  source  = "github.com/rromenskyi/terraform-null-label?ref=v0.1.0"
+  context = var.context
+  name    = "zitadel"
+}
+
 locals {
   instances = var.enabled ? toset(["enabled"]) : toset([])
+
+  tags = module.label.tags
 
   db_name = "platform_zitadel"
   db_user = "platform_zitadel"
@@ -65,6 +73,7 @@ resource "kubernetes_secret_v1" "zitadel" {
   metadata {
     name      = "zitadel"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   data = {
@@ -86,6 +95,7 @@ resource "kubernetes_secret_v1" "login_client_pat" {
   metadata {
     name      = "zitadel-login-client-pat"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   data = {
@@ -105,10 +115,10 @@ resource "kubernetes_job_v1" "postgres_setup" {
   metadata {
     name      = "zitadel-postgres-setup"
     namespace = var.namespace
-    labels = {
+    labels = merge(local.tags, {
       "app.kubernetes.io/managed-by" = "terraform"
       "app"                          = "zitadel"
-    }
+    })
   }
 
   spec {
@@ -116,7 +126,7 @@ resource "kubernetes_job_v1" "postgres_setup" {
 
     template {
       metadata {
-        labels = { job = "zitadel-postgres-setup" }
+        labels = merge(local.tags, { job = "zitadel-postgres-setup" })
       }
 
       spec {
@@ -192,7 +202,7 @@ resource "kubernetes_deployment_v1" "zitadel" {
   metadata {
     name      = "zitadel"
     namespace = var.namespace
-    labels    = { app = "zitadel" }
+    labels    = merge(local.tags, { app = "zitadel" })
   }
 
   spec {
@@ -210,7 +220,7 @@ resource "kubernetes_deployment_v1" "zitadel" {
 
     template {
       metadata {
-        labels = { app = "zitadel" }
+        labels = merge(local.tags, { app = "zitadel" })
       }
 
       spec {
@@ -683,6 +693,7 @@ resource "kubernetes_config_map_v1" "steps" {
   metadata {
     name      = "zitadel-steps"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   data = {
@@ -744,6 +755,7 @@ resource "kubernetes_service_account_v1" "pat_broker" {
   metadata {
     name      = "zitadel-pat-broker"
     namespace = var.namespace
+    labels    = local.tags
   }
 }
 
@@ -753,6 +765,7 @@ resource "kubernetes_role_v1" "pat_broker" {
   metadata {
     name      = "zitadel-pat-broker"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   rule {
@@ -768,6 +781,7 @@ resource "kubernetes_role_binding_v1" "pat_broker" {
   metadata {
     name      = "zitadel-pat-broker"
     namespace = var.namespace
+    labels    = local.tags
   }
 
   role_ref {
@@ -791,7 +805,7 @@ resource "kubernetes_service_v1" "zitadel" {
   metadata {
     name      = "zitadel"
     namespace = var.namespace
-    labels    = { app = "zitadel" }
+    labels    = merge(local.tags, { app = "zitadel" })
   }
 
   spec {
@@ -814,7 +828,7 @@ resource "kubernetes_service_v1" "zitadel_login" {
   metadata {
     name      = "zitadel-login"
     namespace = var.namespace
-    labels    = { app = "zitadel" }
+    labels    = merge(local.tags, { app = "zitadel" })
   }
 
   spec {
@@ -849,6 +863,7 @@ resource "kubectl_manifest" "login_ingress_route" {
     metadata = {
       name      = "zitadel-login"
       namespace = var.namespace
+      labels    = local.tags
     }
     spec = {
       entryPoints = ["web"]

--- a/modules/zitadel/variables.tf
+++ b/modules/zitadel/variables.tf
@@ -1,3 +1,9 @@
+variable "context" {
+  description = "Serialised parent context from `terraform-null-label`. Caller passes `module.platform_label.context` from the root stack so this module can chain its own label off the platform-wide context — tags propagate down, keeping every k8s resource the module emits consistent with the rest of the engine. Default `null` means the module produces a label with no inherited context."
+  type        = string
+  default     = null
+}
+
 variable "enabled" {
   description = "Deploy Zitadel. When false, no resources are created."
   type        = bool

--- a/mysql.tf
+++ b/mysql.tf
@@ -8,6 +8,7 @@ module "mysql" {
   source     = "./modules/mysql"
   depends_on = [module.addons]
 
+  context          = module.platform_label.context
   enabled          = local.platform.services.mysql.enabled
   namespace        = kubernetes_namespace_v1.platform.metadata[0].name
   volume_base_path = var.host_volume_path

--- a/ollama.tf
+++ b/ollama.tf
@@ -11,6 +11,7 @@ module "ollama" {
   source     = "./modules/ollama"
   depends_on = [module.addons]
 
+  context          = module.platform_label.context
   enabled          = local.platform.services.ollama.enabled
   namespace        = kubernetes_namespace_v1.platform.metadata[0].name
   volume_base_path = var.host_volume_path

--- a/postgres.tf
+++ b/postgres.tf
@@ -8,6 +8,7 @@ module "postgres" {
   source     = "./modules/postgres"
   depends_on = [module.addons]
 
+  context          = module.platform_label.context
   enabled          = local.platform.services.postgres.enabled
   namespace        = kubernetes_namespace_v1.platform.metadata[0].name
   volume_base_path = var.host_volume_path

--- a/redis.tf
+++ b/redis.tf
@@ -7,6 +7,7 @@ module "redis" {
   source     = "./modules/redis"
   depends_on = [module.addons]
 
+  context          = module.platform_label.context
   enabled          = local.platform.services.redis.enabled
   namespace        = kubernetes_namespace_v1.platform.metadata[0].name
   volume_base_path = var.host_volume_path

--- a/vault.tf
+++ b/vault.tf
@@ -28,6 +28,7 @@ module "vault" {
   source     = "./modules/vault"
   depends_on = [module.addons, kubernetes_namespace_v1.platform]
 
+  context          = module.platform_label.context
   enabled          = local.platform.services.vault.enabled
   namespace        = kubernetes_namespace_v1.platform.metadata[0].name
   hostname         = local.platform.services.vault.hostname

--- a/zitadel.tf
+++ b/zitadel.tf
@@ -105,6 +105,7 @@ module "zitadel" {
   source     = "./modules/zitadel"
   depends_on = [module.addons, module.postgres]
 
+  context                   = module.platform_label.context
   enabled                   = local.platform.services.zitadel.enabled
   namespace                 = kubernetes_namespace_v1.platform.metadata[0].name
   postgres_host             = module.postgres.host


### PR DESCRIPTION
## Summary
- Final batch in the null-label propagation rollout — adopts `terraform-null-label` context chain across the remaining 9 modules (mysql, postgres, redis, ollama, vault, zitadel, stalwart, roundcube, longhorn).
- Each module: `var.context` input → `module "label"` chained off it → `local.tags` exposed → every k8s resource it owns gets labels via `merge(local.tags, { existing })`. Existing-wins on collision preserves selector-bound `app = "<X>"` labels.
- Root callsites in `mysql.tf` / `postgres.tf` / `redis.tf` / `ollama.tf` / `mail.tf` (stalwart + roundcube) / `vault.tf` / `zitadel.tf` / `longhorn.tf` pass `module.platform_label.context` through. Helm releases remain untouched (charts own their own labels).

## Plan check
`./tf plan` after the sweep:

```
Plan: 3 to add, 70 to change, 0 to destroy.
```

(The 3 adds are pre-existing pending Job re-creates from `module.backup` and `module.minio`, unrelated to this PR.) Zero destroy, zero replace — k8s metadata.labels mutations are pure in-place updates.

## Test plan
- [x] `terraform fmt -recursive` clean
- [x] `terraform validate` passes
- [x] Plan checkpoint after each module shows zero destroy/replace
- [ ] Apply on the live cluster — labels propagate to existing resources without churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)