### PR TITLE
feat(project): gcp_wif_service_accounts — standalone WIF SA + ConfigMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -663,6 +663,20 @@ envs:
 
 Engine emits `VaultStaticSecret` per entry → VSO syncs into a `kubernetes.io/ssh-auth` Secret named `git-deploy-key-<id>` in the project namespace. Components reference it via `git_sync.ssh_key_secret_name: git-deploy-key-<id>` exactly as before — Vault path is wholly invisible to consumer charts.
 
+### GCP Workload Identity Federation — standalone SAs for chart-managed workloads
+
+The per-component `gcp_wif:` knob (component yaml) wires the SA + credential-config + projected token + mounts into an engine-rendered `kind: deployment` Pod. For workloads the engine does NOT own the Pod of (Argo CD helm charts), use the per-env standalone variant:
+
+```yaml
+envs:
+  dev:
+    gcp_wif_service_accounts:
+      <k8s-sa-name>:
+        gcp_service_account: <gsa>@<project>.iam.gserviceaccount.com
+```
+
+Engine emits two objects per entry in the project namespace: a bare `ServiceAccount` named `<k8s-sa-name>` (the GCP-side WIF `principalSet` binding authorizes `system:serviceaccount:<ns>:<k8s-sa-name>` → the GCP SA), and a `<k8s-sa-name>-gcp-wif-credential-config` ConfigMap carrying `credential-config.json` (the GCP SDK `external_account` shape, audience from `services.gcp_wif.pool_provider_audience`, impersonating the given GCP SA). The chart sets `serviceAccountName: <k8s-sa-name>`, renders the projected SA-token volume (audience = the same pool provider), mounts the ConfigMap at `/var/run/secrets/gcp/creds/`, and points `GOOGLE_APPLICATION_CREDENTIALS` at `/var/run/secrets/gcp/creds/credential-config.json`. Engine emits only the SA + ConfigMap, never the Pod. Plan-time check fails if any entry is declared while the cluster audience is empty.
+
 ### Vault storage
 
 `services.vault.storage_class` in `config/platform.yaml` picks the storage backend:

--- a/locals.tf
+++ b/locals.tf
@@ -396,8 +396,9 @@ locals {
           # Vault themselves via Zitadel SSO with the `tenant_<slug>`
           # role grant — operator out of the loop. `host` picks the
           # `known_hosts` line; default `github.com`.
-          git_deploy_keys    = try(env_spec.git_deploy_keys, {})
-          image_pull_secrets = try(env_spec.image_pull_secrets, {})
+          git_deploy_keys          = try(env_spec.git_deploy_keys, {})
+          image_pull_secrets       = try(env_spec.image_pull_secrets, {})
+          gcp_wif_service_accounts = try(env_spec.gcp_wif_service_accounts, {})
           # Engine-managed Zitadel OIDC clients for chart-deployed
           # apps. Engine creates a Zitadel Project + OIDC Application
           # per entry and emits a Secret in the project namespace

--- a/main.tf
+++ b/main.tf
@@ -193,6 +193,8 @@ module "project" {
   image_pull_secrets = try(each.value.image_pull_secrets, {})
   chart_oidc_apps    = try(each.value.chart_oidc_apps, {})
 
+  gcp_wif_service_accounts = try(each.value.gcp_wif_service_accounts, {})
+
   # Operator-supplied literal data for entries declared in this
   # project's `secrets:` map. When a `secrets:<name>` entry's name
   # appears as a top-level key in `var.operator_secret_values`, the

--- a/modules/project/CHANGELOG.md
+++ b/modules/project/CHANGELOG.md
@@ -8,6 +8,14 @@ the project itself follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **`gcp_wif_service_accounts` — standalone WIF SA + credential-config for
+  chart-managed workloads.** Per-env map of k8s SA name →
+  `{ gcp_service_account }`. Engine emits a bare `ServiceAccount` plus a
+  `<sa>-gcp-wif-credential-config` ConfigMap (same `external_account` shape
+  as the per-component `gcp_wif` knob) without owning any Pod — for Argo CD
+  helm charts that wire their own pod. Audience reuses
+  `gcp_wif_pool_provider_audience`; a plan-time check fails if entries are
+  declared while that audience is empty.
 - **GCP Workload Identity Federation per-component opt-in.** New variable
   `gcp_wif_pool_provider_audience` (cluster-wide audience string). When
   any component yaml under this project has `gcp_wif.gcp_service_account:

--- a/modules/project/main.tf
+++ b/modules/project/main.tf
@@ -272,6 +272,15 @@ locals {
     if try(c.gcp_wif, null) != null && try(c.gcp_wif.gcp_service_account, "") != ""
   }
 
+  # Standalone WIF ServiceAccounts for chart-managed workloads — same
+  # external_account shape as `gcp_wif_components`, but the engine emits
+  # only the SA + ConfigMap (the chart owns the pod). Keyed by k8s SA
+  # name → GCP SA email it impersonates.
+  gcp_wif_service_accounts = {
+    for sa_name, cfg in var.gcp_wif_service_accounts :
+    sa_name => cfg.gcp_service_account
+  }
+
   # Routed through `terraform-null-label` (same module already adopted
   # by chart_oidc + postgres extras) so naming rules are uniform across
   # the engine. The output `module.label.id` is `<namespace>` with
@@ -1017,6 +1026,58 @@ resource "kubernetes_secret_v1" "ollama_endpoint" {
 # stack owns the GCP project IAM.
 resource "kubernetes_config_map_v1" "gcp_wif_credential_config" {
   for_each = local.gcp_wif_components
+
+  metadata {
+    name      = "${each.key}-gcp-wif-credential-config"
+    namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels    = module.project_label.tags
+  }
+
+  data = {
+    "credential-config.json" = jsonencode({
+      type                              = "external_account"
+      audience                          = var.gcp_wif_pool_provider_audience
+      subject_token_type                = "urn:ietf:params:oauth:token-type:jwt"
+      token_url                         = "https://sts.googleapis.com/v1/token"
+      service_account_impersonation_url = "https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/${each.value}:generateAccessToken"
+      credential_source = {
+        file = "/var/run/secrets/gcp/tokens/token"
+        format = {
+          type = "text"
+        }
+      }
+    })
+  }
+}
+
+# ── GCP WIF — standalone SA + credential-config for chart-managed workloads ────
+#
+# Same external_account ConfigMap as the per-component knob above, but
+# decoupled from any engine-owned Pod. Declared via
+# `envs.<env>.gcp_wif_service_accounts:` for workloads the engine does
+# NOT render (Argo CD helm charts). Engine emits the bare ServiceAccount
+# the GCP-side principalSet binding authorizes, plus the credential-config
+# ConfigMap; the chart sets `serviceAccountName`, renders the projected
+# SA-token volume, and mounts the ConfigMap itself.
+check "gcp_wif_service_accounts_audience_set" {
+  assert {
+    condition     = length(var.gcp_wif_service_accounts) == 0 || var.gcp_wif_pool_provider_audience != ""
+    error_message = "project '${local.namespace}' declares gcp_wif_service_accounts (${join(", ", keys(var.gcp_wif_service_accounts))}) but `services.gcp_wif.pool_provider_audience` is empty in config/platform.yaml. Set the audience or drop the entries."
+  }
+}
+
+resource "kubernetes_service_account_v1" "gcp_wif_standalone" {
+  for_each = local.gcp_wif_service_accounts
+
+  metadata {
+    name      = each.key
+    namespace = kubernetes_namespace_v1.this.metadata[0].name
+    labels    = module.project_label.tags
+  }
+}
+
+resource "kubernetes_config_map_v1" "gcp_wif_standalone_credential_config" {
+  for_each = local.gcp_wif_service_accounts
 
   metadata {
     name      = "${each.key}-gcp-wif-credential-config"

--- a/modules/project/variables.tf
+++ b/modules/project/variables.tf
@@ -97,6 +97,14 @@ variable "gcp_wif_pool_provider_audience" {
   default     = ""
 }
 
+variable "gcp_wif_service_accounts" {
+  description = "Standalone GCP Workload Identity Federation ServiceAccounts for CHART-MANAGED workloads (Argo CD helm charts the engine does not own the pod of). Map of k8s SA name → { gcp_service_account = <email> }. Per entry the engine emits a bare `ServiceAccount` of that name PLUS a `<sa>-gcp-wif-credential-config` ConfigMap carrying the external_account `credential-config.json` impersonating the given GCP SA (same shape the per-component `gcp_wif` knob renders). The chart wires the pod itself — sets `serviceAccountName: <sa>`, mounts the ConfigMap at `/var/run/secrets/gcp/creds/`, renders the projected SA-token volume, points `GOOGLE_APPLICATION_CREDENTIALS` at the mounted file. Engine emits ONLY the SA + ConfigMap, never the pod. Audience comes from `gcp_wif_pool_provider_audience`; a plan-time check fails if any entry is set while that audience is empty. Declared under `envs.<env>.gcp_wif_service_accounts:` in the domain yaml."
+  type = map(object({
+    gcp_service_account = string
+  }))
+  default = {}
+}
+
 variable "zitadel_org_id" {
   description = "Zitadel org id where `kind: app` components auto-provision projects + applications. Caller resolves at root via `data \"zitadel_orgs\" \"platform_org\"` and passes the value down. Owning the data source at root rather than inside this module avoids the apply-time defer that propagates as `must be replaced` on every downstream resource whenever any consumer module declares `depends_on = [module.zitadel]`."
   type        = string


### PR DESCRIPTION
## Summary

- New per-env `gcp_wif_service_accounts:` map (k8s SA name → `{ gcp_service_account }`). Engine emits a bare `ServiceAccount` + a `<sa>-gcp-wif-credential-config` ConfigMap (the same `external_account` `credential-config.json` shape the per-component `gcp_wif` knob renders), **without owning any Pod**.
- For Argo CD helm-chart workloads the engine doesn't render: the chart sets `serviceAccountName`, renders the projected SA-token volume, and mounts the ConfigMap itself. The engine only materializes the two cluster objects the GCP-side `principalSet` binding + the GCP SDK need.
- Audience reuses `gcp_wif_pool_provider_audience`; plan-time check fails if entries are declared while that audience is empty.
- README + module CHANGELOG updated.

## Why

The existing `gcp_wif:` knob is coupled to engine-rendered `kind: deployment` components (it injects pod volumes/mounts). Chart-managed (ArgoCD) workloads that go keyless on GCP need just the SA + credential-config ConfigMap materialized in their namespace; the chart owns the pod wiring. This is the decoupled variant.

## Test plan

- [x] Live-applied; the SA + ConfigMap materialize in the target namespace; `credential-config.json` is the correct `external_account` shape (right impersonation SA + cluster audience). Zero pod objects emitted.
- [ ] Consumer chart sets `serviceAccountName` + mounts the ConfigMap and successfully exchanges a federated token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)