### PR TITLE
redis: disable AOF on the Sentinel cache

### DIFF
--- a/modules/redis/CHANGELOG.md
+++ b/modules/redis/CHANGELOG.md
@@ -7,6 +7,19 @@ the project itself follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+- **Disable AOF/RDB persistence on the Sentinel cache** via `commonConfiguration`
+  (`appendonly no`, `save ""`). The data volume is an emptyDir (no PVC), so the
+  cache never survives a restart anyway, but the chart-default `appendonly yes`
+  fsynced to the node's local disk every second — under host disk contention
+  that fsync stalled ("Asynchronous AOF fsync is taking too long — disk is
+  busy?"), briefly wedging the server and dropping in-flight client connections
+  (WordPress object-cache logged `Error while reading line from the server` and
+  fell back to slow uncached page loads → occasional origin timeouts). Removing
+  the fsync removes the stalls. Only overrides the chart's default
+  `commonConfiguration`; the default `disableCommands: [FLUSHDB, FLUSHALL]`
+  (separate field) is untouched.
+
 ### Added
 - **`redis-acl-keeper` — per-tenant ACL users that survive Valkey restarts.**
   The Sentinel chart is effectively ephemeral (no `aclfile`, no PVC), so ACL

--- a/modules/redis/main.tf
+++ b/modules/redis/main.tf
@@ -368,6 +368,21 @@ resource "helm_release" "valkey_sentinel" {
   values = [yamlencode({
     architecture = "replication"
 
+    # This is a cache, not a datastore — the data volume is an emptyDir
+    # (no PVC) so nothing here is meant to survive a pod restart anyway.
+    # The chart defaults to `appendonly yes`, which fsyncs the AOF to the
+    # node's local disk every second; under disk contention on the host
+    # that fsync stalls ("Asynchronous AOF fsync is taking too long — disk
+    # is busy?"), briefly wedging the server and dropping in-flight client
+    # connections (WordPress object-cache then logs `Error while reading
+    # line from the server` and falls back to slow uncached page loads).
+    # Disable both AOF and RDB: a cache has no durability requirement, and
+    # removing the fsync removes the stalls. Overrides only the chart's
+    # default `commonConfiguration` — the default `disableCommands:
+    # [FLUSHDB, FLUSHALL]` (rendered into primary/replica.conf, a separate
+    # field) is untouched.
+    commonConfiguration = "appendonly no\nsave \"\""
+
     image = {
       registry   = "docker.io"
       repository = var.sentinel.image_repo


### PR DESCRIPTION
Cache runs on an emptyDir (no PVC) — AOF persistence is pointless and its per-second fsync stalled under host disk contention, dropping WP object-cache connections and slowing page loads. Disable AOF+RDB via commonConfiguration. Applied + verified live (appendonly=no on both nodes, no more fsync warnings, keeper re-applied ACLs after the roll).

🤖 Generated with [Claude Code](https://claude.com/claude-code)