### PR TITLE
feat(cloudflare): per-zone DNSSEC engine knob (opt-in via domain yaml)

### DIFF
--- a/cloudflare_zones.tf
+++ b/cloudflare_zones.tf
@@ -1,0 +1,57 @@
+# Per-zone Cloudflare settings managed at the engine level.
+#
+# Zones themselves are NOT created by Terraform here — they pre-exist
+# in the operator's Cloudflare account and are referenced by
+# `cloudflare_zone_id` in each `config/domains/<name>.yaml`. The engine
+# only manages zone-level SETTINGS that are operator-policy decisions:
+# DNSSEC today, potentially TLS minimum / WAF posture / bot management
+# later.
+#
+# Opt-in per domain via `dnssec_enabled: true` on the domain yaml.
+# Default off — the engine does not flip DNSSEC on zones that haven't
+# explicitly asked. Disabling (removing the flag or setting false)
+# tears the resource down, which IS destructive — Cloudflare disables
+# the DNSSEC signing at the zone, parent-zone DS records would need
+# manual removal at the registrar.
+
+locals {
+  # Domains that opted into DNSSEC. Keyed by domain name for stable
+  # for_each (zone_ids are stable but less greppable in plan output).
+  _dnssec_zones = {
+    for name, cfg in local._domain_configs :
+    name => cfg.cloudflare_zone_id
+    if try(cfg.dnssec_enabled, false) && try(cfg.cloudflare_zone_id, "") != ""
+  }
+}
+
+# DNSSEC enable per opted-in zone. The provider resource is "make
+# DNSSEC active on this zone"; computed attributes (`digest`,
+# `key_tag`, `algorithm`, etc.) are exposed via the output below so
+# the operator can paste DS records into the registrar when the
+# registrar isn't Cloudflare itself.
+resource "cloudflare_zone_dnssec" "this" {
+  for_each = local._dnssec_zones
+
+  zone_id = each.value
+  status  = "active"
+}
+
+# DS records the operator submits to the parent registrar to chain
+# the DNSSEC trust. When the zone's registrar IS Cloudflare,
+# Cloudflare handles the parent-DS injection automatically and this
+# output is reference-only. When the registrar is external (Namecheap,
+# Porkbun, etc.), the operator copy-pastes from here into the
+# registrar's DNSSEC panel.
+output "cloudflare_dnssec_ds_records" {
+  description = "DS records per DNSSEC-enabled domain. Submit to the parent registrar (only needed when the registrar is NOT Cloudflare itself; Cloudflare-registered domains auto-chain). Keyed by domain name; each value carries the DS record fields the registrar UI expects (`key_tag`, `algorithm`, `digest_type`, `digest`)."
+  value = {
+    for name, _ in local._dnssec_zones :
+    name => {
+      key_tag     = cloudflare_zone_dnssec.this[name].key_tag
+      algorithm   = cloudflare_zone_dnssec.this[name].algorithm
+      digest_type = cloudflare_zone_dnssec.this[name].digest_type
+      digest      = cloudflare_zone_dnssec.this[name].digest
+      ds          = cloudflare_zone_dnssec.this[name].ds
+    }
+  }
+}

--- a/config/domains/example.com.yaml.example
+++ b/config/domains/example.com.yaml.example
@@ -9,6 +9,21 @@ name: example.com                              # Domain name (used in hostnames)
 slug: example-com                              # URL-safe slug (used in namespace names)
 cloudflare_zone_id: "your-zone-id-from-cf"     # Cloudflare Zone ID for this domain
 
+# (Optional) Enable DNSSEC on this zone. Engine emits a
+# `cloudflare_zone_dnssec` resource that flips the zone's DNSSEC
+# status to active. Default false — DNSSEC stays off.
+#
+# After apply, the operator submits DS records to the parent
+# registrar (only needed when the registrar is NOT Cloudflare itself;
+# Cloudflare-registered domains auto-chain). DS values are surfaced
+# via the platform output `cloudflare_dnssec_ds_records[<name>]`.
+#
+# Disabling (removing the flag or setting false) IS destructive —
+# tears down DNSSEC at the zone; parent DS records would need manual
+# removal at the registrar to avoid resolution breakage.
+#
+# dnssec_enabled: true
+
 # (Optional) Mail-stack opt-in. Exactly ONE domain across all
 # `config/domains/*.yaml` files should set `mail.primary: true` —
 # that domain becomes the home of the platform mail stack


### PR DESCRIPTION
## Summary

- New root-level `cloudflare_zones.tf` emits a `cloudflare_zone_dnssec` resource per domain that opts in via `dnssec_enabled: true` in its `config/domains/<name>.yaml`. Default off — engine does not touch DNSSEC on zones that have not explicitly asked.
- New top-level output `cloudflare_dnssec_ds_records` surfaces the DS record fields (key_tag, algorithm, digest_type, digest, full `ds` string) per opted-in domain — operator pastes those into the parent registrar's DNSSEC panel when the registrar is NOT Cloudflare itself (Cloudflare-registered domains auto-chain the parent DS injection and the output is reference-only).
- `config/domains/example.com.yaml.example` updated with the new `dnssec_enabled` field documentation.

## Scope

Zones themselves are NOT Terraform-managed by this patch — they pre-exist in the operator's Cloudflare account and are referenced by `cloudflare_zone_id` per domain yaml (same pattern existing tenant zones use). Only zone-level settings that are operator-policy decisions are managed here. DNSSEC today; TLS minimum / WAF posture / bot management may follow if a downstream consumer asks.

## Plan summary

`./tf plan -out=tfplan` against an operator config with three new `dnssec_enabled: true` domain yamls shows:

- 3 `cloudflare_zone_dnssec.this["<domain>"]` resources created (one per opted-in domain).
- Bootstrap-job re-creations + post-apply VaultStaticSecret drift unrelated to this PR.
- 0 destroy.

## Behavioural notes

- Disabling DNSSEC (removing the flag or setting `false` on a previously-opted-in domain) IS destructive — tears down DNSSEC at the zone; parent DS records would need manual removal at the registrar to avoid resolution breakage. Engine does NOT gate this with `prevent_destroy` (per the no-`lifecycle`-cost rule) — operator discretion.
- Output is computed-after-apply for fresh enables; the first `terraform output -json cloudflare_dnssec_ds_records` after apply returns the DS values ready to paste at the parent registrar.

## Test plan

- [ ] Merge
- [ ] `./tf plan -out=tfplan` → operator review → `./tf apply tfplan`
- [ ] `terraform output -json cloudflare_dnssec_ds_records | jq` returns DS records for opted-in domains
- [ ] `curl -H "Authorization: Bearer $CLOUDFLARE_API_TOKEN" https://api.cloudflare.com/client/v4/zones/<zone_id>/dnssec | jq .result.status` returns `active`
- [ ] (For non-Cloudflare-registered domains only) operator submits DS records to parent registrar

🤖 Generated with [Claude Code](https://claude.com/claude-code)
