### PR TITLE
fix(vault): enable cert-manager mode for vault-config-operator chart

### DIFF
--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -944,7 +944,23 @@ resource "helm_release" "vault_config_operator" {
     serviceAccount = {
       name = var.vault_config_operator_service_account
     }
+
+    # Provision serving certs for the operator's webhook + metrics
+    # endpoints via cert-manager. Without this the chart leaves
+    # `vault-config-operator-certs` and `webhook-server-cert` unfulfilled,
+    # the Deployment pod stays `ContainerCreating` on FailedMount, and
+    # the Helm release wedges on its Ready wait. The platform already
+    # runs cert-manager in `cert-manager` namespace via `module.addons`,
+    # so this just lights up the chart's built-in cert-manager
+    # Certificate templates.
+    enableCertManager = true
   })]
+
+  # Helm Ready-wait — without this the apply returns before the operator
+  # is up, and downstream `kubectl_manifest` CRDs land on a chart whose
+  # webhook isn't serving yet (admission rejects with "no endpoints").
+  wait    = true
+  timeout = 300
 }
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
PR #117 landed but its first apply tripped on the vault-config-operator chart's webhook + metrics serving certs being missing. The chart's \`enableCertManager\` defaults to false, leaving \`vault-config-operator-certs\` and \`webhook-server-cert\` Secrets unfulfilled — the operator pod stays ContainerCreating on FailedMount, and the Helm release wedges on its Ready wait until apply timeout fires.

cert-manager already runs in the platform via \`module.addons\`, so flipping \`enableCertManager: true\` in the chart values lights up its built-in cert-manager Certificate templates and the missing Secrets land automatically.

Also added \`wait = true\` + \`timeout = 300\` on the helm_release so the apply blocks until the operator + admission webhook are up. Without the wait, downstream \`kubectl_manifest\` CRDs would land while the webhook isn't serving and admission rejects them with "no endpoints".

## Recovery
The cluster's failed Helm release was cleaned with \`helm uninstall vault-config-operator -n vault-config-operator\` + \`kubectl delete ns vault-config-operator\` before this PR's apply.

## Test plan
- [x] \`terraform fmt\` clean
- [x] \`terraform validate\` passes
- [ ] Apply — Helm release reaches Ready, all 3 CRDs land Reconciled

🤖 Generated with [Claude Code](https://claude.com/claude-code)