### PR TITLE
feat(vault): post-init bootstrap + vault-config-operator + base CRDs (Phase 1)

### DIFF
--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -8,20 +8,39 @@ terraform {
       source  = "hashicorp/random"
       version = "~> 3.0"
     }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 3.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.14"
+    }
   }
 }
 
 # =============================================================================
-# Vault community — Phase 0: brings the server up + auto-unseals + emits root
-# token to a TF-managed Secret. No KV mounts, no auth methods, no policies.
+# Vault community — server, auto-unseal, and post-init configuration plumbing.
 # =============================================================================
 #
-# Phase 0 success: `services.vault.enabled: true` brings up a working
-# Vault you can log into in the UI as the root user (token from
-# `terraform output -raw vault_root_token`). Phase 1 (deferred PR)
-# wires the Zitadel JWT auth method + admin/operator policies. Phase
-# 2 introduces the Vault Secrets Operator + first migrated secret.
-# Phase 3 bulk-migrates the cheatsheet-bound TF outputs.
+# Phase 0 (live): server StatefulSet + raft single-node + bootstrap-Secret-
+# driven auto-unseal. Operator can log into the UI with the root token
+# (`terraform output -raw vault_root_token`). Nothing is mounted yet, no
+# auth methods enabled.
+#
+# Phase 1 (this module, current state): post-init bootstrap Job +
+# vault-config-operator Helm release + base CRDs (KV-v2 mount at `secret/`,
+# read-only policy `vso-tenant-read`, kubernetes-auth role for VSO). The
+# Job's only purpose is to give vault-config-operator's ServiceAccount
+# admin rights via Vault's kubernetes auth method; from there vco reconciles
+# every other Vault-side concern via CRDs.
+#
+# Phase 2 (next PR): Zitadel app for Vault + OIDC auth method (CR
+# `JWTOIDCAuthEngineConfig`) + per-tenant policies + per-tenant OIDC roles
+# (CRs derived from the engine's tenant list). The hashicorp/vault-secrets-
+# operator (VSO) Helm release lands here too, plus the engine integration
+# in `modules/project` that emits `VaultStaticSecret` instead of literal
+# `kubernetes_secret_v1` when `operator_secret_values[<x>] = { vault_path }`.
 #
 # Storage: built-in raft single-node (no external Postgres/Consul).
 # RocksDB-style on-disk store. hostPath PV survives pod replace and
@@ -95,6 +114,67 @@ locals {
       tls_disable = "true"
     }
   HCL
+
+  # Phase 1 bootstrap script — minimum needed before vault-config-operator
+  # can take over the rest of the configuration via CRDs:
+  #   1. Enable kubernetes auth method.
+  #   2. Configure it with the in-cluster API + this Job's SA JWT for
+  #      TokenReview.
+  #   3. Write a `vault-config-operator-admin` policy (full sudo on
+  #      every path — vco needs to manage mounts, auth methods, roles,
+  #      policies on the operator's behalf).
+  #   4. Bind the vco ServiceAccount to that policy via a kubernetes-
+  #      auth role.
+  # That's it. KV-v2 mount, VSO's read-only policy + role, OIDC auth
+  # method, per-tenant policies + roles — all become CRDs reconciled by
+  # vault-config-operator (next PR phase wires them).
+  #
+  # All operations idempotent: `auth enable` tolerates "path is already
+  # in use", `auth/.../config` and `policy write` and `auth/.../role/<x>`
+  # are PUT semantics so re-applies converge.
+  configure_script = <<-EOT
+    set -eu
+
+    export VAULT_TOKEN=$(cat /etc/vault-bootstrap/root-token)
+    if [ -z "$VAULT_TOKEN" ]; then
+      echo "[vault-bootstrap] ERROR: root token empty — bootstrap Secret not yet populated"
+      exit 1
+    fi
+
+    echo "[vault-bootstrap] waiting for vault unsealed+active..."
+    until vault status -format=json 2>/dev/null | grep -q '"sealed": false'; do
+      sleep 2
+    done
+    echo "[vault-bootstrap] vault active"
+
+    enable_ok() {
+      out=$(vault "$@" 2>&1) && return 0
+      echo "$out" | grep -q "path is already in use" && return 0
+      echo "$out" >&2
+      return 1
+    }
+
+    echo "[vault-bootstrap] enable + configure kubernetes auth"
+    enable_ok auth enable kubernetes
+    vault write auth/kubernetes/config \
+      kubernetes_host="https://kubernetes.default.svc.cluster.local" \
+      kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
+      token_reviewer_jwt=@/var/run/secrets/kubernetes.io/serviceaccount/token
+
+    echo "[vault-bootstrap] write vault-config-operator-admin policy"
+    vault policy write vault-config-operator-admin - <<'POLICY'
+    path "*" { capabilities = ["create","read","update","delete","list","sudo"] }
+    POLICY
+
+    echo "[vault-bootstrap] bind k8s role for vault-config-operator SA → admin policy"
+    vault write auth/kubernetes/role/vault-config-operator \
+      bound_service_account_names="${var.vault_config_operator_service_account}" \
+      bound_service_account_namespaces="${var.vault_config_operator_namespace}" \
+      policies=vault-config-operator-admin \
+      ttl=24h
+
+    echo "[vault-bootstrap] done — vault-config-operator can now take over via CRDs"
+  EOT
 }
 
 # -----------------------------------------------------------------------------
@@ -700,6 +780,278 @@ resource "kubernetes_job_v1" "vault_init" {
   timeouts {
     create = "5m"
   }
+}
+
+# -----------------------------------------------------------------------------
+# Phase 1 — vault_bootstrap Job
+#
+# Runs after vault_init, mounts the bootstrap Secret to read the root token,
+# performs the minimum configuration needed before vault-config-operator can
+# take over via CRDs:
+#   - Enables kubernetes auth method, configures it with the in-cluster API
+#     server URL + this Job's SA JWT (TokenReview path).
+#   - Writes the `vault-config-operator-admin` policy (full sudo).
+#   - Binds vault-config-operator's ServiceAccount to that policy through a
+#     kubernetes-auth role.
+#
+# Everything else (KV-v2 mount, VSO read-only policy, OIDC config, per-tenant
+# policies + OIDC roles) lives as kubectl_manifest-managed CRDs reconciled by
+# vault-config-operator — see CRD section below.
+#
+# RBAC: the Job uses the same `vault` ServiceAccount as the StatefulSet. That
+# SA also needs `system:auth-delegator` so Vault can call TokenReview against
+# JWTs presented by k8s-auth clients (vault-config-operator, VSO, ...).
+# -----------------------------------------------------------------------------
+
+resource "kubernetes_cluster_role_binding_v1" "vault_token_reviewer" {
+  for_each = local.instances
+
+  metadata {
+    name   = "vault-token-reviewer-${var.namespace}"
+    labels = local.tags
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "system:auth-delegator"
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account_v1.vault["enabled"].metadata[0].name
+    namespace = var.namespace
+  }
+}
+
+resource "kubernetes_job_v1" "vault_bootstrap" {
+  for_each = local.instances
+
+  depends_on = [
+    kubernetes_job_v1.vault_init,
+    kubernetes_cluster_role_binding_v1.vault_token_reviewer,
+  ]
+
+  metadata {
+    # Suffix forces a NEW Job on every input change — k8s Jobs are immutable
+    # post-create, so the only way to re-run on script change is a new name.
+    name      = "vault-bootstrap-${substr(sha256(local.configure_script), 0, 10)}"
+    namespace = var.namespace
+    labels = merge(local.tags, {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app"                          = "vault"
+    })
+  }
+
+  spec {
+    backoff_limit = 3
+    # Auto-cleanup completed Jobs after 10 minutes — keeps `kubectl get jobs`
+    # from accumulating one entry per apply over weeks.
+    ttl_seconds_after_finished = 600
+
+    template {
+      metadata {
+        labels = merge(local.tags, { job = "vault-bootstrap" })
+      }
+
+      spec {
+        restart_policy       = "Never"
+        service_account_name = kubernetes_service_account_v1.vault["enabled"].metadata[0].name
+
+        volume {
+          name = "bootstrap"
+          secret {
+            secret_name = kubernetes_secret_v1.vault_bootstrap["enabled"].metadata[0].name
+          }
+        }
+
+        container {
+          name = "bootstrap"
+          # Same image as the StatefulSet — has the `vault` CLI built in,
+          # avoids dragging in a separate image layer.
+          image = var.image
+
+          resources {
+            requests = { cpu = "10m", memory = "32Mi" }
+            limits   = { cpu = "200m", memory = "128Mi" }
+          }
+
+          volume_mount {
+            name       = "bootstrap"
+            mount_path = "/etc/vault-bootstrap"
+            read_only  = true
+          }
+
+          env {
+            name  = "VAULT_ADDR"
+            value = "http://vault.${var.namespace}.svc.cluster.local:8200"
+          }
+
+          command = ["sh", "-c", local.configure_script]
+        }
+      }
+    }
+  }
+
+  wait_for_completion = true
+
+  timeouts {
+    create = "5m"
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Phase 1 — vault-config-operator (RedHat-COP)
+#
+# Declarative Vault management via CRDs. After the bootstrap Job above gives
+# its ServiceAccount admin rights, vco logs into Vault via kubernetes auth
+# and reconciles every CRD this module emits below: SecretEngineMount, Policy,
+# KubernetesAuthEngineRole, JWTOIDCAuthEngineConfig, JWTOIDCAuthEngineRole.
+#
+# Repo + docs: https://github.com/redhat-cop/vault-config-operator
+#
+# Operator namespace is dedicated (`vault-config-operator`) so its RBAC and
+# leader-election lock don't tangle with the platform namespace.
+# -----------------------------------------------------------------------------
+
+resource "kubernetes_namespace_v1" "vault_config_operator" {
+  for_each = local.instances
+
+  metadata {
+    name   = var.vault_config_operator_namespace
+    labels = local.tags
+  }
+}
+
+resource "helm_release" "vault_config_operator" {
+  for_each = local.instances
+
+  depends_on = [kubernetes_namespace_v1.vault_config_operator]
+
+  name       = "vault-config-operator"
+  repository = "https://redhat-cop.github.io/vault-config-operator"
+  chart      = "vault-config-operator"
+  version    = var.vault_config_operator_chart_version
+  namespace  = kubernetes_namespace_v1.vault_config_operator["enabled"].metadata[0].name
+
+  values = [yamlencode({
+    # Default vault address vco uses for all CR reconcile calls.
+    vaultAddress = "http://vault.${var.namespace}.svc.cluster.local:8200"
+
+    # Run the operator's controller-manager pod with a stable name so the
+    # bootstrap Job's vault role binds reliably (the kubernetes-auth role
+    # references `<vault_config_operator_service_account>` literally).
+    serviceAccount = {
+      name = var.vault_config_operator_service_account
+    }
+  })]
+}
+
+# -----------------------------------------------------------------------------
+# Phase 1 — initial CRDs reconciled by vault-config-operator.
+#
+# Three CRs land:
+#   1. KubernetesAuthEngineConfig (no-op if the bootstrap Job already wrote it,
+#      but the CR makes the config part of the engine state too — vco will
+#      re-assert if Vault drifts).
+#   2. SecretEngineMount — KV-v2 at `secret/`.
+#   3. Policy `vso-tenant-read` — read on every tenant subtree.
+#   4. KubernetesAuthEngineRole `vso` — bind VSO's ServiceAccount to the
+#      read-only policy. (VSO Helm release lands in PR-B — the role just sits
+#      idle until then, harmless.)
+#
+# Per-tenant policies + roles + OIDC config live in PR-B (needs Zitadel app).
+# -----------------------------------------------------------------------------
+
+locals {
+  # Authentication block every CR shares — points at the kubernetes auth
+  # method enabled by the bootstrap Job, role `vault-config-operator`. vco
+  # picks this up, exchanges its SA JWT for a Vault token via that role,
+  # then performs the reconcile call.
+  vco_authentication = {
+    path = "kubernetes"
+    role = "vault-config-operator"
+  }
+
+  vco_connection = {
+    address = "http://vault.${var.namespace}.svc.cluster.local:8200"
+  }
+}
+
+resource "kubectl_manifest" "kv_v2_mount" {
+  for_each = local.instances
+
+  depends_on = [helm_release.vault_config_operator]
+
+  yaml_body = yamlencode({
+    apiVersion = "redhatcop.redhat.io/v1alpha1"
+    kind       = "SecretEngineMount"
+    metadata = {
+      name      = "kv-v2-secret"
+      namespace = kubernetes_namespace_v1.vault_config_operator["enabled"].metadata[0].name
+    }
+    spec = {
+      authentication = local.vco_authentication
+      connection     = local.vco_connection
+      path           = "" # mount AT secret (root of the path is `<name>` from metadata)
+      name           = "secret"
+      type           = "kv-v2"
+    }
+  })
+}
+
+resource "kubectl_manifest" "vso_read_policy" {
+  for_each = local.instances
+
+  depends_on = [helm_release.vault_config_operator]
+
+  yaml_body = yamlencode({
+    apiVersion = "redhatcop.redhat.io/v1alpha1"
+    kind       = "Policy"
+    metadata = {
+      name      = "vso-tenant-read"
+      namespace = kubernetes_namespace_v1.vault_config_operator["enabled"].metadata[0].name
+    }
+    spec = {
+      authentication = local.vco_authentication
+      connection     = local.vco_connection
+      policy         = <<-POLICY
+        path "secret/data/tenants/*"     { capabilities = ["read"] }
+        path "secret/metadata/tenants/*" { capabilities = ["read", "list"] }
+      POLICY
+    }
+  })
+}
+
+# VSO's kubernetes-auth role binding. References the SA that the upstream
+# `hashicorp/vault-secrets-operator` Helm chart creates by default — that
+# release lands in PR-B but the role can sit ahead of time, idle until VSO
+# pods come up and start using it.
+resource "kubectl_manifest" "vso_k8s_role" {
+  for_each = local.instances
+
+  depends_on = [
+    kubectl_manifest.vso_read_policy,
+    kubectl_manifest.kv_v2_mount,
+  ]
+
+  yaml_body = yamlencode({
+    apiVersion = "redhatcop.redhat.io/v1alpha1"
+    kind       = "KubernetesAuthEngineRole"
+    metadata = {
+      name      = "vso"
+      namespace = kubernetes_namespace_v1.vault_config_operator["enabled"].metadata[0].name
+    }
+    spec = {
+      authentication                 = local.vco_authentication
+      connection                     = local.vco_connection
+      path                           = "kubernetes"
+      targetServiceAccounts          = ["vault-secrets-operator-controller-manager"]
+      targetServiceAccountNamespaces = { matchLabels = { "kubernetes.io/metadata.name" = "vault-secrets-operator" } }
+      policies                       = ["vso-tenant-read"]
+      tokenTTL                       = 86400 # 24h, vault-side cap
+    }
+  })
 }
 
 # -----------------------------------------------------------------------------

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -53,3 +53,33 @@ variable "cpu_limit" {
   type    = string
   default = "1"
 }
+
+# -----------------------------------------------------------------------------
+# Phase 1 — bootstrap step that lets vault-config-operator take over.
+# The bootstrap Job (post-init, post-unseal) creates the minimum needed for
+# vault-config-operator to authenticate and start reconciling its CRDs:
+#   - kubernetes auth method enabled + configured
+#   - admin policy `vault-config-operator-admin`
+#   - kubernetes-auth role binding vco's ServiceAccount → admin policy
+# Everything else (KV-v2 mount, VSO read-only policy, OIDC auth method,
+# per-tenant policies + OIDC roles) lands as `kubectl_manifest`-managed CRDs
+# in subsequent PRs.
+# -----------------------------------------------------------------------------
+
+variable "vault_config_operator_namespace" {
+  description = "Namespace where vault-config-operator's ServiceAccount lives. The Phase 1 bootstrap Job pre-configures Vault's kubernetes auth method to trust this `<ns>:<sa>` so that vault-config-operator (installed via Helm release in this same module) can authenticate against Vault and reconcile its CRDs."
+  type        = string
+  default     = "vault-config-operator"
+}
+
+variable "vault_config_operator_service_account" {
+  description = "ServiceAccount name vault-config-operator authenticates with against Vault's kubernetes auth method. The Phase 1 bootstrap Job binds this SA to the `vault-config-operator-admin` policy via a kubernetes-auth role."
+  type        = string
+  default     = "vault-config-operator-controller-manager"
+}
+
+variable "vault_config_operator_chart_version" {
+  description = "Chart version for the vault-config-operator Helm release. Pinned so apply-at-time is deterministic; bump deliberately."
+  type        = string
+  default     = "0.8.48"
+}


### PR DESCRIPTION
## Summary
Phase 0 left Vault running but isolated (no auth methods, no mounts, no policies). This PR wires the minimum bootstrap so post-init Vault configuration becomes declarative via [vault-config-operator](https://github.com/redhat-cop/vault-config-operator) (vco) CRDs instead of growing a long bash-in-Job script.

After this lands:
- KV-v2 mount available at `secret/`.
- Path layout established: `secret/data/tenants/<tenant>/<secret-name>` is the home for any operator/tenant secret material.
- vault-config-operator running in a dedicated namespace, holds admin in Vault via kubernetes-auth.
- VSO read-only policy + role primed (VSO Helm release lands in the next PR — policy sits idle until then).

## Bootstrap Job (`vault-bootstrap`)
- Runs after `vault-init` populates the bootstrap Secret with the root token.
- Same `hashicorp/vault` image as the StatefulSet — no extra image layer.
- Native `vault` CLI for every operation; no JSON-escape wrangling for the SA CA cert / token reviewer JWT.
- Steps: enable kubernetes auth method → configure with in-cluster API + Job's SA JWT → write `vault-config-operator-admin` policy → bind vco's ServiceAccount to the policy via a kubernetes-auth role.
- Job name suffixed with `sha256(script)` so a script change triggers a new Job (k8s Jobs are immutable). `ttl_seconds_after_finished = 600` to keep `kubectl get jobs` clean.

## Why vault-config-operator over alternatives
- Active project (latest release 2026-04-19, main branch updated 2026-05-09).
- CRDs cover everything we need: `SecretEngineMount`, `Policy`, `KubernetesAuthEngineRole`, `JWTOIDCAuthEngineConfig`, `JWTOIDCAuthEngineRole`, etc.
- Avoids the `hashicorp/vault` Terraform provider (cascade-trap concern from prior decision).
- One Deployment + CRDs in a dedicated namespace — reasonable operational surface for a 1-operator shop.
- Reconcile loop re-asserts engine-managed state if Vault drifts.

The other options considered: hashicorp/vault TF provider (rejected), hashicorp/vault-helm `server.postStart` (every-restart-runs idempotency hell), Crossplane upbound/provider-vault (Upjet wrapper of the same rejected provider). vault-config-operator was the only one that fits.

## Initial CRDs reconciled by vco
- `SecretEngineMount kv-v2-secret` — KV-v2 at `secret/`.
- `Policy vso-tenant-read` — read on `secret/data/tenants/*`, list on metadata.
- `KubernetesAuthEngineRole vso` — binds VSO's ServiceAccount to the read-only policy.

## Plan
```
Plan: 10 to add, 15 to change, 0 to destroy.
```
(7 new vault-side resources + 3 unrelated Job re-creates picked up from prior drift; 0 destroy / 0 replace.)

## What's next (separate PR)
- Zitadel app for Vault (via existing `module.zitadel-app`).
- `JWTOIDCAuthEngineConfig` + per-tenant `Policy` + per-tenant `JWTOIDCAuthEngineRole` CRs (engine derives tenant list from domain yaml).
- `hashicorp/vault-secrets-operator` Helm release + cluster `VaultConnection` + `VaultAuth`.
- Engine `modules/project` integration: when `operator_secret_values[<x>] = { vault_path = "..." }`, emit `VaultStaticSecret` CR instead of literal `kubernetes_secret_v1` data.

## Test plan
- [x] `terraform fmt` clean
- [x] `terraform validate` passes
- [x] `terraform init` picks up new `helm` (~> 3.0) and `kubectl` providers
- [x] Plan: 10 add, 15 change, 0 destroy
- [ ] Apply on live cluster — bootstrap Job runs to completion, vco pod comes up Ready, all three CRDs land Reconciled
- [ ] Manual probe: `kubectl -n vault-config-operator get policies,secretenginemounts,kubernetesauthenginerole` shows all three with `RECONCILED=True`
- [ ] Vault UI: `secret/` mount visible in Secrets Engines list, `vso-tenant-read` policy visible in Policies, `kubernetes/role/vso` in Auth Methods → kubernetes → Roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)