### PR TITLE
fix(stalwart): pin pod spec serviceAccountName to "default" explicitly

### DIFF
--- a/modules/stalwart/CHANGELOG.md
+++ b/modules/stalwart/CHANGELOG.md
@@ -12,3 +12,11 @@ the project itself follows [Semantic Versioning](https://semver.org/).
   module conventions. Pure file reorganisation — no resource, input, output, or
   default value changed; `terraform plan` is identical before and after.
 - Initial `README.md` and `CHANGELOG.md` added per AGENT.md module conventions.
+- Pod spec now sets `service_account_name = "default"` explicitly on the
+  Deployment. The kubernetes Terraform provider doesn't reliably clear a
+  previously-set string field by omission, so leaving the field implicit
+  leaves the live Deployment pinned to whatever SA was last assigned. With
+  the explicit value, a future Pod-side SA change (or removal) actually
+  propagates through `terraform apply`. Defensive only — current Deployment
+  was already pointing at `default`; this just makes the intent
+  declarative.

--- a/modules/stalwart/main.tf
+++ b/modules/stalwart/main.tf
@@ -951,6 +951,12 @@ resource "kubernetes_deployment_v1" "stalwart" {
         # come up against an empty data dir.
         node_selector = length(var.node_selector) > 0 ? var.node_selector : null
 
+        # Explicit "default" — the kubernetes TF provider doesn't
+        # reliably clear a previously-set string field by omission,
+        # so removing this line silently leaves the live Deployment
+        # pinned to whatever SA was last assigned.
+        service_account_name = "default"
+
         dynamic "toleration" {
           for_each = var.tolerations
           content {


### PR DESCRIPTION
## Summary

- Pod spec on `stalwart` Deployment now sets `service_account_name = "default"` explicitly. The kubernetes TF provider doesn't reliably clear a previously-set string field by omission, so an implicit absence silently leaves the live Deployment pinned to whatever SA was last assigned.
- Defensive only — current Deployment was already pointing at `default`; this makes the intent declarative so future Pod-side SA changes (or removals) actually propagate through `terraform apply`.

## Discovered via

A botched experiment that set a custom SA on the Deployment, then tried to remove it via TF config — the live serviceAccountName stayed pinned, the ReplicaSet then failed to schedule pods after the SA was destroyed elsewhere. Same shape will bite anyone adding/removing pod-level SAs through this module in the future.

## Test plan

- [x] Already applied; verified Deployment spec has `serviceAccountName: default`, pod running 2/2 ready, OIDC + IMAP auth flowing.
- [ ] Operator confirms no drift on next `./tf plan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)