### PR TITLE
fix(redis): haproxy tcp-check actually expands the AUTH password + checksum-driven rollouts

### DIFF
--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -473,7 +473,13 @@ resource "kubernetes_config_map_v1" "haproxy_config" {
       backend redis_back
         option tcp-check
         tcp-check connect
-        tcp-check send AUTH\ $${REDIS_PASSWORD}\r\n
+        # send-lf (log-format) expands %[env(VAR)] reliably; plain `send`
+        # with $${VAR} is NOT substituted in tcp-check argument context
+        # in haproxy 3.x, so the literal $${REDIS_PASSWORD} would hit
+        # valkey and AUTH-fail with WRONGPASS, marking every backend
+        # NOSRV. send-lf has no such caveat — it's the documented path
+        # for env-derived secret material in health-check sequences.
+        tcp-check send-lf AUTH\ %[env(REDIS_PASSWORD)]\r\n
         tcp-check expect string +OK
         tcp-check send PING\r\n
         tcp-check expect string +PONG
@@ -507,6 +513,20 @@ resource "kubernetes_deployment_v1" "haproxy" {
     template {
       metadata {
         labels = merge(local.tags, { app = "redis", component = "haproxy" })
+        annotations = {
+          # Re-roll haproxy when the AUTH password rotates. envFrom is
+          # read once at container start; without this, a Secret update
+          # leaves running haproxy pods with the stale password and
+          # AUTH-checks against valkey fail until manual restart.
+          "checksum/redis-default" = sha256(jsonencode(kubernetes_secret_v1.default["enabled"].data))
+          # Re-roll haproxy when the haproxy.cfg ConfigMap changes too
+          # — ConfigMap volume mounts auto-refresh on disk, but haproxy
+          # only reads the file once at process start; without a
+          # rollout trigger a config edit (e.g. tcp-check syntax fix)
+          # would silently sit in the ConfigMap with running pods on
+          # the stale config until manual restart.
+          "checksum/haproxy-config" = sha256(jsonencode(kubernetes_config_map_v1.haproxy_config["enabled"].data))
+        }
       }
 
       spec {


### PR DESCRIPTION
## Summary
Two latent engine bugs in `modules/redis` surfaced when an unrelated apply forced the haproxy Deployment to redeploy:

1. **`tcp-check send` does not expand env vars in haproxy 3.x.** The check sequence sent the literal string `\${REDIS_PASSWORD}` to valkey, which answered WRONGPASS. Every backend was marked DOWN and frontends served `<NOSRV>` (HAProxy `SC` flag) — tenants saw *"Error establishing a Redis connection"*. Replaced with `tcp-check send-lf AUTH %[env(REDIS_PASSWORD)]\r\n` (log-format expansion is the documented reliable path for env-derived secret material in checks).

2. **No rollout trigger on Secret / ConfigMap changes.** envFrom Secret values and ConfigMap volume mounts are read once at process start; haproxy never reloads them. Any password rotation or config edit would silently sit unused on running pods until manual restart. Added two `checksum/...` annotations on the haproxy pod template, sha256-keyed off the source Secret data and the ConfigMap data — TF re-rolls haproxy whenever either changes.

## Why bug 1 was invisible until now
HAProxy 3.x parses `\${VAR}` as raw text inside a `tcp-check send` argument. Most other haproxy directives expand it — `tcp-check send` is the exception. Earlier haproxy versions or different image flavours may have happened to expand it; bg jobs / matrixmedia work in the parent session caused a haproxy redeploy that exposed the bug for the first time.

## Verification (after `./tf apply` of this branch)
```
$ curl -sIo /dev/null -w 'http=%{http_code}\n' https://paseka.co
http=200

$ curl -s https://paseka.co | grep -i 'redis'
Performance optimized by Redis Object Cache. Learn more: https://wprediscache.com
Retrieved 3361 objects (448 КБ) from Redis using Predis (v2.4.0).
```
HAProxy backend status went from `redis_back/<NOSRV>` to `redis_back/valkey2` with real bytes transferred.

## Follow-ups (separate PRs)
Other shared services that envFrom an operator-managed Secret (mysql, postgres) should get the same checksum-annotation pattern.

## Test plan
- [x] `terraform fmt` clean
- [x] `terraform validate` passes
- [x] Plan: ConfigMap + Deployment in-place updates, 0 destroy
- [x] Apply on live cluster — haproxy rolled, AUTH succeeded, paseka.co serves 200, WP reports object-cache hits
- [x] Manual probe: `printf "AUTH \\\${REDIS_PASSWORD}\r\n" | nc valkey 6379` → WRONGPASS (confirms unsubstituted literal); `printf "AUTH <real-pwd>\r\n" | nc valkey 6379` → +OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)