### PR TITLE
fix(vault): set vco CR authentication.serviceAccount.name explicitly

### DIFF
--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -987,6 +987,14 @@ locals {
   vco_authentication = {
     path = "kubernetes"
     role = "vault-config-operator"
+    # Without this, vco impersonates the CRD default SA (`default`), and
+    # Vault's k8s-auth role rejects with `service account name not
+    # authorized` because it only binds `controller-manager`. Setting
+    # this explicitly forces vco to TokenRequest a JWT for the SA the
+    # role accepts.
+    serviceAccount = {
+      name = var.vault_config_operator_service_account
+    }
   }
 
   vco_connection = {


### PR DESCRIPTION
## Summary
vco's CRD default for \`authentication.serviceAccount.name\` is \`default\` — vco issues a TokenRequest for the \`default\` SA in its namespace and logs into Vault with that JWT. The bootstrap Job binds \`controller-manager\` only, so every login was rejected with \`service account name not authorized\`. All 14 vco-managed CRs failed reconcile; Vault UI showed only the built-in cubbyhole + token + bootstrap kubernetes auth.

Confirmed by manual \`vault login\` with a JWT created for \`controller-manager\` SA — succeeded. So the role binding is right; vco just wasn't sending the matching SA's token.

Fix: explicit \`serviceAccount.name\` in the shared \`vco_authentication\` local. Every CR's authentication block now picks it up.

## Plan
\`\`\`
Plan: 3 to add, 17 to change, 1 to destroy.
\`\`\`
- 17 change: every vco CR (mount + policies + OIDC config + OIDC roles + k8s role) gets the new SA field
- 3 add: usual Job churn (Phase 1 bootstrap re-runs because script content changes)
- 1 destroy: minio.buckets timestamp Job cosmetic

After apply, vco reconciles all CRs in one cycle → Vault UI shows \`secret/\` mount + \`oidc/\` auth method + 6 policies + 5 OIDC roles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)