### PR TITLE
fix(vault): add AuthEngineMount CR to enable oidc/ before config + roles

### DIFF
--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -1138,12 +1138,37 @@ resource "kubernetes_secret_v1" "vault_oidc" {
   }
 }
 
+resource "kubectl_manifest" "oidc_auth_mount" {
+  for_each = local.oidc_instances
+
+  depends_on = [helm_release.vault_config_operator]
+
+  yaml_body = yamlencode({
+    apiVersion = "redhatcop.redhat.io/v1alpha1"
+    kind       = "AuthEngineMount"
+    metadata = {
+      name      = "oidc"
+      namespace = kubernetes_namespace_v1.vault_config_operator["enabled"].metadata[0].name
+    }
+    spec = {
+      authentication = local.vco_authentication
+      connection     = local.vco_connection
+      path           = "" # mount AT `oidc` (path of name)
+      name           = "oidc"
+      type           = "oidc"
+    }
+  })
+}
+
 resource "kubectl_manifest" "oidc_config" {
   for_each = local.oidc_instances
 
   depends_on = [
     helm_release.vault_config_operator,
     kubernetes_secret_v1.vault_oidc,
+    # JWTOIDCAuthEngineConfig writes to /v1/auth/oidc/config — only
+    # exists after AuthEngineMount enables `oidc/` first.
+    kubectl_manifest.oidc_auth_mount,
   ]
 
   yaml_body = yamlencode({


### PR DESCRIPTION
## Summary
After PR #126 unstuck vco's authentication, reconcile started succeeding but OIDC chain still failed: vco's \`JWTOIDCAuthEngineConfig\` writes to \`/v1/auth/oidc/config\` and per-tenant \`JWTOIDCAuthEngineRole\` writes to \`/v1/auth/oidc/role/<name>\`. Both require \`oidc/\` to be already enabled as an auth method. vco does NOT auto-enable on Config CR — that's a separate \`AuthEngineMount\` CR (auth-method equivalent of \`SecretEngineMount\` for KV-v2).

Result on cluster after PR #126 apply:
- \`secret/\` mount: ✅ (had \`SecretEngineMount kv-v2-secret\`)
- \`oidc/\` auth method: ❌ (no \`AuthEngineMount oidc\`)
- OIDC config + roles: 404 "no handler for route \"auth/oidc/...\""

Fix: add \`AuthEngineMount oidc\` CR (type=oidc, name=oidc → mounts at \`oidc/\`) ahead of the OIDC config via depends_on. Reconcile order becomes:
1. AuthEngineMount → mount appears
2. JWTOIDCAuthEngineConfig → config writes
3. JWTOIDCAuthEngineRole × 5 → roles bind

After apply, Vault UI shows \`oidc/\` in Auth Methods, OIDC sign-in button works, operator + tenants land on their policies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)