### PR TITLE
feat(coredns): zone_forwarders engine knob next to host_overrides

### DIFF
--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -552,15 +552,31 @@ services:
   # pattern.
   coredns:
     # In-cluster DNS overrides — emit a `coredns-custom` ConfigMap
-    # in `kube-system` carrying a `hosts` block. Each (hostname, ip)
-    # pair below makes Pods inside this cluster resolve `hostname`
-    # to the given IP, regardless of public DNS. Public records are
-    # untouched. Use case: routing outbound traffic to a hostname
-    # whose canonical public IP isn't reachable from inside the
-    # cluster (e.g. residential ISP routing, WG-mesh-only relays).
-    # Empty map (default) = ConfigMap not emitted, CoreDNS unchanged.
+    # in `kube-system` carrying drop-in `*.server` files.
+    #
+    # Two knobs, both default empty; either being non-empty triggers
+    # the ConfigMap. After applying the operator must
+    # `kubectl rollout restart -n kube-system deploy/coredns` —
+    # CoreDNS does not auto-reload custom imports on file change.
+    #
+    # host_overrides — static A records. Each (hostname, ip) pair
+    # makes Pods inside this cluster resolve `hostname` to the given
+    # IP, regardless of public DNS. Public records are untouched.
+    # Use case: routing outbound traffic to a hostname whose canonical
+    # public IP isn't reachable from inside the cluster (e.g. WG-mesh-
+    # only relays, residential ISP DNS quirks).
+    #
+    # zone_forwarders — delegate a whole zone to an upstream DNS
+    # resolver. Each (zone, upstream_ip) pair emits a server block
+    # with `forward . <upstream>` + a 30s cache. Use case: private
+    # DNS zones hosted off-cluster (Cloud DNS private zone reached
+    # via a forwarder VM) whose A-records the in-cluster Pods need
+    # to resolve.
+    #
     # host_overrides:
     #   relay.example.com: 10.x.x.x
+    # zone_forwarders:
+    #   foo.internal: 10.0.0.1
 
   gcp_wif:
     # GCP Workload Identity Federation — cluster-wide audience the

--- a/coredns_overrides.tf
+++ b/coredns_overrides.tf
@@ -1,4 +1,4 @@
-# CoreDNS host overrides — drop-in `*.server` ConfigMap.
+# CoreDNS custom drop-ins — host overrides + zone forwarders.
 #
 # k3s ships CoreDNS pre-wired to import `/etc/coredns/custom/*.server`
 # files as additional top-level server blocks (separate zones), and
@@ -9,16 +9,13 @@
 # startup. A per-host server block in its own zone scope sidesteps
 # that.
 #
-# Engine emits one server block per (hostname, ip) pair declared in
-# `services.coredns.host_overrides`. Each block carries a `hosts`
-# plugin with the static A record; CoreDNS zone-routes queries for
-# that hostname to this block, everything else continues to the
-# default `.:53` block.
+# Two knobs, both default empty:
 #
-# Use case: in-cluster Pod resolves a public hostname to a private IP
-# (e.g. routing outbound mail through a WG-mesh-only relay whose TLS
-# cert is issued for the public hostname). DNS public records are
-# untouched; only Pods inside this cluster see the override.
+#   services.coredns.host_overrides   — static A records inside cluster.
+#   services.coredns.zone_forwarders  — delegate a zone to an upstream DNS.
+#
+# Either one being non-empty triggers the ConfigMap; both can populate
+# the same map with their respective `.server` keys.
 #
 # Operator config shape (`config/platform.yaml`):
 #
@@ -26,12 +23,25 @@
 #     coredns:
 #       host_overrides:
 #         relay.example.com: 10.x.x.x
-#         other.host.example: 10.y.y.y
+#       zone_forwarders:
+#         foo.internal: 10.0.0.1     # zone → upstream DNS resolver IP
 #
-# Empty map (default) → ConfigMap is not emitted, CoreDNS unchanged.
+# CoreDNS does NOT auto-reload custom imports on file change — after
+# editing the operator config and applying, the operator must run
+# `kubectl rollout restart -n kube-system deploy/coredns` to pick up
+# the new server blocks.
+
+locals {
+  _coredns_custom_enabled = (
+    length(local.platform.services.coredns.host_overrides) > 0 ||
+    length(local.platform.services.coredns.zone_forwarders) > 0
+  )
+
+  _coredns_custom_instances = local._coredns_custom_enabled ? toset(["enabled"]) : toset([])
+}
 
 resource "kubernetes_config_map_v1" "coredns_custom_overrides" {
-  for_each = length(local.platform.services.coredns.host_overrides) > 0 ? toset(["enabled"]) : toset([])
+  for_each = local._coredns_custom_instances
 
   metadata {
     name      = "coredns-custom"
@@ -42,26 +52,40 @@ resource "kubernetes_config_map_v1" "coredns_custom_overrides" {
     })
   }
 
-  # One server block per host. CoreDNS routes queries for the named
-  # zone (the hostname) to this block; everything outside the zone
-  # falls through to the default `.:53 {}` block (forward chain).
-  # `ttl 60` keeps Pod-side resolver caches short so an IP change
-  # propagates within a minute. CoreDNS does NOT auto-reload custom
-  # imports on file change — operator must
-  # `kubectl rollout restart -n kube-system deploy/coredns` after
-  # editing the override map.
-  data = {
-    "host-overrides.server" = join("\n\n", [
-      for host, ip in local.platform.services.coredns.host_overrides :
-      <<-BLOCK
-        ${host} {
-            hosts {
-                ${ip} ${host}
-                ttl 60
-                fallthrough
-            }
-        }
-      BLOCK
-    ])
-  }
+  # One server block per host (host_overrides) or per zone
+  # (zone_forwarders). CoreDNS routes queries for the named zone to
+  # the matching block; everything outside falls through to the
+  # default `.:53 {}` block (forward chain).
+  #
+  # `ttl 60` on hosts keeps Pod-side resolver caches short so an IP
+  # change propagates within a minute. `cache 30` on forwarders is the
+  # conventional short-TTL cache for delegated zones.
+  data = merge(
+    length(local.platform.services.coredns.host_overrides) > 0 ? {
+      "host-overrides.server" = join("\n\n", [
+        for host, ip in local.platform.services.coredns.host_overrides :
+        <<-BLOCK
+          ${host} {
+              hosts {
+                  ${ip} ${host}
+                  ttl 60
+                  fallthrough
+              }
+          }
+        BLOCK
+      ])
+    } : {},
+    length(local.platform.services.coredns.zone_forwarders) > 0 ? {
+      "zone-forwarders.server" = join("\n\n", [
+        for zone, upstream in local.platform.services.coredns.zone_forwarders :
+        <<-BLOCK
+          ${zone}:53 {
+              errors
+              cache 30
+              forward . ${upstream}
+          }
+        BLOCK
+      ])
+    } : {},
+  )
 }

--- a/locals.tf
+++ b/locals.tf
@@ -106,7 +106,8 @@ locals {
         scale_sets               = {}
       }
       coredns = {
-        host_overrides = {}
+        host_overrides  = {}
+        zone_forwarders = {}
       }
       cluster_oidc = {
         enabled           = false


### PR DESCRIPTION
## Summary

- New \`services.coredns.zone_forwarders\` map. Each \`(zone, upstream_ip)\` pair emits a \`*.server\` drop-in block with \`forward . <upstream>\` plus a 30s cache. Use case: delegate a whole zone to an off-cluster DNS resolver (Cloud DNS private zone reached via a forwarder VM) whose A-records in-cluster Pods need to resolve.
- Same \`coredns-custom\` ConfigMap as the existing \`host_overrides\`; just a second \`.server\` key. Both maps gate the ConfigMap independently — either non-empty triggers emission.
- platform.yaml.example documents the new shape.

## Test plan

- [x] Live-applied with one zone delegation. CoreDNS rollout-restart picked up the new block (\`loa.internal.:53\` shows in startup log alongside default \`.:53\` and existing host_override zones).
- [x] DNS probe from a Pod confirms forwarder routes queries to upstream (no \"connection refused\" — gets real NXDOMAIN from upstream when the name doesn't exist there).
- [ ] Operator confirms no diff on a follow-up plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)