### PR TITLE
feat(argocd): per-tenant Vault-mode for repo deploy keys

### DIFF
--- a/argocd_repos.tf
+++ b/argocd_repos.tf
@@ -1,38 +1,50 @@
 # Argo CD repo credential Secrets.
 #
-# Generic mechanism: operator supplies SSH private keys via
-# `var.argocd_repo_ssh_keys` (map of `<id>` => PEM-encoded key).
-# Components with `kind: argocd_app` reference an entry by `id`
-# through the `repo_ssh_key_id:` field in their gitignored yaml. TF
-# collects unique (repo_url, ssh_key_id) pairs across all such
-# components and emits one Secret per pair in the Argo CD namespace,
-# shaped per Argo CD's repository-secret convention (label
-# `argocd.argoproj.io/secret-type: repository` + data {type, url,
-# sshPrivateKey}). Multiple components pointing at the same repo with
-# the same key reuse one Secret; different keys for the same URL get
-# distinct Secrets — Argo CD's match-by-URL semantics tolerate either.
+# Per-tenant model: each `argocd_bootstraps:` entry lives under a project
+# in the domain yaml; that project's `slug` (e.g. `ipsupport-us`) is the
+# tenant the deploy-key Secret is owned by. Two emit modes per
+# (url, ssh_key_id) pair, picked by the operator-provided
+# `var.argocd_repo_ssh_keys` map:
 #
-# Mirrors the existing `git_deploy_keys` mechanism (per-namespace
-# git-sync key Secrets) — same private key value can serve both if
-# the operator adds it as a deploy key on every consuming repo, but
-# the maps are separate so an operator can scope keys narrowly.
+#   1. **Vault** (default — operator did NOT add the key id to
+#      `var.argocd_repo_ssh_keys`). Engine emits a `VaultStaticSecret`
+#      CR pointing at `secret/data/tenants/<slug>/argocd-deploy-keys/<id>`.
+#      Tenant authenticates against Vault via Zitadel SSO with the
+#      `tenant_<slug>` role grant and writes the key under that path
+#      themselves (Vault UI: Secrets → secret/ → tenants/<slug>/argocd-deploy-keys/<id>
+#      with one data key `sshPrivateKey`). VSO syncs into a Secret in
+#      the Argo CD namespace; templating layers in the static
+#      `type=git` + `url=<repo_url>` fields the chart needs alongside
+#      the SSH key.
+#
+#   2. **Literal** (legacy — operator put the key value into
+#      `var.argocd_repo_ssh_keys[<id>]` via `TF_VAR_argocd_repo_ssh_keys`
+#      in `.env`). Engine emits the historical `kubernetes_secret_v1`
+#      with the data inlined. Path forward is to migrate every entry
+#      to mode 1 — keeps `.env` lean and lets tenants self-serve.
+#
+# Argo CD's match-by-URL semantics tolerate either shape — once the
+# Secret carries the right `url` + `sshPrivateKey`, repo pulls work.
 
 variable "argocd_repo_ssh_keys" {
-  description = "Operator-supplied map of `<id>` => SSH private key (PEM string). Bootstrap entries reference an id by `repo_ssh_key_id:` under the domain yaml's `argocd_bootstraps:` map. Empty map = no private repo support; bootstrap repos must be public. NOT marked sensitive at the variable level so `for_each` over keys works; the rendered Secret's `data` block is sensitive in state."
+  description = "LEGACY operator-supplied map of `<id>` => SSH private key (PEM string). Each id present here picks the literal-emit path: engine writes the value straight into a `kubernetes_secret_v1` in the Argo CD namespace. Empty map (default) pushes EVERY referenced `repo_ssh_key_id` into Vault-mode — engine emits a `VaultStaticSecret` instead, and the matching tenant uploads the key into Vault under `secret/data/tenants/<slug>/argocd-deploy-keys/<id>` themselves. New work should not add to this map; left in place for the migration window."
   type        = map(string)
   default     = {}
 }
 
 locals {
-  # (url, ssh_key_id) pairs across every project's `argocd_bootstraps:`
-  # map. Flattens project × bootstrap-entry; `distinct()` collapses
-  # duplicates so multiple envs / multiple bootstrap entries sharing
-  # one deploy repo produce one Secret.
+  # (slug, url, ssh_key_id) triples across every project's
+  # `argocd_bootstraps:` map. Slug is the project's tenant identity —
+  # determines the Vault path the deploy key lives at, and whose
+  # Zitadel role can write it. `distinct()` collapses duplicates so
+  # multiple envs / multiple bootstrap entries sharing one deploy
+  # repo produce one Secret per tenant.
   _argocd_app_repo_pairs = distinct(flatten([
     for _, project in local.projects : [
       for _, entry in try(project.argocd_bootstraps, {}) : {
         url        = try(entry.repo_url, "")
         ssh_key_id = try(entry.repo_ssh_key_id, "")
+        slug       = project.slug
       }
       if try(entry.repo_ssh_key_id, "") != "" && try(entry.repo_url, "") != ""
     ]
@@ -45,23 +57,21 @@ locals {
     for pair in local._argocd_app_repo_pairs :
     "${pair.ssh_key_id}-${substr(md5(pair.url), 0, 8)}" => pair
   }
-}
 
-# Precondition: every referenced ssh_key_id resolves in the operator's
-# var.argocd_repo_ssh_keys map. Surfaces as a clear plan-time error
-# instead of a sync-time `permission denied` from Argo CD's repo pull.
-check "argocd_repo_ssh_keys_resolved" {
-  assert {
-    condition = alltrue([
-      for pair in local._argocd_app_repo_pairs :
-      contains(keys(var.argocd_repo_ssh_keys), pair.ssh_key_id)
-    ])
-    error_message = "argocd_bootstraps entry references a `repo_ssh_key_id` not present in `var.argocd_repo_ssh_keys`. Referenced ids: ${jsonencode([for p in local._argocd_app_repo_pairs : p.ssh_key_id])}. Available ids: ${jsonencode(keys(var.argocd_repo_ssh_keys))}. Add the missing entry to `terraform.tfvars` (`argocd_repo_ssh_keys = { ... }`) or remove the `repo_ssh_key_id:` field from the domain yaml's argocd_bootstraps entry if the repo is public."
+  # Per-mode partition. Vault mode is implicit — any `repo_ssh_key_id`
+  # NOT present in `var.argocd_repo_ssh_keys` resolves via Vault.
+  argocd_repo_creds_literal = {
+    for k, v in local.argocd_repo_creds : k => v
+    if contains(keys(var.argocd_repo_ssh_keys), v.ssh_key_id)
+  }
+  argocd_repo_creds_vault = {
+    for k, v in local.argocd_repo_creds : k => v
+    if !contains(keys(var.argocd_repo_ssh_keys), v.ssh_key_id)
   }
 }
 
 resource "kubernetes_secret_v1" "argocd_repo" {
-  for_each = local.platform.services.argocd.enabled ? local.argocd_repo_creds : {}
+  for_each = local.platform.services.argocd.enabled ? local.argocd_repo_creds_literal : {}
 
   metadata {
     name      = "repo-${each.key}"
@@ -77,4 +87,72 @@ resource "kubernetes_secret_v1" "argocd_repo" {
     url           = each.value.url
     sshPrivateKey = var.argocd_repo_ssh_keys[each.value.ssh_key_id]
   }
+}
+
+# Vault mode requires VSO's consuming-namespace SA in the Argo CD ns —
+# VSO impersonates this SA when authenticating against Vault's k8s auth
+# method (see feedback_vso_impersonates_consuming_namespace_sa). Engine
+# emits the SA on demand: only when at least one repo cred is in vault
+# mode, no SA otherwise.
+resource "kubernetes_service_account_v1" "argocd_vso_proxy" {
+  count = local.platform.services.argocd.enabled && length(local.argocd_repo_creds_vault) > 0 ? 1 : 0
+
+  depends_on = [kubernetes_namespace_v1.argocd]
+
+  metadata {
+    name      = "vault-secrets-operator-controller-manager"
+    namespace = local.platform.services.argocd.namespace
+    labels = {
+      "app.kubernetes.io/managed-by" = "terraform"
+    }
+  }
+}
+
+resource "kubectl_manifest" "argocd_repo_vault" {
+  for_each = local.platform.services.argocd.enabled ? local.argocd_repo_creds_vault : {}
+
+  depends_on = [kubernetes_service_account_v1.argocd_vso_proxy]
+
+  yaml_body = yamlencode({
+    apiVersion = "secrets.hashicorp.com/v1beta1"
+    kind       = "VaultStaticSecret"
+    metadata = {
+      name      = "repo-${each.key}"
+      namespace = local.platform.services.argocd.namespace
+      labels = {
+        "app.kubernetes.io/managed-by" = "terraform"
+      }
+    }
+    spec = {
+      vaultAuthRef = ""
+      mount        = "secret"
+      type         = "kv-v2"
+      path         = "tenants/${each.value.slug}/argocd-deploy-keys/${each.value.ssh_key_id}"
+      destination = {
+        name   = "repo-${each.key}"
+        create = true
+        labels = {
+          "argocd.argoproj.io/secret-type" = "repository"
+        }
+        # VSO templating: combine the operator-provided `sshPrivateKey`
+        # from Vault with the engine-known static `type` + `url` so the
+        # rendered Secret matches Argo CD's repository-Secret schema.
+        # `excludeRaw` drops VSO's default `_raw` JSON dump (whole
+        # Vault response as one blob) — Argo CD's repo Secret schema
+        # has no place for it and extra fields confuse the SSH client
+        # (`_raw` showed up as the offending difference vs. legacy
+        # literal-mode Argo CD repo Secrets that work).
+        transformation = {
+          excludeRaw = true
+          excludes   = [".*"]
+          templates = {
+            type          = { text = "git" }
+            url           = { text = each.value.url }
+            sshPrivateKey = { text = "{{- get .Secrets \"sshPrivateKey\" -}}" }
+          }
+        }
+      }
+      refreshAfter = "30s"
+    }
+  })
 }


### PR DESCRIPTION
## Summary
Argo CD repo deploy keys flow through Vault now, instead of \`var.argocd_repo_ssh_keys\` literal map. Each \`argocd_bootstraps:\` entry's \`repo_ssh_key_id\` is resolved implicitly:

- If id NOT in \`var.argocd_repo_ssh_keys\` → engine emits \`VaultStaticSecret\` CR, path \`secret/data/tenants/<project_slug>/argocd-deploy-keys/<id>\`.
- If id IS in \`var.argocd_repo_ssh_keys\` (legacy) → engine emits literal \`kubernetes_secret_v1\`. Backcompat shim during migration.

## Per-tenant path
Project's slug (\`ipsupport-us\`, \`paseka-co\`, ...) owns its deploy keys subtree. Tenant authenticates via Zitadel SSO with the \`tenant_<slug>\` role grant and writes the key themselves — operator out of the loop after the initial Zitadel role grant.

## VSO templating
Vault stores only \`sshPrivateKey\`. Engine combines it with static \`type=git\` + \`url=<repo_url>\` via VSO's \`destination.transformation.templates\`. \`excludeRaw = true\` drops VSO's default \`_raw\` JSON blob (was breaking ArgoCD's repo Secret schema with an extra unrecognised field — confirmed during the matrixmedia bring-up).

## Engine additions
- \`kubernetes_service_account_v1.argocd_vso_proxy\` in argocd ns when at least one repo cred is in vault mode (consuming-namespace SA pattern).
- \`kubectl_manifest.argocd_repo_vault[<key>]\` per vault-mode entry.

## Verification (already on cluster)
\`\`\`
$ kubectl -n argocd get secret -l argocd.argoproj.io/secret-type=repository
NAME                             TYPE     DATA   AGE
repo-matrixmedia-e279d819        Opaque   3      27m
repo-sipmesh-8f51ecbb            Opaque   3      4m
repo-sipmesh-frontend-4068a509   Opaque   3      4m

$ kubectl -n argocd get vaultstaticsecret
NAME                             AGE
repo-matrixmedia-e279d819        30m
repo-sipmesh-8f51ecbb            4m
repo-sipmesh-frontend-4068a509   4m
\`\`\`

All three current deploy keys now flow through Vault. Operator's \`terraform.tfvars\` \`argocd_repo_ssh_keys\` was emptied to \`{}\` (gitignored, not part of this PR).

## Test plan
- [x] terraform fmt + validate
- [x] Apply (already done)
- [x] All three repo Secrets carry \`sshPrivateKey\` + \`type\` + \`url\` (no \`_raw\`)
- [x] SSH ls-remote against each repo succeeds (pubkey installed on GitHub side)

🤖 Generated with [Claude Code](https://claude.com/claude-code)