### PR TITLE
fix(vault): correct KubernetesAuthEngineRole CRD shape for VSO role

### DIFF
--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -1059,13 +1059,18 @@ resource "kubectl_manifest" "vso_k8s_role" {
       namespace = kubernetes_namespace_v1.vault_config_operator["enabled"].metadata[0].name
     }
     spec = {
-      authentication                 = local.vco_authentication
-      connection                     = local.vco_connection
-      path                           = "kubernetes"
-      targetServiceAccounts          = ["vault-secrets-operator-controller-manager"]
-      targetServiceAccountNamespaces = { matchLabels = { "kubernetes.io/metadata.name" = "vault-secrets-operator" } }
-      policies                       = ["vso-tenant-read"]
-      tokenTTL                       = 86400 # 24h, vault-side cap
+      authentication        = local.vco_authentication
+      connection            = local.vco_connection
+      path                  = "kubernetes"
+      targetServiceAccounts = ["vault-secrets-operator-controller-manager"]
+      # CRD shape — single `targetNamespaces` parent with EITHER a
+      # `targetNamespaces` list OR a `targetNamespaceSelector` (mutually
+      # exclusive; admission webhook rejects both).
+      targetNamespaces = {
+        targetNamespaces = ["vault-secrets-operator"]
+      }
+      policies = ["vso-tenant-read"]
+      tokenTTL = 86400 # 24h, vault-side cap
     }
   })
 }


### PR DESCRIPTION
## Summary
The \`KubernetesAuthEngineRole\` CRD shipped by vault-config-operator nests namespace selection under a single \`targetNamespaces\` parent that takes EITHER a \`targetNamespaces\` list OR a \`targetNamespaceSelector\` (mutually exclusive — admission webhook enforces this).

PR #117 used a flat \`targetServiceAccountNamespaces\` selector field that doesn't exist in the CRD. Webhook rejected with:

\`\`\`
admission webhook "vkubernetesauthenginerole.kb.io" denied the request:
only one of TargetNamespaceSelector or TargetNamespaces can be specified
\`\`\`

Fixed by using the explicit list form: \`targetNamespaces.targetNamespaces = ["vault-secrets-operator"]\`.

## Test plan
- [x] terraform fmt + validate clean
- [ ] Apply — vso_k8s_role CR creates Reconciled

🤖 Generated with [Claude Code](https://claude.com/claude-code)