### PR TITLE
feat(vault): Phase 2 — Zitadel OIDC self-serve + per-tenant policies + VSO

### DIFF
--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -1076,6 +1076,266 @@ resource "kubectl_manifest" "vso_k8s_role" {
 }
 
 # -----------------------------------------------------------------------------
+# Phase 2 — Zitadel OIDC auth method.
+#
+# Renders three CRs reconciled by vault-config-operator:
+#   1. JWTOIDCAuthEngineConfig  → enables `oidc/` auth path, points it
+#      at Zitadel's discovery URL, plugs in the client_id/secret from
+#      the Vault Application created upstream via module.zitadel-app.
+#   2. Policy `operator`        → full sudo on every path. The break-
+#      glass equivalent of the root token, gated behind a Zitadel
+#      project role grant instead of the Secret-mounted root token.
+#   3. JWTOIDCAuthEngineRole `operator` → binds the operator policy to
+#      users whose id_token claims include `vault:operator`. Operator
+#      assigns this Zitadel project role to themselves once and signs
+#      into Vault UI via "Sign in with OIDC".
+#
+# Per-tenant policies + OIDC roles render in the for_each below.
+# -----------------------------------------------------------------------------
+
+locals {
+  oidc_instances = (var.enabled && var.oidc_enabled) ? toset(["enabled"]) : toset([])
+
+  # Vault UI's OIDC callback URL. Two callbacks for compatibility with
+  # both UI launch paths Vault uses across releases (`/ui/...` for
+  # current UI, root `/oidc/callback` for direct API redirects).
+  oidc_redirect_uris = [
+    "https://${var.hostname}/ui/vault/auth/oidc/oidc/callback",
+    "https://${var.hostname}/oidc/callback",
+  ]
+
+  # Set of tenant entries to project for_each over — empty when OIDC is
+  # off (per-tenant CRs only make sense with OIDC enabled).
+  tenant_set = (var.enabled && var.oidc_enabled) ? toset(var.tenants) : toset([])
+}
+
+# OIDC client_id + client_secret land in a Secret that vco's
+# JWTOIDCAuthEngineConfig CR references by Secret name. Engine emits the
+# Secret directly (vco operator namespace) so vco's reconcile loop can
+# pull it on demand without a CR-managed secret.
+resource "kubernetes_secret_v1" "vault_oidc" {
+  for_each = local.oidc_instances
+
+  metadata {
+    name      = "vault-oidc-client"
+    namespace = kubernetes_namespace_v1.vault_config_operator["enabled"].metadata[0].name
+    labels    = local.tags
+  }
+
+  data = {
+    client_id     = var.oidc_client_id
+    client_secret = var.oidc_client_secret
+  }
+}
+
+resource "kubectl_manifest" "oidc_config" {
+  for_each = local.oidc_instances
+
+  depends_on = [
+    helm_release.vault_config_operator,
+    kubernetes_secret_v1.vault_oidc,
+  ]
+
+  yaml_body = yamlencode({
+    apiVersion = "redhatcop.redhat.io/v1alpha1"
+    kind       = "JWTOIDCAuthEngineConfig"
+    metadata = {
+      name      = "oidc"
+      namespace = kubernetes_namespace_v1.vault_config_operator["enabled"].metadata[0].name
+    }
+    spec = {
+      authentication   = local.vco_authentication
+      connection       = local.vco_connection
+      path             = "oidc"
+      OIDCDiscoveryURL = var.oidc_issuer_url
+      OIDCCredentials = {
+        # vco shape: secret holding `client_id` + `client_secret` keys
+        # under data; vco resolves at reconcile time.
+        secret = {
+          name = kubernetes_secret_v1.vault_oidc["enabled"].metadata[0].name
+        }
+      }
+      defaultRole = "operator"
+    }
+  })
+}
+
+resource "kubectl_manifest" "operator_policy" {
+  for_each = local.oidc_instances
+
+  depends_on = [helm_release.vault_config_operator]
+
+  yaml_body = yamlencode({
+    apiVersion = "redhatcop.redhat.io/v1alpha1"
+    kind       = "Policy"
+    metadata = {
+      name      = "operator"
+      namespace = kubernetes_namespace_v1.vault_config_operator["enabled"].metadata[0].name
+    }
+    spec = {
+      authentication = local.vco_authentication
+      connection     = local.vco_connection
+      policy         = <<-POLICY
+        path "*" { capabilities = ["create", "read", "update", "delete", "list", "sudo"] }
+      POLICY
+    }
+  })
+}
+
+resource "kubectl_manifest" "operator_oidc_role" {
+  for_each = local.oidc_instances
+
+  depends_on = [
+    kubectl_manifest.oidc_config,
+    kubectl_manifest.operator_policy,
+  ]
+
+  yaml_body = yamlencode({
+    apiVersion = "redhatcop.redhat.io/v1alpha1"
+    kind       = "JWTOIDCAuthEngineRole"
+    metadata = {
+      name      = "operator"
+      namespace = kubernetes_namespace_v1.vault_config_operator["enabled"].metadata[0].name
+    }
+    spec = {
+      authentication      = local.vco_authentication
+      connection          = local.vco_connection
+      path                = "oidc"
+      name                = "operator"
+      userClaim           = "sub"
+      allowedRedirectURIs = local.oidc_redirect_uris
+      groupsClaim         = "urn:zitadel:iam:org:project:roles"
+      policies            = ["operator"]
+      boundClaimsType     = "string"
+      boundClaims = {
+        "urn:zitadel:iam:org:project:roles" = [var.oidc_operator_zitadel_role]
+      }
+      tokenTTL = 28800 # 8h
+    }
+  })
+}
+
+# Per-tenant policy + OIDC role. Engine derives `var.tenants` from the
+# upstream project list — every tenant namespace gets a free Vault
+# tenant. Policy grants RW on `secret/data/tenants/<name>/*`; the OIDC
+# role binds the matching `vault:tenant:<name>` Zitadel project role
+# claim to that policy. Operator grants the role to the tenant's
+# Zitadel user; tenant signs into Vault UI scoped to their subtree.
+
+resource "kubectl_manifest" "tenant_policy" {
+  for_each = local.tenant_set
+
+  depends_on = [helm_release.vault_config_operator]
+
+  yaml_body = yamlencode({
+    apiVersion = "redhatcop.redhat.io/v1alpha1"
+    kind       = "Policy"
+    metadata = {
+      name      = "tenant-${each.value}-rw"
+      namespace = kubernetes_namespace_v1.vault_config_operator["enabled"].metadata[0].name
+    }
+    spec = {
+      authentication = local.vco_authentication
+      connection     = local.vco_connection
+      policy         = <<-POLICY
+        path "secret/data/tenants/${each.value}/*"     { capabilities = ["create", "read", "update", "delete", "list"] }
+        path "secret/metadata/tenants/${each.value}/*" { capabilities = ["read", "list", "delete"] }
+        path "secret/data/tenants/${each.value}"       { capabilities = ["list"] }
+        path "secret/metadata/tenants/${each.value}"   { capabilities = ["list"] }
+      POLICY
+    }
+  })
+}
+
+resource "kubectl_manifest" "tenant_oidc_role" {
+  for_each = local.tenant_set
+
+  depends_on = [
+    kubectl_manifest.oidc_config,
+    kubectl_manifest.tenant_policy,
+  ]
+
+  yaml_body = yamlencode({
+    apiVersion = "redhatcop.redhat.io/v1alpha1"
+    kind       = "JWTOIDCAuthEngineRole"
+    metadata = {
+      name      = "tenant-${each.value}"
+      namespace = kubernetes_namespace_v1.vault_config_operator["enabled"].metadata[0].name
+    }
+    spec = {
+      authentication      = local.vco_authentication
+      connection          = local.vco_connection
+      path                = "oidc"
+      name                = "tenant-${each.value}"
+      userClaim           = "sub"
+      allowedRedirectURIs = local.oidc_redirect_uris
+      groupsClaim         = "urn:zitadel:iam:org:project:roles"
+      policies            = ["tenant-${each.value}-rw"]
+      boundClaimsType     = "string"
+      boundClaims = {
+        "urn:zitadel:iam:org:project:roles" = ["vault:tenant:${each.value}"]
+      }
+      tokenTTL = 28800 # 8h
+    }
+  })
+}
+
+# -----------------------------------------------------------------------------
+# Phase 2 — Vault Secrets Operator (VSO) + cluster-level VaultConnection
+# and VaultAuth.
+#
+# VSO consumes Vault paths via VaultStaticSecret CRs the engine emits in
+# tenant namespaces. The cluster-level VaultConnection + VaultAuth here
+# tell every VaultStaticSecret in the cluster how to reach Vault and
+# which auth backend / role to use; tenant CRs reference these by name.
+# -----------------------------------------------------------------------------
+
+resource "kubernetes_namespace_v1" "vso" {
+  for_each = (var.enabled && var.vso_enabled) ? toset(["enabled"]) : toset([])
+
+  metadata {
+    name   = var.vso_namespace
+    labels = local.tags
+  }
+}
+
+resource "helm_release" "vso" {
+  for_each = (var.enabled && var.vso_enabled) ? toset(["enabled"]) : toset([])
+
+  depends_on = [kubernetes_namespace_v1.vso]
+
+  name       = "vault-secrets-operator"
+  repository = "https://helm.releases.hashicorp.com"
+  chart      = "vault-secrets-operator"
+  version    = var.vso_chart_version
+  namespace  = kubernetes_namespace_v1.vso["enabled"].metadata[0].name
+
+  values = [yamlencode({
+    # Default cluster-level VaultConnection + VaultAuth — every
+    # VaultStaticSecret in the cluster picks these up unless it
+    # references named CRs explicitly. Saves emitting a
+    # VaultConnection per tenant namespace.
+    defaultVaultConnection = {
+      enabled = true
+      address = "http://vault.${var.namespace}.svc.cluster.local:8200"
+    }
+    defaultAuthMethod = {
+      enabled   = true
+      namespace = "*" # any namespace can use the default auth
+      method    = "kubernetes"
+      mount     = "kubernetes"
+      kubernetes = {
+        role           = "vso"
+        serviceAccount = "vault-secrets-operator-controller-manager"
+      }
+    }
+  })]
+
+  wait    = true
+  timeout = 300
+}
+
+# -----------------------------------------------------------------------------
 # Outputs
 # -----------------------------------------------------------------------------
 

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -83,3 +83,81 @@ variable "vault_config_operator_chart_version" {
   type        = string
   default     = "0.8.48"
 }
+
+# -----------------------------------------------------------------------------
+# Phase 2 — OIDC self-serve via Zitadel.
+# When OIDC is enabled, vco emits a JWTOIDCAuthEngineConfig pointing at
+# Zitadel, plus an admin role bound to the `vault:operator` Zitadel project
+# role and (optionally) one role per tenant bound to `vault:tenant:<name>`.
+# Operator and tenants log into Vault UI via "Sign in with OIDC" and land
+# scoped to their policy — no userpass, no manual token paste.
+# -----------------------------------------------------------------------------
+
+variable "oidc_enabled" {
+  description = "Enable Zitadel OIDC auth method on Vault. False keeps Vault root-token-only (operator break-glass; tenants cannot self-serve via UI). True needs `oidc_issuer_url`, `oidc_client_id`, `oidc_client_secret` populated — caller wires `module.zitadel-app` upstream and pipes the resulting client_id / client_secret here."
+  type        = bool
+  default     = false
+}
+
+variable "oidc_issuer_url" {
+  description = "Zitadel public issuer URL Vault uses for OIDC discovery (`<issuer>/.well-known/openid-configuration`). Same value passed to other OIDC consumers in the platform (oauth2-proxy, stalwart, etc). Required when `oidc_enabled = true`."
+  type        = string
+  default     = ""
+}
+
+variable "oidc_client_id" {
+  description = "Vault's Zitadel OIDC client_id. Caller creates the Zitadel Application via `module.zitadel-app` and pipes the resulting client_id here. Required when `oidc_enabled = true`."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "oidc_client_secret" {
+  description = "Vault's Zitadel OIDC client_secret. Sensitive. Caller pipes from `module.zitadel-app`. Required when `oidc_enabled = true`."
+  type        = string
+  default     = ""
+  sensitive   = true
+}
+
+variable "oidc_operator_zitadel_role" {
+  description = "Zitadel project role name granting full Vault admin access via OIDC. The Zitadel project role assertion lands as a claim in the id_token; vco's `JWTOIDCAuthEngineRole operator` matches users whose claims include this string and binds them to the `operator` policy (full sudo). Operator's own Zitadel user must hold this project role for SSO to land them on the admin UI."
+  type        = string
+  default     = "vault:operator"
+}
+
+variable "tenants" {
+  description = "Tenants getting their own `secret/data/tenants/<name>/*` Vault path + RW policy + OIDC role. Each entry is a short, DNS-safe name (used in the path, the policy name `tenant-<name>-rw`, and the OIDC role's `bound_claims`). The matching Zitadel project role is `vault:tenant:<name>` — operator grants that role to the relevant Zitadel user(s), they sign into Vault UI via OIDC and land scoped to their tenant subtree. Empty list = no tenant policies emitted (Vault stays operator-only via `oidc_operator_zitadel_role`). Engine derives this from `keys(local.projects)` upstream — every project namespace gets a Vault tenant for free."
+  type        = list(string)
+  default     = []
+  validation {
+    condition     = alltrue([for t in var.tenants : can(regex("^[a-z0-9][a-z0-9-]{0,38}[a-z0-9]$", t))])
+    error_message = "Each tenant name must be 2-40 chars, lowercase alphanumeric with internal hyphens. Used directly in Vault paths and policy names."
+  }
+}
+
+# -----------------------------------------------------------------------------
+# Phase 2 — Vault Secrets Operator (VSO).
+# Hashicorp's official VSO consumes Vault paths and materialises them as k8s
+# Secrets in tenant namespaces. The engine emits `VaultStaticSecret` CRs
+# pointing at `secret/data/tenants/<tenant>/<name>` paths; VSO syncs them
+# into the tenant namespace under the same Secret name as in the operator
+# config, keeping consumer charts (envFrom, etc) unchanged.
+# -----------------------------------------------------------------------------
+
+variable "vso_enabled" {
+  description = "Install hashicorp/vault-secrets-operator + cluster-level `VaultConnection` and `VaultAuth`. Required for the engine's `vault_path` mode in `operator_secret_values` to actually materialise k8s Secrets from Vault. Default false keeps the operator absent — engine vault_path entries would emit CRs that nothing reconciles, which is not useful."
+  type        = bool
+  default     = false
+}
+
+variable "vso_chart_version" {
+  description = "Chart version for hashicorp/vault-secrets-operator. Pinned so apply-time is deterministic; bump deliberately."
+  type        = string
+  default     = "0.10.0"
+}
+
+variable "vso_namespace" {
+  description = "Namespace VSO controller-manager + its k8s ServiceAccount live in. The Phase 1 bootstrap CRDs already configured a kubernetes-auth role for `vault-secrets-operator-controller-manager` in this namespace; changing this default requires also updating the matching CR target."
+  type        = string
+  default     = "vault-secrets-operator"
+}

--- a/vault.tf
+++ b/vault.tf
@@ -1,27 +1,69 @@
-# Vault community — platform secrets store, replacement for the
-# Infisical attempt that hit a paywall on OIDC SSO.
+# Vault community — platform secrets store.
 #
-# Phase 0 (this PR): module skeleton, raft single-node, hostPath PV,
-# init Job, postStart auto-unseal. Operator gets a working Vault UI
-# at `https://<hostname>` and a root token via
-# `terraform output -raw vault_root_token` for break-glass.
-#
-# Phase 1 (deferred): Zitadel JWT auth method via the `hashicorp/vault`
-# TF provider — `vault_jwt_auth_backend` + `vault_jwt_auth_backend_role`
-# mapping Zitadel `vault_admin` / `vault_operator` claims to Vault
-# policies. UI login page gets the "Sign in with OIDC" button. Phase 2
-# wires the Vault Secrets Operator + first migrated tenant secret.
-# See `BACKLOG.md` for the full roadmap.
-
-# Vault has its own internal store (raft), unlike Infisical which
-# needed Postgres + Redis. So no infrastructure prereq checks here
-# beyond hostname.
+# Architecture (read modules/vault/main.tf header for the full version):
+#   - Phase 0 (live): server StatefulSet, raft single-node, auto-unseal.
+#   - Phase 1 (live, PRs #117/#118/#119): post-init bootstrap Job +
+#     vault-config-operator + base CRDs (KV-v2 mount, VSO read-only
+#     policy + role).
+#   - Phase 2 (this file's wiring + module Phase 2 block): Zitadel app
+#     for Vault + OIDC auth method via vco CRDs + per-tenant policies +
+#     OIDC roles + hashicorp/vault-secrets-operator (VSO) install.
+#     After this lands operator + tenants log into Vault UI via Zitadel
+#     SSO, scoped to their policy; engine VaultStaticSecret CRs in
+#     tenant namespaces are reconciled by VSO into k8s Secrets.
 
 check "vault_hostname_set" {
   assert {
     condition     = !local.platform.services.vault.enabled || local.platform.services.vault.hostname != ""
     error_message = "services.vault.hostname must be set when vault is enabled (e.g. `vault.example.com`). Drives the IngressRoute Host(...) match. Add the matching `<prefix>: vault` route to your domain yaml so cloudflared sees the hostname through the same project-IngressRoute pipeline as Stalwart and oauth2-proxy."
   }
+}
+
+# Zitadel application for Vault — gives the OIDC auth method its
+# client_id / client_secret. Module emits a k8s Secret carrying the
+# OIDC env vars; we lift only client_id / client_secret out of the
+# module's outputs (Vault doesn't run as a SvelteKit app, so the
+# AUTH_ZITADEL_* envFrom convention isn't useful here — vco's
+# JWTOIDCAuthEngineConfig CR consumes a Secret in its own namespace
+# created by `module.vault`).
+module "vault_oidc" {
+  source     = "./modules/zitadel-app"
+  for_each   = local.platform.services.vault.enabled && local.platform.services.zitadel.enabled ? toset(["enabled"]) : toset([])
+  depends_on = [kubernetes_namespace_v1.platform]
+
+  providers = {
+    zitadel    = zitadel
+    kubernetes = kubernetes
+    random     = random
+  }
+
+  org_id       = local.platform.services.zitadel.enabled ? data.zitadel_orgs.platform_org["enabled"].ids[0] : ""
+  project_name = "vault"
+  app_name     = "vault"
+  issuer_url   = "https://${local.platform.services.zitadel.external_domain}"
+
+  # Vault's UI takes the OIDC provider's redirect under either of two
+  # callback paths depending on the launch route. Register both so the
+  # exact URL Vault sends matches in either case.
+  redirect_uris = [
+    "https://${local.platform.services.vault.hostname}/ui/vault/auth/oidc/oidc/callback",
+    "https://${local.platform.services.vault.hostname}/oidc/callback",
+  ]
+  # Vault doesn't drive a post-logout redirect anywhere meaningful;
+  # keep the list empty.
+  post_logout_uris = []
+  # Operator-side k8s Secret destination — lands in `platform`
+  # namespace alongside other zitadel-app secrets, but Vault itself
+  # consumes the OIDC creds via vco's CR-managed Secret in vco's
+  # namespace (see module.vault). This Secret stays as the canonical
+  # record of which OIDC client Vault is wired to.
+  secret_namespace = kubernetes_namespace_v1.platform.metadata[0].name
+  secret_name      = "vault-zitadel-oidc"
+  # Vault doesn't envFrom — vco's CR-managed Secret carries the
+  # client_id / client_secret in its own shape. Skip every prefab
+  # format; the canonical Secret here is just an audit record of
+  # which Zitadel client backs Vault.
+  secret_formats = []
 }
 
 module "vault" {
@@ -33,4 +75,24 @@ module "vault" {
   namespace        = kubernetes_namespace_v1.platform.metadata[0].name
   hostname         = local.platform.services.vault.hostname
   volume_base_path = var.host_volume_path
+
+  # Phase 2 — OIDC self-serve. Wired only when both Vault AND Zitadel
+  # are on; otherwise the module stays in Phase 1 shape (root-token
+  # only). Tenant list = every project namespace's slug — engine
+  # automatically gives every tenant a Vault path/policy/OIDC role
+  # (the role is dormant until the operator grants the matching
+  # `vault:tenant:<slug>` Zitadel project role to a user; nothing
+  # consumes the per-tenant `secret/data/tenants/<slug>/*` path until
+  # something is `vault kv put`'d there).
+  oidc_enabled       = local.platform.services.vault.enabled && local.platform.services.zitadel.enabled
+  oidc_issuer_url    = local.platform.services.zitadel.enabled ? "https://${local.platform.services.zitadel.external_domain}" : ""
+  oidc_client_id     = local.platform.services.vault.enabled && local.platform.services.zitadel.enabled ? module.vault_oidc["enabled"].client_id : ""
+  oidc_client_secret = local.platform.services.vault.enabled && local.platform.services.zitadel.enabled ? module.vault_oidc["enabled"].client_secret : ""
+  tenants            = sort([for p in values(local.projects) : p.slug])
+
+  # Phase 2 — VSO. Tied to vault.enabled (no separate config knob;
+  # VSO is part of the Vault story — installing it without Vault
+  # makes no sense, and operating Vault without it leaves the
+  # engine's vault_path mode broken).
+  vso_enabled = local.platform.services.vault.enabled
 }


### PR DESCRIPTION
## Summary
Phase 2 builds on the Phase 1 bootstrap (PRs #117/#118/#119, all merged + applied). After this lands the operator and every tenant log into Vault UI via Zitadel SSO scoped to their policy, and VSO is installed + ready to consume \`VaultStaticSecret\` CRs (engine-emit side comes in the next PR).

## What lands

### OIDC self-serve via Zitadel
- New \`module "vault_oidc"\` callsite in \`vault.tf\` — Zitadel application via the existing \`module.zitadel-app\`. Vault doesn't envFrom Auth.js conventions, so \`secret_formats = []\` skips the prefab env-name layouts; the canonical Secret in \`platform\` namespace is the audit record of which Zitadel client backs Vault.
- vco emits \`JWTOIDCAuthEngineConfig oidc\` against the Zitadel issuer, OIDC client creds in a vco-namespace Secret.
- vco emits \`Policy operator\` (full sudo) + \`JWTOIDCAuthEngineRole operator\` binding the policy to users carrying the \`vault:operator\` Zitadel project role claim.

Operator grants themselves the \`vault:operator\` Zitadel project role once and signs in via "Sign in with OIDC" on the Vault UI — full admin, no root token paste.

### Per-tenant policies + roles
\`tenants\` variable on the module; root derives the list from \`keys(local.projects)\` so every project namespace gets a Vault tenant for free. Per entry:
- \`Policy tenant-<slug>-rw\` — read+write on \`secret/data/tenants/<slug>/*\` and the matching metadata path.
- \`JWTOIDCAuthEngineRole tenant-<slug>\` — binds policy to users carrying the \`vault:tenant:<slug>\` Zitadel project role claim.

Roles are dormant until the operator grants the matching Zitadel project role to a user; nothing consumes the per-tenant Vault path until something is \`vault kv put\`'d there.

### VSO
hashicorp/vault-secrets-operator Helm release with cluster-level default \`VaultConnection\` (vault.platform.svc:8200) + \`VaultAuth\` (kubernetes-auth role \`vso\`, the same role the Phase 1 CRD already bound to the read-only policy). Toggled by \`local.platform.services.vault.enabled\` directly — no separate config knob; VSO is part of the Vault story.

## Plan
\`\`\`
Plan: 22 to add, 3 to change, 1 to destroy.
\`\`\`
- 22 add: 4 \`tenant_policy\` + 4 \`tenant_oidc_role\` (one per project) + OIDC config + operator policy/role + VSO ns/helm + Zitadel app artefacts + OIDC client Secret in vco namespace.
- 3 change: unrelated Job churn from prior drift.
- 1 destroy: \`module.minio.kubernetes_job_v1.buckets\` timestamp recreate (cosmetic Job churn, not data — known pattern).

## What's still missing
**Engine \`vault_path\` mode** in \`modules/project\` — separate PR. When an \`operator_secret_values[<name>]\` entry has the shape \`{ vault_path = "..." }\`, the engine should emit a \`VaultStaticSecret\` CR instead of literal \`kubernetes_secret_v1.data\`. After that PR lands the matrixmedia operator-supplied secrets can move from \`.env\` into Vault.

## Test plan
- [x] terraform fmt + validate clean
- [x] Plan: 22 add, 3 change, 1 destroy (cosmetic)
- [ ] Apply on cluster
- [ ] Vault UI reachable at https://vault.ipsupport.us
- [ ] Operator grants themselves Zitadel project role \`vault:operator\` → "Sign in with OIDC" lands on admin UI
- [ ] All 4 tenant Policy + OIDC role CRs land Reconciled in vco namespace
- [ ] VSO controller-manager pod Running

🤖 Generated with [Claude Code](https://claude.com/claude-code)