### PR TITLE
chore(chat): bump Open WebUI v0.9.2 → v0.9.5

### DIFF
--- a/config/components/chat.yaml
+++ b/config/components/chat.yaml
@@ -1,4 +1,4 @@
-image: ghcr.io/open-webui/open-webui:v0.9.2
+image: ghcr.io/open-webui/open-webui:v0.9.5
 port: 8080
 replicas: 1
 


### PR DESCRIPTION
## Summary

- Bumps `config/components/chat.yaml` image tag from `v0.9.2` to `v0.9.5`.
- Already applied live in cluster earlier today; this commit just lands the diff in main so reconcile-from-scratch matches the running deployment.

## Test plan

- [x] Image already running in `phost-ipsupport-us-prod` for ~few hours, https://chat.ipsupport.us returns 200, OIDC auth functional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)