### PR TITLE
feat: traefik_public LB Services + auto-inject image-pull-secret on default SA

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -109,6 +109,10 @@ locals {
         host_overrides  = {}
         zone_forwarders = {}
       }
+      traefik_public = {
+        enabled = false
+        pools   = {}
+      }
       cluster_oidc = {
         enabled           = false
         external_hostname = ""
@@ -310,6 +314,7 @@ locals {
       gcp_wif          = merge(local._platform_defaults.services.gcp_wif, try(local._platform_services.gcp_wif, {}))
       seafile          = merge(local._platform_defaults.services.seafile, try(local._platform_services.seafile, {}))
       security_scan    = merge(local._platform_defaults.services.security_scan, try(local._platform_services.security_scan, {}))
+      traefik_public   = merge(local._platform_defaults.services.traefik_public, try(local._platform_services.traefik_public, {}))
     }
   }
 

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -1350,6 +1350,32 @@ resource "kubectl_manifest" "image_pull_secret_vault" {
   })
 }
 
+# Patch the namespace's default ServiceAccount with imagePullSecrets
+# pointing at every image-pull Secret declared above. Chart-side
+# Deployments that don't explicitly set serviceAccountName inherit
+# `default` and pick up these secrets automatically — tenants don't
+# need to know the Secret name or wire `imagePullSecrets:` into
+# every workload manifest.
+resource "kubernetes_default_service_account_v1" "this" {
+  for_each = length(var.image_pull_secrets) > 0 ? toset(["enabled"]) : toset([])
+
+  metadata {
+    namespace = kubernetes_namespace_v1.this.metadata[0].name
+  }
+
+  dynamic "image_pull_secret" {
+    for_each = var.image_pull_secrets
+    content {
+      name = image_pull_secret.key
+    }
+  }
+
+  # The default SA is auto-created by k8s; this resource adopts it
+  # (kubernetes provider's documented pattern for managing built-in
+  # objects). On destroy it removes the imagePullSecrets we added
+  # but leaves the SA itself alone.
+}
+
 # ── Zitadel auto-provisioning for chart-deployed apps ────────────────────────
 #
 # Counterpart of the `kind: app` machinery below — but for charts the

--- a/traefik_public.tf
+++ b/traefik_public.tf
@@ -1,0 +1,91 @@
+# Additional LoadBalancer Service(s) pointing at the existing Traefik
+# chart's pods, one per MetalLB pool the operator wants exposed.
+#
+# Why this exists: the platform's Traefik (terraform-k8s-addons) is
+# `traefik_service_type = "ClusterIP"` — it's reachable only through
+# in-cluster DNS today. The Cloudflare Tunnel chain handles every
+# public hostname (cloudflared → ClusterIP). When the operator wants
+# a hostname served WITHOUT going through CF Tunnel — direct A-record
+# straight to a node's public IP — we need Traefik to be reachable on
+# that IP. Instead of running a second Traefik (CRD-watcher collision
+# with the existing one + IngressClass migration for every existing
+# IngressRoute), we just add MORE Service objects with the same
+# selector pointing at the same pods.
+#
+# Tenant-facing contract:
+#   - DNS A-record → one of the IPs in `services.traefik_public.pools`
+#   - IngressRoute in the tenant namespace matching `Host(<that-fqdn>)`
+#   - That's it. No `ingressClassName`, no MetalLB annotations on the
+#     tenant Service, no chart-side knobs. Same Traefik instance that
+#     serves CF Tunnel traffic also serves direct-IP traffic — the
+#     decision is at DNS, not at Traefik.
+#
+# `allow-shared-ip` is set per-pool with the pool name as the sharing
+# key, so a future SipMesh / other chart Service that needs the same
+# IP for its own ports (e.g. SIP 5160/5061) can share by adding
+# `metallb.io/allow-shared-ip: <pool-name>` to its own Service and
+# claiming non-overlapping ports. No engine change needed for the
+# share to start working.
+
+resource "kubernetes_service_v1" "traefik_public" {
+  for_each = local.platform.services.traefik_public.enabled ? local.platform.services.traefik_public.pools : {}
+
+  metadata {
+    name      = "traefik-public-${each.key}"
+    namespace = "ingress-controller"
+    labels = merge(module.platform_label.tags, {
+      "app.kubernetes.io/managed-by" = "terraform"
+      "app.kubernetes.io/component"  = "traefik-public"
+      "platform.local/pool"          = each.key
+    })
+    annotations = {
+      "metallb.io/address-pool"    = each.key
+      "metallb.io/loadBalancerIPs" = each.value
+      # Sharing key = pool name. Future Services on the same IP just
+      # add the same annotation + claim non-overlapping ports — no
+      # engine-side change to enable.
+      "metallb.io/allow-shared-ip" = each.key
+    }
+  }
+
+  spec {
+    type = "LoadBalancer"
+    # `Cluster` (default) tolerates Traefik pods landing on any node
+    # — MetalLB-active node forwards via kube-proxy DNAT + flannel
+    # to wherever the Traefik pods live. Source IP is SNAT'd to the
+    # node IP (not the original client IP). Flip to `Local` only when
+    # source-IP preservation is needed AND every MetalLB-active node
+    # has a Traefik pod (otherwise the pool's node would drop
+    # incoming traffic).
+    external_traffic_policy = "Cluster"
+
+    # Match the existing Traefik chart's pod labels — both Services
+    # (chart-bundled ClusterIP + this engine-emitted LoadBalancer)
+    # target the same pods.
+    selector = {
+      "app.kubernetes.io/instance" = "traefik-ingress-controller"
+      "app.kubernetes.io/name"     = "traefik"
+    }
+
+    port {
+      name        = "web"
+      port        = 80
+      target_port = "web"
+      protocol    = "TCP"
+    }
+    port {
+      name        = "websecure"
+      port        = 443
+      target_port = "websecure"
+      protocol    = "TCP"
+    }
+  }
+}
+
+output "traefik_public_endpoints" {
+  description = "Map of MetalLB pool name → public IP where Traefik also listens. Reference-only — DNS records pointing here should be unproxied A-records (CF Tunnel is the parallel path, not this one)."
+  value = {
+    for k, v in local.platform.services.traefik_public.pools :
+    k => v if local.platform.services.traefik_public.enabled
+  }
+}


### PR DESCRIPTION
## Summary

Two related engine extensions, both already live + verified in cluster. Bundled as one PR — both serve the same goal (direct-IP path without per-chart glue).

### 1. `traefik_public.tf` — extra Traefik exposure per MetalLB pool

- New per-pool `kubernetes_service_v1` of type LoadBalancer, selector pointing at the existing Traefik chart pods.
- One operator-facing knob: `services.traefik_public.pools: { <pool-name>: <ip> }`.
- `metallb.io/allow-shared-ip: <pool>` baked in — future tenant Services on same IP with non-overlapping ports just need the same annotation, no engine change.
- ClusterIP path untouched; new LB Services are additive.
- Tenant just points DNS at the IP — same IngressRoute serves both paths.

### 2. `modules/project`: default-SA imagePullSecrets injection

- New `kubernetes_default_service_account_v1` resource (for_each-gated on `var.image_pull_secrets` non-empty), patches the auto-created `default` SA with imagePullSecrets pointing at every emitted image-pull Secret.
- Chart-side Deployments inheriting `default` SA pick up the secret automatically — no chart change needed to consume private images.

## Test plan

- [x] Live-applied; per-pool LoadBalancer Services hold the expected IPs from MetalLB.
- [x] Default SA inherits the configured imagePullSecrets; private-image pull succeeds against a test workload.
- [ ] Operator confirms no plan drift on follow-up apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)