### PR TITLE
fix(vault): tokenTTL CRD types + drop VSO Vault-namespace field

### DIFF
--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -1070,7 +1070,9 @@ resource "kubectl_manifest" "vso_k8s_role" {
         targetNamespaces = ["vault-secrets-operator"]
       }
       policies = ["vso-tenant-read"]
-      tokenTTL = 86400 # 24h, vault-side cap
+      # KubernetesAuthEngineRole CRD wants seconds-as-int here (different
+      # from JWTOIDCAuthEngineRole CRD, which wants a duration string).
+      tokenTTL = 86400 # 24h
     }
   })
 }
@@ -1210,7 +1212,7 @@ resource "kubectl_manifest" "operator_oidc_role" {
       boundClaims = {
         "urn:zitadel:iam:org:project:roles" = [var.oidc_operator_zitadel_role]
       }
-      tokenTTL = 28800 # 8h
+      tokenTTL = "8h" # CRD requires duration string, not seconds int
     }
   })
 }
@@ -1275,7 +1277,7 @@ resource "kubectl_manifest" "tenant_oidc_role" {
       boundClaims = {
         "urn:zitadel:iam:org:project:roles" = ["vault:tenant:${each.value}"]
       }
-      tokenTTL = 28800 # 8h
+      tokenTTL = "8h" # CRD requires duration string, not seconds int
     }
   })
 }
@@ -1320,10 +1322,17 @@ resource "helm_release" "vso" {
       address = "http://vault.${var.namespace}.svc.cluster.local:8200"
     }
     defaultAuthMethod = {
-      enabled   = true
-      namespace = "*" # any namespace can use the default auth
-      method    = "kubernetes"
-      mount     = "kubernetes"
+      enabled = true
+      # `namespace` here is Vault's enterprise NAMESPACE feature
+      # (HCP/Enterprise only) — NOT a k8s namespace selector. On
+      # community Vault it must stay unset; the chart renders an
+      # unquoted bare `*` as a YAML alias and parsing dies (line 16:
+      # "did not find expected alphabetic or numeric character").
+      # Cross-namespace consumption of the default VaultAuth is
+      # implicit — VaultStaticSecret CRs in any namespace reference
+      # `default` by name and the operator resolves it.
+      method = "kubernetes"
+      mount  = "kubernetes"
       kubernetes = {
         role           = "vso"
         serviceAccount = "vault-secrets-operator-controller-manager"


### PR DESCRIPTION
## Summary
Three CRD-shape bugs from PR #121's first apply, fixed in follow-on apply iterations during debug. All three are already live on the cluster (Phase 2 is Reconciled); this PR just brings git in sync with the cluster state — no behavioural change on \`./tf apply\`.

1. **\`JWTOIDCAuthEngineRole.spec.tokenTTL\` requires duration string.** PR #121 sent \`28800\` int; admission webhook rejected with \`cannot unmarshal number into Go struct field ... of type string\`. Fixed \`operator\` + per-tenant OIDC roles to \`"8h"\`.

2. **\`KubernetesAuthEngineRole.spec.tokenTTL\` requires int (seconds).** My first Phase 2 fix flipped the VSO k8s-auth role to \`"24h"\` string by mistake — different CRD, opposite type from #1. Restored to \`86400\` with a clarifying comment.

3. **Drop \`helm_release.vso\` chart \`defaultAuthMethod.namespace = "*"\`.** That field is the Vault Enterprise NAMESPACE feature (HCP/Enterprise only), not k8s namespace selection. The chart template renders the bare \`*\` and the chart manifest fails to parse (\`line 16: did not find expected alphabetic or numeric character\`). On community Vault the field must stay unset; default VaultAuth stays cross-namespace-resolvable by name.

## Verification
\`\`\`
$ kubectl -n vault-config-operator get jwtoidcauthengineroles
NAME                        AGE
operator                    ...
tenant-ipsupport-us         ...
tenant-jagdterrier-club     ...
tenant-paseka-co            ...
tenant-priroda-kharkov-ua   ...

$ kubectl -n vault-secrets-operator get pods
NAME                                                        READY   STATUS
vault-secrets-operator-controller-manager-547747c87-...     2/2     Running
\`\`\`

## Test plan
- [x] terraform fmt + validate clean
- [x] Plan: 0 destroy, 0 replace, in-place no-op (cluster matches code already)

🤖 Generated with [Claude Code](https://claude.com/claude-code)