### PR TITLE
feat(component, project): GCP Workload Identity Federation per-component opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,6 +414,16 @@ postgres: true                      # Provision PostgreSQL database + role
 redis: true                         # Provision Redis ACL user + key prefix
 ollama: true                        # Inject OLLAMA_HOST / OLLAMA_BASE_URL
 
+# Optional GCP Workload Identity Federation — pod gets a dedicated
+# ServiceAccount + projected SA-token volume + external_account
+# credential-config ConfigMap mount + GOOGLE_APPLICATION_CREDENTIALS
+# env var, so GCP SDKs auth via WIF (no JSON key) and impersonate
+# the named GCP SA. Requires `services.gcp_wif.pool_provider_audience`
+# set in platform.yaml and a matching `principalSet://` binding on
+# the GCP side (lives in whichever stack owns the GCP project IAM).
+gcp_wif:
+  gcp_service_account: app-runtime@my-gcp-project.iam.gserviceaccount.com
+
 # Map component env var names → keys in the `db-credentials` Secret
 env:
   WORDPRESS_DB_HOST: DB_HOST

--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -562,6 +562,30 @@ services:
     # host_overrides:
     #   relay.example.com: 10.x.x.x
 
+  gcp_wif:
+    # GCP Workload Identity Federation — cluster-wide audience the
+    # operator's GCP-side WIF pool provider expects in incoming
+    # projected SA token `aud` claims. Set once per cluster (one
+    # external IAM federation target); per-component opt-in via
+    # `gcp_wif:` on the component yaml supplies only the GCP SA
+    # email to impersonate.
+    #
+    # Engine prerequisite: `services.cluster_oidc.enabled: true` so
+    # the cluster's OIDC discovery + JWKS are publicly reachable for
+    # GCP STS to verify token signatures.
+    #
+    # GCP-side prerequisites (out of platform scope, lives in
+    # whichever Terraform stack owns the GCP project IAM):
+    #   - Workload Identity Pool + OIDC provider trusting the
+    #     cluster's issuer (`services.cluster_oidc.external_hostname`)
+    #   - Per-binding `roles/iam.workloadIdentityUser` on each GCP SA
+    #     for `principalSet://...subject/system:serviceaccount:<ns>:<sa>`
+    #
+    # Empty audience (default) disables WIF; component-level opt-in
+    # then fails a plan-time check.
+    #
+    # pool_provider_audience: "//iam.googleapis.com/projects/123456789/locations/global/workloadIdentityPools/k3s-cluster/providers/k3s-oidc"
+
   seafile:
     # Single-pod Seafile community edition — file storage with
     # library-based sync, OIDC SSO via Zitadel, behind the platform's

--- a/locals.tf
+++ b/locals.tf
@@ -114,6 +114,18 @@ locals {
         node_selector     = {}
         tolerations       = []
       }
+      # Cluster-wide constants for GCP Workload Identity Federation.
+      # `pool_provider_audience` must equal the full WIF pool provider
+      # path the operator configured GCP-side (the same string GCP STS
+      # validates against incoming projected SA token `aud` claims).
+      # One audience per cluster — per-binding parameterisation is not
+      # needed; the only per-component value is the impersonated GCP
+      # SA email, which lives on each component yaml under `gcp_wif:`.
+      # Disabled (empty audience) is the default; component-level
+      # opt-in fails a plan-time check when the audience is empty.
+      gcp_wif = {
+        pool_provider_audience = ""
+      }
       seafile = {
         enabled           = false
         namespace         = "seafile"
@@ -294,6 +306,7 @@ locals {
       buildkitd        = merge(local._platform_defaults.services.buildkitd, try(local._platform_services.buildkitd, {}))
       coredns          = merge(local._platform_defaults.services.coredns, try(local._platform_services.coredns, {}))
       cluster_oidc     = merge(local._platform_defaults.services.cluster_oidc, try(local._platform_services.cluster_oidc, {}))
+      gcp_wif          = merge(local._platform_defaults.services.gcp_wif, try(local._platform_services.gcp_wif, {}))
       seafile          = merge(local._platform_defaults.services.seafile, try(local._platform_services.seafile, {}))
       security_scan    = merge(local._platform_defaults.services.security_scan, try(local._platform_services.security_scan, {}))
     }

--- a/main.tf
+++ b/main.tf
@@ -216,6 +216,11 @@ module "project" {
   redis_helm_revision       = module.redis.helm_revision
   ollama_url                = module.ollama.url
 
+  # GCP Workload Identity Federation — cluster-wide audience the
+  # operator's WIF pool provider expects. Empty string disables
+  # component-level wiring (default).
+  gcp_wif_pool_provider_audience = local.platform.services.gcp_wif.pool_provider_audience
+
   # Zitadel — issuer URL is null when `services.zitadel.enabled = false`,
   # which trips the project-level check on any `kind: app` component
   # that opted into oidc. `zitadel_org_id` flows from the root-owned

--- a/modules/component/CHANGELOG.md
+++ b/modules/component/CHANGELOG.md
@@ -7,6 +7,22 @@ the project itself follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **GCP Workload Identity Federation knobs (`gcp_wif_credential_configmap_name`
+  / `gcp_wif_audience`).** When the caller passes a non-null ConfigMap
+  name, the deployment pod gets: a dedicated ServiceAccount (so the
+  GCP-side `principalSet://...subject/system:serviceaccount:<ns>:<sa>`
+  binding resolves to ONLY this component, not the namespace's shared
+  `default` SA); a projected `serviceAccountToken` volume at
+  `/var/run/secrets/gcp/tokens/token` with the caller-supplied audience;
+  a ConfigMap mount at `/var/run/secrets/gcp/creds` carrying
+  `credential-config.json`; and `GOOGLE_APPLICATION_CREDENTIALS` env
+  var pointing at that file. GCP SDKs auto-detect the external-account
+  flow and impersonate the GCP SA without any static credential.
+  Defaults are null/empty — existing components are unaffected.
+  ServiceAccount creation gate (`local.sa_instances`) now fires on
+  either `cluster_role_rules` non-empty OR WIF opt-in.
+
 ### Changed
 - File layout split into `main.tf` / `variables.tf` / `outputs.tf` per AGENT.md
   module conventions. Pure file reorganisation — no resource, input, output, or

--- a/modules/component/main.tf
+++ b/modules/component/main.tf
@@ -52,6 +52,20 @@ locals {
   # accidentally match) and not inside an `@`-separated digest.
   rbac_instances = length(var.cluster_role_rules) > 0 ? toset(["enabled"]) : toset([])
 
+  # GCP Workload Identity Federation: pod opts in via a non-null
+  # credential-config ConfigMap name from the caller. Drives the
+  # projected-token volume, the ConfigMap mount, and the env var
+  # consumed by GCP SDKs. Validated at the top of the file so a
+  # missing audience surfaces at plan time, not at apply.
+  gcp_wif_instances = var.gcp_wif_credential_configmap_name != null ? toset(["enabled"]) : toset([])
+
+  # Pod gets a dedicated ServiceAccount when EITHER it needs RBAC for
+  # in-cluster k8s API calls (cluster_role_rules) OR it opts into GCP
+  # WIF (the principalSet:// binding on the GCP side resolves against
+  # the specific `<ns>:<sa>` pair — sharing the namespace `default`
+  # SA would broaden the binding to every pod in the ns).
+  sa_instances = (length(var.cluster_role_rules) > 0 || var.gcp_wif_credential_configmap_name != null) ? toset(["enabled"]) : toset([])
+
   effective_image_pull_policy = (
     var.image_pull_policy != null
     ? var.image_pull_policy
@@ -174,7 +188,7 @@ resource "kubernetes_config_map_v1" "files" {
 # `<namespace>-<component>` so they don't collide cluster-wide.
 
 resource "kubernetes_service_account_v1" "this" {
-  for_each = local.rbac_instances
+  for_each = local.sa_instances
 
   metadata {
     name      = var.name
@@ -245,10 +259,12 @@ resource "kubernetes_deployment_v1" "this" {
       }
 
       spec {
-        # Custom SA when cluster_role_rules is non-empty; default SA
-        # otherwise. K8s defaults to "default" SA in the namespace —
-        # leaving service_account_name unset preserves that.
-        service_account_name = length(var.cluster_role_rules) > 0 ? kubernetes_service_account_v1.this["enabled"].metadata[0].name : null
+        # Custom SA when the component needs RBAC (cluster_role_rules)
+        # OR opts into GCP WIF (gcp_wif_credential_configmap_name) —
+        # see local.sa_instances. K8s defaults to "default" SA when
+        # unset, which is the historical behaviour for components
+        # opting into neither.
+        service_account_name = length(local.sa_instances) > 0 ? kubernetes_service_account_v1.this["enabled"].metadata[0].name : null
 
         # Pod placement: node_selector, tolerations, affinity. All
         # default to empty so this block is a no-op for existing
@@ -562,6 +578,19 @@ resource "kubernetes_deployment_v1" "this" {
             }
           }
 
+          # GCP WIF — single env var that points GCP SDKs at the
+          # mounted external_account credential-config.json. Mounts
+          # for the file + the projected SA token volume are added
+          # under volume_mounts further down; the projected SA token
+          # volume itself is added under pod.spec.volume.
+          dynamic "env" {
+            for_each = local.gcp_wif_instances
+            content {
+              name  = "GOOGLE_APPLICATION_CREDENTIALS"
+              value = "/var/run/secrets/gcp/creds/credential-config.json"
+            }
+          }
+
           # Random-value env vars — one key per entry in the component's
           # `env_random:` list (e.g. WEBUI_SECRET_KEY). Values persist in
           # terraform state across applies. Emitted as explicit `env`
@@ -667,6 +696,27 @@ resource "kubernetes_deployment_v1" "this" {
               name       = "git-content"
               mount_path = volume_mount.value.mount
               sub_path   = "current"
+              read_only  = true
+            }
+          }
+
+          # GCP WIF — token (projected serviceAccountToken) +
+          # credential-config (ConfigMap). Both read-only; GCP SDK
+          # opens the token file fresh on every STS refresh (kubelet
+          # rotates the projected token in place ahead of expiry).
+          dynamic "volume_mount" {
+            for_each = local.gcp_wif_instances
+            content {
+              name       = "gcp-wif-token"
+              mount_path = "/var/run/secrets/gcp/tokens"
+              read_only  = true
+            }
+          }
+          dynamic "volume_mount" {
+            for_each = local.gcp_wif_instances
+            content {
+              name       = "gcp-wif-creds"
+              mount_path = "/var/run/secrets/gcp/creds"
               read_only  = true
             }
           }
@@ -822,6 +872,40 @@ resource "kubernetes_deployment_v1" "this" {
           content {
             name = "git-content"
             empty_dir {}
+          }
+        }
+
+        # GCP WIF — projected serviceAccountToken with the audience
+        # the operator's WIF pool provider expects. Kubelet rotates
+        # the token in place ahead of expiry; GCP SDKs re-read the
+        # file on STS exchange.
+        dynamic "volume" {
+          for_each = local.gcp_wif_instances
+          content {
+            name = "gcp-wif-token"
+            projected {
+              sources {
+                service_account_token {
+                  audience           = var.gcp_wif_audience
+                  expiration_seconds = 3600
+                  path               = "token"
+                }
+              }
+            }
+          }
+        }
+
+        # GCP WIF — credential-config.json ConfigMap mount. Caller
+        # (modules/project) renders the ConfigMap with the
+        # `external_account` GCP SDK shape; component just mounts
+        # it.
+        dynamic "volume" {
+          for_each = local.gcp_wif_instances
+          content {
+            name = "gcp-wif-creds"
+            config_map {
+              name = var.gcp_wif_credential_configmap_name
+            }
           }
         }
 

--- a/modules/component/variables.tf
+++ b/modules/component/variables.tf
@@ -120,6 +120,18 @@ variable "oidc_secret_name" {
   default     = null
 }
 
+variable "gcp_wif_credential_configmap_name" {
+  description = "Name of the ConfigMap carrying the GCP external_account `credential-config.json` for this component. Null = component is not opted into GCP Workload Identity Federation (the default). When set, the engine: (1) creates a dedicated ServiceAccount for the pod (so the `principalSet://...subject/system:serviceaccount:<ns>:<sa>` binding on the GCP side resolves to ONLY this component, not the namespace's shared `default` SA); (2) mounts a projected `serviceAccountToken` volume at `/var/run/secrets/gcp/tokens/token` with the audience supplied via `var.gcp_wif_audience`; (3) mounts the ConfigMap at `/var/run/secrets/gcp/creds`; (4) sets `GOOGLE_APPLICATION_CREDENTIALS=/var/run/secrets/gcp/creds/credential-config.json` so any GCP SDK auto-detects the external-account flow. Caller (`modules/project`) emits the ConfigMap and passes its name here; the audience must match the WIF pool provider the operator configured GCP-side."
+  type        = string
+  default     = null
+}
+
+variable "gcp_wif_audience" {
+  description = "Audience the projected ServiceAccount token is minted with when the component opts into GCP WIF (`var.gcp_wif_credential_configmap_name` set). Must equal the full `//iam.googleapis.com/projects/<NUMBER>/locations/global/workloadIdentityPools/<POOL>/providers/<PROVIDER>` path that the GCP-side WIF pool provider expects in the `aud` claim. Empty string is invalid when `gcp_wif_credential_configmap_name` is non-null; caller validates upstream."
+  type        = string
+  default     = ""
+}
+
 variable "pod_annotations" {
   description = "Pod-template annotations rendered under `spec.template.metadata.annotations`. Primary use: a `checksum/<name>` entry whose value is a hash of an envFrom-mounted Secret's contents — when the Secret rotates, the annotation flips, and the Deployment rolls out so the pod picks up the new env. K8s does NOT rollout pods on Secret change by itself (envFrom values are read at process start), so anything that drives env from an externally-rotatable Secret (Zitadel OIDC client, etc.) needs this. Caller computes the hash and passes it here."
   type        = map(string)

--- a/modules/project/CHANGELOG.md
+++ b/modules/project/CHANGELOG.md
@@ -7,6 +7,19 @@ the project itself follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **GCP Workload Identity Federation per-component opt-in.** New variable
+  `gcp_wif_pool_provider_audience` (cluster-wide audience string). When
+  any component yaml under this project has `gcp_wif.gcp_service_account:
+  <email>` set, the engine emits a `<component>-gcp-wif-credential-config`
+  ConfigMap in the project namespace with the GCP SDK `external_account`
+  shape (audience from the new variable, impersonation URL from the
+  component's GCP SA email) and wires `gcp_wif_credential_configmap_name`
+  + `gcp_wif_audience` into `modules/component`, which renders the
+  projected SA token volume + mounts + GOOGLE_APPLICATION_CREDENTIALS
+  env. Plan-time check fails if any component opts in but the audience
+  is empty. Components not opted in are unaffected.
+
 ### Changed
 - File layout split into `main.tf` / `variables.tf` / `outputs.tf` per AGENT.md
   module conventions. Pure file reorganisation — no resource, input, output, or

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -262,6 +262,16 @@ locals {
     for _, c in local.normalized_components : try(c.ollama, false)
   ]) || try(var.shared_services.ollama, false)
 
+  # Components that opt into GCP Workload Identity Federation. Keyed
+  # by component name → the GCP ServiceAccount email the projected
+  # k8s SA token will impersonate via the WIF principalSet binding
+  # (that binding itself lives in the GCP-side TF, not here).
+  gcp_wif_components = {
+    for name, c in local.normalized_components :
+    name => try(c.gcp_wif.gcp_service_account, "")
+    if try(c.gcp_wif, null) != null && try(c.gcp_wif.gcp_service_account, "") != ""
+  }
+
   # Routed through `terraform-null-label` (same module already adopted
   # by chart_oidc + postgres extras) so naming rules are uniform across
   # the engine. The output `module.label.id` is `<namespace>` with
@@ -384,6 +394,13 @@ check "ollama_enabled_when_needed" {
   assert {
     condition     = !local.needs_ollama || var.ollama_url != null
     error_message = "project '${local.namespace}' has a component with `ollama: true` but `services.ollama` is disabled in config/platform.yaml. Either enable Ollama or drop `ollama: true` from the component spec."
+  }
+}
+
+check "gcp_wif_audience_set_when_needed" {
+  assert {
+    condition     = length(local.gcp_wif_components) == 0 || var.gcp_wif_pool_provider_audience != ""
+    error_message = "project '${local.namespace}' has component(s) with `gcp_wif.gcp_service_account` set (${join(", ", keys(local.gcp_wif_components))}) but `services.gcp_wif.pool_provider_audience` is empty in config/platform.yaml. Either set the audience (`//iam.googleapis.com/projects/<NUMBER>/locations/global/workloadIdentityPools/<POOL>/providers/<PROVIDER>`) or drop `gcp_wif:` from the component spec(s)."
   }
 }
 
@@ -981,6 +998,49 @@ resource "kubernetes_secret_v1" "ollama_endpoint" {
   }
 }
 
+# ── GCP Workload Identity Federation — per-component credential-config ConfigMap
+#
+# When a component yaml has `gcp_wif.gcp_service_account: <email>`,
+# the engine emits a ConfigMap whose `credential-config.json` is the
+# GCP SDK `external_account` shape. The Pod mounts it at
+# `/var/run/secrets/gcp/creds/credential-config.json` (handled in
+# `modules/component`) and the SDK reads `GOOGLE_APPLICATION_CREDENTIALS`
+# = that path, auto-exchanges the projected k8s SA token at GCP STS,
+# impersonates the GCP SA, and starts calling GCP APIs.
+#
+# The audience (full WIF pool provider path) is operator-supplied
+# cluster-wide via `services.gcp_wif.pool_provider_audience`. Only
+# the GCP SA email varies per-component.
+#
+# GCP-side principalSet binding (which k8s SA may impersonate which
+# GCP SA) is NOT engine-managed — it lives in whichever Terraform
+# stack owns the GCP project IAM.
+resource "kubernetes_config_map_v1" "gcp_wif_credential_config" {
+  for_each = local.gcp_wif_components
+
+  metadata {
+    name      = "${each.key}-gcp-wif-credential-config"
+    namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels    = module.project_label.tags
+  }
+
+  data = {
+    "credential-config.json" = jsonencode({
+      type                              = "external_account"
+      audience                          = var.gcp_wif_pool_provider_audience
+      subject_token_type                = "urn:ietf:params:oauth:token-type:jwt"
+      token_url                         = "https://sts.googleapis.com/v1/token"
+      service_account_impersonation_url = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${each.value}:generateAccessToken"
+      credential_source = {
+        file = "/var/run/secrets/gcp/tokens/token"
+        format = {
+          type = "text"
+        }
+      }
+    })
+  }
+}
+
 # ── Operator-defined Secrets (per-env `secrets:` block) ───────────────────────
 #
 # Three modes per entry, picked by yaml shape:
@@ -1429,6 +1489,15 @@ module "component" {
   ollama_secret_name = try(each.value.ollama, false) && local.needs_ollama ? (
     values(kubernetes_secret_v1.ollama_endpoint)[0].metadata[0].name
   ) : null
+
+  # GCP Workload Identity Federation — pass the per-component
+  # ConfigMap name + the cluster-wide audience. Both stay null/""
+  # for components that did not opt in, which collapses every
+  # related resource in modules/component to zero.
+  gcp_wif_credential_configmap_name = contains(keys(local.gcp_wif_components), each.key) ? (
+    kubernetes_config_map_v1.gcp_wif_credential_config[each.key].metadata[0].name
+  ) : null
+  gcp_wif_audience = contains(keys(local.gcp_wif_components), each.key) ? var.gcp_wif_pool_provider_audience : ""
 
   # OIDC Secret wiring — two ways the component can opt in:
   #

--- a/modules/project/variables.tf
+++ b/modules/project/variables.tf
@@ -85,6 +85,12 @@ variable "ollama_url" {
   default     = null
 }
 
+variable "gcp_wif_pool_provider_audience" {
+  description = "Cluster-wide WIF audience (`//iam.googleapis.com/projects/<NUMBER>/locations/global/workloadIdentityPools/<POOL>/providers/<PROVIDER>`) used in both the projected SA token's `aud` claim AND in the rendered `credential-config.json` for every component opted into GCP Workload Identity Federation via `gcp_wif.gcp_service_account` on its component yaml. Empty string disables WIF wiring; component-level opt-in then fails a plan-time check. Sourced from `services.gcp_wif.pool_provider_audience` at the root."
+  type        = string
+  default     = ""
+}
+
 variable "zitadel_org_id" {
   description = "Zitadel org id where `kind: app` components auto-provision projects + applications. Caller resolves at root via `data \"zitadel_orgs\" \"platform_org\"` and passes the value down. Owning the data source at root rather than inside this module avoids the apply-time defer that propagates as `must be replaced` on every downstream resource whenever any consumer module declares `depends_on = [module.zitadel]`."
   type        = string


### PR DESCRIPTION
## Summary

Adds a generic engine knob that turns ~30 lines of pod-spec boilerplate (projected SA token volume + credential-config ConfigMap + `GOOGLE_APPLICATION_CREDENTIALS` env + mounts) into a two-line component-yaml entry:

```yaml
# in any operator-side component yaml under config/components/
kind: deployment
image: ...
gcp_wif:
  gcp_service_account: app@my-project.iam.gserviceaccount.com
```

Cluster-wide constants live under a new `services.gcp_wif:` block in `config/platform.yaml`:

```yaml
services:
  gcp_wif:
    pool_provider_audience: "//iam.googleapis.com/projects/<NUMBER>/locations/global/workloadIdentityPools/<POOL>/providers/<PROVIDER>"
```

## What the engine does when a component opts in

- **`modules/project`** emits a per-component `<name>-gcp-wif-credential-config` ConfigMap rendering the GCP SDK `external_account` shape (audience from `services.gcp_wif.pool_provider_audience`, impersonation URL derived from the component's `gcp_wif.gcp_service_account`).
- **`modules/component`** creates a dedicated ServiceAccount for the pod (so the GCP-side `principalSet://...subject/system:serviceaccount:<ns>:<sa>` binding resolves to ONLY this component, not the namespace's shared `default` SA), mounts the ConfigMap, mounts a projected SA-token volume with the operator audience, and sets `GOOGLE_APPLICATION_CREDENTIALS=/var/run/secrets/gcp/creds/credential-config.json`.
- Plan-time check fails if any component opts in but the cluster-wide audience is empty.

## What the engine does NOT do

- **GCP-side `principalSet` binding** (`google_service_account_iam_member` or equivalent). That belongs to whichever Terraform stack owns the GCP project IAM and the WIF pool/provider — not the platform.
- **WIF pool / provider creation.** Same — operator owns IAM upstream.
- **Per-namespace ConfigMap sharing.** Each opted-in component gets its own `<name>-gcp-wif-credential-config`; trivial cost, easier reasoning than a shared / per-(ns, gcp-sa) scheme.

## Prerequisite already in place

`services.cluster_oidc.enabled = true` so the cluster's OIDC discovery + JWKS are publicly reachable for GCP STS signature verification — shipped in PRs #150 / #151.

## Files

```
modules/component/{main.tf, variables.tf, CHANGELOG.md}
modules/project/{main.tf, variables.tf, CHANGELOG.md}
main.tf                         # wire variable from local.platform.services.gcp_wif to module.project
locals.tf                       # defaults block + merge
config/platform.yaml.example    # operator-facing docs of services.gcp_wif
README.md                       # component yaml docs: gcp_wif: knob example
```

## Plan summary

Pure engine change — **zero functional diff** for any operator config that doesn't have `gcp_wif:` on any component. Plan against the current operator config shows only the usual idempotent-job drift noise; no new resources.

A consumer-side smoke test (a single Deployment with `gcp_wif:` set) would produce:

- 1 new `kubernetes_config_map_v1.gcp_wif_credential_config[<name>]`
- 1 new `kubernetes_service_account_v1.this["enabled"]` (now also created on WIF opt-in, not just `cluster_role_rules`)
- The Deployment's pod spec gains volume + mounts + env (in-place, on the Deployment's existing diff)

## Test plan

- [ ] Merge
- [ ] `./tf plan -out=tfplan` against current operator config → no new resources (only the usual idempotent-job drift)
- [ ] Operator opts in one consumer component (e.g. via the lineoneagent-infra handoff's recommended pattern), sets `services.gcp_wif.pool_provider_audience` in platform.yaml, applies
- [ ] Pod comes up Ready with the projected token + ConfigMap mounted
- [ ] Inside the pod: `cat $GOOGLE_APPLICATION_CREDENTIALS` returns the external_account JSON
- [ ] GCP SDK call (`gcloud auth list` or any API request) authenticates as the impersonated GCP SA without a JSON key

🤖 Generated with [Claude Code](https://claude.com/claude-code)
