### PR TITLE
feat(security-scan): optional Telegram DM notification

### DIFF
--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -574,6 +574,16 @@ services:
     # snapshot_schedule: "0 4 * * 0"                 # default: Sunday 04:00 UTC
     # github_repo: rromenskyi/terraform-minikube-platform
     # branch_prefix: security-scan/snapshot          # branch the snapshot lives on (force-pushed each run)
+    #
+    # Optional Telegram DM notification on snapshot changes. Engine
+    # emits a second VaultStaticSecret pointing at the path below;
+    # operator places `bot_token` (BotFather string) + `chat_id`
+    # (numeric int) at that path. The CronJob's commit-pr step
+    # POSTs to Telegram Bot API after a successful PR open/refresh.
+    # Without these knobs (or empty Vault values) the script
+    # silently skips the curl — PR open is the only signal.
+    # telegram_notify_enabled: false
+    # telegram_vault_path: platform/telegram-bots/operator
 
   buildkitd:
     enabled: false

--- a/locals.tf
+++ b/locals.tf
@@ -114,6 +114,8 @@ locals {
         snapshot_schedule            = "0 4 * * 0"
         github_repo                  = "rromenskyi/terraform-minikube-platform"
         branch_prefix                = "security-scan/snapshot"
+        telegram_notify_enabled      = false
+        telegram_vault_path          = "platform/telegram-bots/operator"
       }
       backup = {
         enabled                = false

--- a/modules/security-scan/CHANGELOG.md
+++ b/modules/security-scan/CHANGELOG.md
@@ -21,3 +21,11 @@ the project itself follows [Semantic Versioning](https://semver.org/).
 - Snapshot scope is the platform-system namespaces only (allowlist
   hardcoded in `local.target_namespaces`); tenant project namespaces
   are out of v0 scope.
+- Optional Telegram DM notification on snapshot changes. When
+  `var.telegram_notify_enabled = true`, engine emits a second
+  VaultStaticSecret pointing at `var.telegram_vault_path`
+  (default `platform/telegram-bots/operator` with keys `bot_token` +
+  numeric `chat_id`). The commit-pr CronJob step POSTs to Telegram
+  Bot API after a successful PR open/refresh, with a one-line
+  link to the PR. Optional `secretKeyRef` so leaving the toggle
+  off (default) doesn't break container start.

--- a/modules/security-scan/main.tf
+++ b/modules/security-scan/main.tf
@@ -355,6 +355,41 @@ resource "kubectl_manifest" "github_pat_vault" {
   })
 }
 
+# Optional Telegram notification on snapshot changes. When the
+# operator places a bot's `bot_token` + `chat_id` (numeric) at
+# `secret/data/platform/telegram-bots/operator`, the CronJob's
+# commit-pr step DM's the operator with a one-line link to the PR
+# whenever the snapshot content changed. VSS only emitted when
+# `var.telegram_notify_enabled = true`; if disabled, the CronJob
+# step that consumes these env vars no-ops silently (no Secret to
+# bind, container starts fine, notification curl is skipped).
+resource "kubectl_manifest" "telegram_vault" {
+  for_each = (var.enabled && var.telegram_notify_enabled) ? toset(["enabled"]) : toset([])
+
+  depends_on = [kubernetes_service_account_v1.vso_proxy]
+
+  yaml_body = yamlencode({
+    apiVersion = "secrets.hashicorp.com/v1beta1"
+    kind       = "VaultStaticSecret"
+    metadata = {
+      name      = "security-scan-telegram"
+      namespace = kubernetes_namespace_v1.this["enabled"].metadata[0].name
+      labels    = local.tags
+    }
+    spec = {
+      vaultAuthRef = ""
+      mount        = "secret"
+      type         = "kv-v2"
+      path         = var.telegram_vault_path
+      destination = {
+        name   = "security-scan-telegram"
+        create = true
+      }
+      refreshAfter = "30s"
+    }
+  })
+}
+
 # ConfigMap carrying the two scripts the CronJob runs. defaultMode
 # 0755 in the volume mount so they're executable straight from the
 # mount.
@@ -455,6 +490,33 @@ resource "kubernetes_cron_job_v1" "snapshot" {
               env {
                 name  = "REPORT_PATH"
                 value = "inventory/cve-report.md"
+              }
+
+              # Telegram notification env. When the VSS-synced
+              # `security-scan-telegram` Secret is missing
+              # (telegram_notify_enabled = false), `optional: true`
+              # makes the env vars unset and the script's `[ -z
+              # "$TELEGRAM_BOT_TOKEN" ]` guard skips the curl call
+              # silently — no container start failure.
+              env {
+                name = "TELEGRAM_BOT_TOKEN"
+                value_from {
+                  secret_key_ref {
+                    name     = "security-scan-telegram"
+                    key      = "bot_token"
+                    optional = true
+                  }
+                }
+              }
+              env {
+                name = "TELEGRAM_CHAT_ID"
+                value_from {
+                  secret_key_ref {
+                    name     = "security-scan-telegram"
+                    key      = "chat_id"
+                    optional = true
+                  }
+                }
               }
 
               volume_mount {

--- a/modules/security-scan/scripts/commit-pr.sh
+++ b/modules/security-scan/scripts/commit-pr.sh
@@ -86,14 +86,42 @@ PR_RESPONSE=$(curl -sS -o /tmp/pr-resp.json -w '%%{http_code}' \
         --arg body  "$PR_BODY" \
         '{title: $title, head: $head, base: $base, body: $body}')")
 
+PR_URL=""
 if [ "$PR_RESPONSE" = "201" ]; then
-  jq -r '"Opened PR: " + .html_url' /tmp/pr-resp.json
+  PR_URL=$(jq -r '.html_url' /tmp/pr-resp.json)
+  echo "Opened PR: $PR_URL"
 elif [ "$PR_RESPONSE" = "422" ]; then
   # Either PR already open OR the head branch is identical to base.
   # Both fine — branch was force-pushed, existing PR refreshes.
   echo "PR not opened (422 — likely already exists for $BRANCH_PREFIX). Branch was force-pushed."
+  # Look up the existing open PR's URL so the Telegram message can
+  # link to it.
+  PR_URL=$(curl -fsSL \
+    -H "Authorization: token $GH_TOKEN" \
+    -H "Accept: application/vnd.github+json" \
+    "https://api.github.com/repos/${GH_REPO}/pulls?head=${GH_REPO%%/*}:${BRANCH_PREFIX}&state=open" \
+    | jq -r '.[0].html_url // empty')
 else
   echo "Unexpected response from GitHub API: HTTP $PR_RESPONSE"
   cat /tmp/pr-resp.json
   exit 1
+fi
+
+# Optional Telegram DM — only fires when the engine wired the
+# `security-scan-telegram` Secret in (telegram_notify_enabled = true)
+# AND the operator populated bot_token + chat_id in Vault. Empty
+# either var = silent skip; container exit code unaffected.
+if [ -n "${TELEGRAM_BOT_TOKEN:-}" ] && [ -n "${TELEGRAM_CHAT_ID:-}" ] && [ -n "$PR_URL" ]; then
+  ADDED=$(git diff HEAD~1 -- "$REPORT_PATH" 2>/dev/null | grep -c '^+|' || true)
+  REMOVED=$(git diff HEAD~1 -- "$REPORT_PATH" 2>/dev/null | grep -c '^-|' || true)
+  MSG=$(printf '🛡 *Platform CVE snapshot changed*\n\n%s lines added, %s removed in `%s`.\n\nPR: %s' \
+    "$ADDED" "$REMOVED" "$REPORT_PATH" "$PR_URL")
+  curl -fsS -o /dev/null \
+    -X POST \
+    "https://api.telegram.org/bot${TELEGRAM_BOT_TOKEN}/sendMessage" \
+    -d "chat_id=${TELEGRAM_CHAT_ID}" \
+    --data-urlencode "text=${MSG}" \
+    -d "parse_mode=Markdown" \
+    && echo "Telegram notification sent." \
+    || echo "Telegram notification failed (non-fatal — report still committed)."
 fi

--- a/modules/security-scan/variables.tf
+++ b/modules/security-scan/variables.tf
@@ -63,3 +63,15 @@ variable "branch_prefix" {
   type        = string
   default     = "security-scan/snapshot"
 }
+
+variable "telegram_notify_enabled" {
+  description = "Whether to DM the operator on Telegram when the snapshot content changed since last run. Requires the operator to have placed a bot's `bot_token` + numeric `chat_id` at `var.telegram_vault_path` in Vault. False (default) skips the VaultStaticSecret + the env wiring entirely; the CronJob runs without notification — PR open is the only signal."
+  type        = bool
+  default     = false
+}
+
+variable "telegram_vault_path" {
+  description = "Vault path (under `secret/data/...`, kv-v2 mount) holding the Telegram bot creds for snapshot notifications. Expected data keys: `bot_token` (the `<id>:<auth>` string from BotFather) and `chat_id` (numeric int — Bot API doesn't accept usernames for DMs, only channel `@names` or numeric chat IDs). Default path lives under `platform/telegram-bots/operator` to leave room for additional bots later. Has no effect when `var.telegram_notify_enabled = false`."
+  type        = string
+  default     = "platform/telegram-bots/operator"
+}

--- a/security_scan.tf
+++ b/security_scan.tf
@@ -20,4 +20,6 @@ module "security_scan" {
   snapshot_schedule            = local.platform.services.security_scan.snapshot_schedule
   github_repo                  = local.platform.services.security_scan.github_repo
   branch_prefix                = local.platform.services.security_scan.branch_prefix
+  telegram_notify_enabled      = local.platform.services.security_scan.telegram_notify_enabled
+  telegram_vault_path          = local.platform.services.security_scan.telegram_vault_path
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #136. Adds an optional Telegram DM notification path to the security-scan snapshot CronJob.

When `var.telegram_notify_enabled = true`, engine emits a second `VaultStaticSecret` pointing at `var.telegram_vault_path` (default `platform/telegram-bots/operator`). Operator places the bot's `bot_token` + numeric `chat_id` at that Vault path; VSO syncs into a `security-scan-telegram` k8s Secret. The commit-pr container reads both via `optional: true` `secretKeyRef` — when the toggle is off (default) and the Secret doesn't exist, env vars stay unset and the script silently skips the curl.

After a successful PR open or refresh, the script POSTs to Telegram Bot API with a one-line link to the PR plus the line-count diff stats. Notification failure is non-fatal — the PR remains the durable signal.

Disabled by default — landing this PR is a no-op apply.

## Operator setup (after merge)

1. Place the bot creds in Vault: `secret/data/platform/telegram-bots/operator` with three data keys: `bot_token` (BotFather string), `chat_id` (numeric int), and any other metadata (`allowed_users` etc. are ignored by this consumer but harmless to have).
2. Set `services.security_scan.telegram_notify_enabled: true` in `config/platform.yaml`.
3. `./tf apply`.

Note: numeric `chat_id` is required — Bot API doesn't accept usernames for DMs to users (only channel `@names`). Operator can look it up via `@userinfobot` on Telegram, or by inspecting any service that already has the chat_id stored from a previous Bot API interaction.

## Test plan

- [ ] Apply with `telegram_notify_enabled: false` (default) — zero diff
- [ ] Flip to `true`, apply — VSS materialises, Secret syncs, Cron container starts cleanly
- [ ] Manually trigger `kubectl create job --from=cronjob/security-scan-snapshot manual-1 -n security-scan` — operator gets a DM with the PR link

🤖 Generated with [Claude Code](https://claude.com/claude-code)