### PR TITLE
feat(redirect-domain): zone-wide in-cluster 308 via Traefik

### DIFF
--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -179,6 +179,22 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "main" {
           }
         }
       ] : [],
+      # Redirect-domain hostnames (apex + `*.<domain>`) per
+      # `redirect_to:` in domain yamls. Same backend as cluster_oidc —
+      # cleartext to Traefik on :80; the engine-emitted IngressRoute
+      # (`modules/redirect-domain`) matches by Host + HostRegexp and
+      # serves a 301 via RedirectRegex middleware before any service
+      # dispatch.
+      [
+        for hostname, cfg in local.redirect_tunnel_hostnames : {
+          hostname = hostname
+          service  = cfg.service
+          origin_request = {
+            origin_server_name = hostname
+            http2_origin       = false
+          }
+        }
+      ],
       # Catch-all (required by Cloudflare — must be the last entry,
       # match-anything by omitting `hostname`).
       [{
@@ -192,7 +208,11 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "main" {
 
 resource "cloudflare_dns_record" "tunnel" {
   for_each = {
-    for hostname, cfg in merge(local.all_hostnames, local.tunnel_argocd_hostnames) :
+    for hostname, cfg in merge(
+      local.all_hostnames,
+      local.tunnel_argocd_hostnames,
+      local.redirect_tunnel_hostnames,
+    ) :
     hostname => cfg
     if cfg.zone_id != null
   }

--- a/config/domains/example.com.yaml.example
+++ b/config/domains/example.com.yaml.example
@@ -24,6 +24,21 @@ cloudflare_zone_id: "your-zone-id-from-cf"     # Cloudflare Zone ID for this dom
 #
 # dnssec_enabled: true
 
+# (Optional) Zone-wide 301 redirect to a canonical target. When set,
+# the engine emits a Traefik IngressRoute + RedirectRegex Middleware
+# (via `modules/redirect-domain`) and folds the apex + `*.<this>`
+# hostnames into the Cloudflare Tunnel + DNS CNAME machinery so
+# requests reach Traefik. Path + query preserved. Status 301.
+#
+# A redirect-only domain typically carries ONLY name/slug/zone_id/
+# dnssec/redirect_to — `envs`, `mail`, `dns` etc are unrelated to
+# this concern and shouldn't be set on the source zone.
+#
+# When CF is dropped later (direct A-records on public IPs), the same
+# IngressRoute keeps serving — only the DNS layer flips.
+#
+# redirect_to: new.example.com
+
 # (Optional) Mail-stack opt-in. Exactly ONE domain across all
 # `config/domains/*.yaml` files should set `mail.primary: true` —
 # that domain becomes the home of the platform mail stack

--- a/modules/redirect-domain/CHANGELOG.md
+++ b/modules/redirect-domain/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this module are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+the project itself follows [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- Initial module: zone-wide permanent HTTP redirect to a canonical
+  target, served by Traefik in-cluster (RedirectRegex Middleware +
+  IngressRoute matching apex + wildcard via Host + HostRegexp). Two
+  K8s resources, no Service, no pod — Traefik handles the 308 on the
+  wire before any service dispatch. Path + query preserved.
+  CHANGELOG / README / variables / outputs all included per AGENT.md
+  module conventions.

--- a/modules/redirect-domain/README.md
+++ b/modules/redirect-domain/README.md
@@ -1,0 +1,79 @@
+# `redirect-domain`
+
+Zone-wide HTTP 308 (permanent) redirect to a canonical target, served
+by Traefik in-cluster.
+Two K8s resources, no Service, no pod — Traefik does the redirect on
+the wire. Survives a Cloudflare exit unchanged: when DNS flips from
+CF Tunnel CNAME to a direct A-record at the platform's public IP, the
+same IngressRoute keeps serving.
+
+## What it emits
+
+1. `traefik.io/v1alpha1/Middleware` (`redirect-<from-slug>`) — a
+   `redirectRegex` middleware (`permanent: true`) capturing the path
+   with `^https?://[^/]+/(.*)` and rebuilding to
+   `https://<to_domain>/${1}`. Wire status code is HTTP 308 (Traefik's
+   canonical for `permanent`); browsers and search engines treat it
+   identically to 301 for canonicalization. Query string preserved
+   automatically by Traefik on redirect.
+2. `traefik.io/v1alpha1/IngressRoute` (`redirect-<from-slug>`) — matches
+   `Host(<from>) || HostRegexp(^.+\.<from>$)` on the `web` entryPoint,
+   attaches the middleware, points services at the Traefik built-in
+   `noop@internal` (never reached — the middleware returns 301 before
+   service dispatch).
+
+Both resources live in `ingress-controller` (the platform's Traefik
+namespace) by default.
+
+## Inputs
+
+- `from_domain` — bare apex (e.g. `old.example.com`).
+- `to_domain` — bare apex of the canonical target (e.g. `new.example.com`).
+- `namespace` — defaults to `ingress-controller`.
+- `labels` — propagated to both manifests; usually the platform's
+  null-label tag set from the caller.
+
+## Outputs
+
+- `ingressroute_name` — for cross-reference in `kubectl get ingressroute`.
+
+## Required upstream wiring (NOT this module's job)
+
+For requests to actually reach Traefik, the source domain has to route
+to the platform. Today, via Cloudflare Tunnel:
+
+1. DNS — apex + wildcard CNAME on the source zone pointed at the
+   tunnel's `<uuid>.cfargotunnel.com`. Proxied.
+2. cloudflared ingress — entries matching `<from_domain>` and
+   `*.<from_domain>` routed to `http://traefik.ingress-controller.svc.cluster.local:80`.
+
+The platform engine handles both in `cloudflare.tf` by reading the
+domain yaml's `redirect_to:` field and folding apex + wildcard into the
+existing tunnel ingress + DNS CNAME for_each machinery.
+
+## Typical use
+
+Operator-side yaml (engine wiring in `redirect_domains.tf` filters
+domain configs that carry a top-level `redirect_to:` field):
+
+```yaml
+# config/domains/old.example.com.yaml
+name: old.example.com
+slug: old-example-com
+cloudflare_zone_id: "<zone-id-from-cf>"
+dnssec_enabled: true
+
+redirect_to: new.example.com
+```
+
+That alone is enough — engine instantiates this module for every
+opted-in domain.
+
+## Why path + query preservation matters
+
+A naive `Location: https://canonical/` 301 throws away the user's URL.
+The regex captures everything after the host and rebuilds the path on
+the new origin; Traefik passes the query string through on the
+redirect. So
+`https://old.example.com/some/deep/page?utm_source=x` lands at
+`https://new.example.com/some/deep/page?utm_source=x`.

--- a/modules/redirect-domain/main.tf
+++ b/modules/redirect-domain/main.tf
@@ -1,0 +1,77 @@
+terraform {
+  required_providers {
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.14"
+    }
+  }
+}
+
+# Zone-wide 301 to the canonical target — done entirely in-cluster via
+# a Traefik IngressRoute + RedirectRegex Middleware. No Cloudflare Rules
+# or Page Rules; CF only carries the DNS + tunnel for now, and when we
+# drop CF entirely (public IPv4 lands → direct A record) the same
+# IngressRoute keeps working unchanged.
+#
+# Two K8s resources, one namespace (ingress-controller), no Service, no
+# pod — Traefik does the redirect on the wire.
+
+# RedirectRegex captures the path with `(.*)` and rebuilds the URL.
+# `^https?://[^/]+/(.*)` is host-agnostic on purpose — the IngressRoute
+# already restricts traffic to the source domain, so the middleware
+# doesn't need to re-match the host. `${1}` (Go template form, not
+# regex backref) carries the original path; Traefik passes the query
+# string through automatically on redirect.
+resource "kubectl_manifest" "middleware" {
+  yaml_body = yamlencode({
+    apiVersion = "traefik.io/v1alpha1"
+    kind       = "Middleware"
+    metadata = {
+      name      = "redirect-${replace(var.from_domain, ".", "-")}"
+      namespace = var.namespace
+      labels    = var.labels
+    }
+    spec = {
+      redirectRegex = {
+        regex       = "^https?://[^/]+/(.*)"
+        replacement = "https://${var.to_domain}/$${1}"
+        permanent   = true
+      }
+    }
+  })
+}
+
+# Matches both the apex (`Host(...)`) and any subdomain
+# (`HostRegexp(...)`). Single rule with both predicates OR'd so one
+# IngressRoute covers the entire zone. No backend — Traefik's
+# `services` field is required by the CRD, so we point at the built-in
+# `noop@internal` service that's a no-op (never reached because the
+# middleware returns 301 before service dispatch).
+resource "kubectl_manifest" "ingressroute" {
+  yaml_body = yamlencode({
+    apiVersion = "traefik.io/v1alpha1"
+    kind       = "IngressRoute"
+    metadata = {
+      name      = "redirect-${replace(var.from_domain, ".", "-")}"
+      namespace = var.namespace
+      labels    = var.labels
+    }
+    spec = {
+      entryPoints = ["web"]
+      routes = [{
+        match = "Host(`${var.from_domain}`) || HostRegexp(`^.+\\.${replace(var.from_domain, ".", "\\.")}$`)"
+        kind  = "Rule"
+        services = [{
+          name = "noop@internal"
+          kind = "TraefikService"
+        }]
+        middlewares = [{
+          name      = "redirect-${replace(var.from_domain, ".", "-")}"
+          namespace = var.namespace
+        }]
+      }]
+    }
+  })
+
+  depends_on = [kubectl_manifest.middleware]
+}

--- a/modules/redirect-domain/outputs.tf
+++ b/modules/redirect-domain/outputs.tf
@@ -1,0 +1,4 @@
+output "ingressroute_name" {
+  description = "Name of the emitted Traefik IngressRoute. Reference-only — operator can grep `kubectl get ingressroute -A` for cross-check."
+  value       = "redirect-${replace(var.from_domain, ".", "-")}"
+}

--- a/modules/redirect-domain/variables.tf
+++ b/modules/redirect-domain/variables.tf
@@ -1,0 +1,31 @@
+variable "from_domain" {
+  description = "Source domain name (apex), e.g. `old.example.com`. The emitted IngressRoute matches both the apex and `*.from_domain` via Host + HostRegexp predicates."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9.-]+\\.[a-z]{2,}$", var.from_domain))
+    error_message = "from_domain must look like a bare apex (e.g. `old.example.com`), not a URL or wildcard."
+  }
+}
+
+variable "to_domain" {
+  description = "Canonical target domain (apex), e.g. `new.example.com`. The 301 sends every request to `https://<to_domain>/<original-path>?<original-query>`."
+  type        = string
+
+  validation {
+    condition     = can(regex("^[a-z0-9][a-z0-9.-]+\\.[a-z]{2,}$", var.to_domain))
+    error_message = "to_domain must look like a bare apex (e.g. `new.example.com`), not a URL."
+  }
+}
+
+variable "namespace" {
+  description = "Kubernetes namespace where the IngressRoute + Middleware land. Defaults to the platform's Traefik namespace so the resources live next to Traefik itself; Traefik watches all namespaces, so any namespace works in practice."
+  type        = string
+  default     = "ingress-controller"
+}
+
+variable "labels" {
+  description = "Labels to attach to both emitted manifests. Caller usually passes the platform-wide null-label tag set so the resources are greppable alongside engine-managed cousins."
+  type        = map(string)
+  default     = {}
+}

--- a/redirect_domains.tf
+++ b/redirect_domains.tf
@@ -1,0 +1,68 @@
+# Per-domain HTTP 301 redirects, driven from a top-level `redirect_to:`
+# field in each `config/domains/<name>.yaml`. Engine emits a Traefik
+# Middleware + IngressRoute per opted-in domain via the
+# `modules/redirect-domain` module, and folds the apex + wildcard
+# hostnames into the existing Cloudflare Tunnel + DNS CNAME machinery
+# in `cloudflare.tf` (via the local maps below) so requests actually
+# reach Traefik.
+#
+# Today the path is DNS → CF Tunnel → cloudflared in-cluster →
+# Traefik :80 → IngressRoute → Middleware → 301. The CF leg is purely
+# transit; flipping to direct A-records on public IPs later swaps the
+# two CF locals for direct DNS without touching the module.
+
+locals {
+  # Domains that opted in. Keyed by domain name for stable for_each.
+  # Skips entries where redirect_to is empty, missing, or equals the
+  # domain itself (would create a redirect loop).
+  _redirect_domains = {
+    for name, cfg in local._domain_configs :
+    name => {
+      from_zone_id = cfg.cloudflare_zone_id
+      from_domain  = cfg.name
+      to_domain    = cfg.redirect_to
+    }
+    if try(cfg.redirect_to, "") != "" && try(cfg.redirect_to, "") != cfg.name
+  }
+
+  # Apex + wildcard hostnames per redirect domain, flattened to a
+  # `hostname => { zone_id, service }` map for cloudflare.tf to fold
+  # into its tunnel ingress + DNS CNAME for_each. Service is always
+  # Traefik on plain HTTP — matches the platform-wide convention for
+  # tunnel-fronted hostnames (CF terminates TLS at the edge with its
+  # anycast cert; Traefik gets cleartext on the `web` entryPoint).
+  redirect_tunnel_hostnames = merge([
+    for _, r in local._redirect_domains : {
+      "${r.from_domain}" = {
+        zone_id = r.from_zone_id
+        service = "http://traefik.ingress-controller.svc.cluster.local:80"
+      }
+      "*.${r.from_domain}" = {
+        zone_id = r.from_zone_id
+        service = "http://traefik.ingress-controller.svc.cluster.local:80"
+      }
+    }
+  ]...)
+}
+
+# One in-cluster Traefik IngressRoute + RedirectRegex Middleware per
+# opted-in domain.
+module "redirect_domain" {
+  source   = "./modules/redirect-domain"
+  for_each = local._redirect_domains
+
+  from_domain = each.value.from_domain
+  to_domain   = each.value.to_domain
+  labels      = module.platform_label.tags
+}
+
+output "redirect_domains" {
+  description = "Map of opted-in redirect domains keyed by source name; value carries the target domain. Reference-only — operator can grep for `<from>` in `kubectl get ingressroute -A` to find the matching IngressRoute."
+  value = {
+    for name, r in local._redirect_domains :
+    name => {
+      from = r.from_domain
+      to   = r.to_domain
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- New `modules/redirect-domain` — zone-wide permanent HTTP redirect to a canonical target via Traefik (RedirectRegex Middleware + IngressRoute matching apex + wildcard via Host + HostRegexp). Two K8s resources, no Service/pod, path + query preserved on the wire (308).
- New top-level domain-yaml field `redirect_to:` filtered into `local._redirect_domains` (same shape as `_dnssec_zones`). Per opted-in domain the engine instantiates one module + folds apex + wildcard hostnames into the existing CF tunnel ingress + DNS CNAME machinery in `cloudflare.tf`.
- `config/domains/example.com.yaml.example` documents the field.

## Why in-cluster, not CF Rules

CF leg is purely transit. When the platform drops Cloudflare (direct A-records on public IPs after the public-v4 pool lands), the IngressRoute keeps serving unchanged — only DNS flips. CF Rules would require a parallel rewrite.

## Test plan

- [x] Live-applied; verified `curl -sI https://<source>/<path>?<q>` returns `HTTP/2 308` with `location: https://<target>/<path>?<q>` for both apex and wildcard subdomain.
- [ ] Operator reviews the field shape in `example.com.yaml.example`.
- [ ] Confirm no destroy/replace on subsequent runs by re-planning post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)