### PR TITLE
fix(cluster-oidc): align IngressRoute + tunnel backend with platform CF Tunnel convention

### DIFF
--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -163,14 +163,16 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "main" {
         }
       ],
       # Platform-level public hostnames not bound to a tenant project
-      # (e.g. the cluster OIDC discovery endpoint). Backend always
-      # Traefik — these are engine-emitted IngressRoutes inside
-      # platform-owned namespaces. Empty list when no platform-level
-      # hostnames are enabled.
+      # (e.g. the cluster OIDC discovery endpoint). Backend = plain
+      # HTTP to Traefik on :80 — matches the platform-wide convention
+      # for tunnel-fronted hostnames (Cloudflare terminates TLS at the
+      # edge with its anycast cert; Traefik gets cleartext HTTP on the
+      # `web` entryPoint and routes to the engine-emitted IngressRoute).
+      # Empty list when no platform-level hostnames are enabled.
       local.platform.services.cluster_oidc.enabled && local.platform.services.cluster_oidc.external_hostname != "" ? [
         {
           hostname = local.platform.services.cluster_oidc.external_hostname
-          service  = "https://traefik.ingress-controller.svc:443"
+          service  = "http://traefik.ingress-controller.svc.cluster.local:80"
           origin_request = {
             origin_server_name = local.platform.services.cluster_oidc.external_hostname
             http2_origin       = false

--- a/cluster_oidc.tf
+++ b/cluster_oidc.tf
@@ -341,8 +341,15 @@ resource "kubectl_manifest" "cluster_oidc_ingressroute" {
         "app.kubernetes.io/component"  = "cluster-oidc-proxy"
       }
     }
+    # entryPoint `web` (plain HTTP, port 80) matches the platform-wide
+    # convention: Cloudflare Tunnel terminates TLS at the edge using
+    # its anycast certificate and forwards plain HTTP to Traefik.
+    # Traefik does not need to terminate TLS itself, so no `tls:`
+    # block and no certResolver — that path would require a per-host
+    # cert in cluster, which the operator does not manage for
+    # tunnel-fronted hostnames.
     spec = {
-      entryPoints = ["websecure"]
+      entryPoints = ["web"]
       routes = [
         {
           match = "Host(`${local.platform.services.cluster_oidc.external_hostname}`) && (Path(`/.well-known/openid-configuration`) || Path(`/openid/v1/jwks`))"
@@ -356,9 +363,6 @@ resource "kubectl_manifest" "cluster_oidc_ingressroute" {
           ]
         }
       ]
-      tls = {
-        certResolver = "letsencrypt"
-      }
     }
   })
 }


### PR DESCRIPTION
## Summary

The initial cluster_oidc PR (#150) put the IngressRoute on `websecure` with `certResolver: letsencrypt`, and pointed the tunnel ingress at `https://traefik:443`. Doesn't match the platform-wide convention for tunnel-fronted hostnames — Cloudflare terminates TLS at its edge using anycast certs and forwards plain HTTP to Traefik on the `web` entryPoint. Traefik does not run an ACME resolver for cluster-internal certs.

Result: GET on the public hostname returned 502 from Cloudflare because Traefik couldn't satisfy the IngressRoute's TLS requirement.

## Two-file fix

- **cluster_oidc.tf** — IngressRoute now `entryPoints: [web]`, no `tls:` block. Matches every other working IngressRoute (argocd, mail, sipmesh-*, etc.).
- **cloudflare.tf** — cluster_oidc tunnel ingress entry: `https://traefik:443` → `http://traefik.ingress-controller.svc.cluster.local:80`. Matches the format every other tunnel-fronted hostname already uses.

## Plan summary

- `cloudflare_zero_trust_tunnel_cloudflared_config.main` updated in-place — exactly one `service:` value changes, for the k8s-oidc hostname; no other entries touched.
- `kubectl_manifest.cluster_oidc_ingressroute["enabled"]` updated in-place — entryPoints + tls field.
- Rest is bootstrap-job re-creation noise unrelated to this PR.
- 0 destroy.

## Test plan

- [ ] Merge
- [ ] `./tf plan -out=tfplan` → operator review → `./tf apply tfplan`
- [ ] `curl -sS https://<external_hostname>/.well-known/openid-configuration` returns the discovery doc (200 + JSON, not 502)
- [ ] `curl -sS https://<external_hostname>/openid/v1/jwks` returns JWKS
- [ ] `curl -sS https://<external_hostname>/anything-else` returns 404 (from nginx, not Traefik)

🤖 Generated with [Claude Code](https://claude.com/claude-code)