### PR TITLE
redirect-domain: pin catch-all IngressRoute to priority 1

### DIFF
--- a/modules/redirect-domain/CHANGELOG.md
+++ b/modules/redirect-domain/CHANGELOG.md
@@ -7,6 +7,16 @@ the project itself follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **Catch-all redirect no longer shadows explicit per-host routes on the
+  same zone.** The IngressRoute now carries `priority: 1`, pinning it to
+  the bottom of Traefik's route table. Traefik's default priority is the
+  match-rule length, and the apex+wildcard OR'd rule is long enough to
+  outrank a plain `Host(...)` rule emitted for a `routes:` entry — a
+  carve-out subdomain on an otherwise redirect-only domain (e.g. a
+  link-tracking host) was 308-redirected instead of reaching its
+  service.
+
 ### Added
 - Initial module: zone-wide permanent HTTP redirect to a canonical
   target, served by Traefik in-cluster (RedirectRegex Middleware +

--- a/modules/redirect-domain/main.tf
+++ b/modules/redirect-domain/main.tf
@@ -47,6 +47,13 @@ resource "kubectl_manifest" "middleware" {
 # `services` field is required by the CRD, so we point at the built-in
 # `noop@internal` service that's a no-op (never reached because the
 # middleware returns 301 before service dispatch).
+#
+# `priority: 1` pins this catch-all to the bottom of Traefik's route
+# table. Traefik's default priority is the rule length, and this OR'd
+# match is long enough to outrank a plain `Host(...)` rule — without
+# the pin, an explicit `routes:` carve-out on a subdomain of a
+# redirected zone (e.g. a link-tracking host on an otherwise
+# redirect-only domain) would be shadowed by the redirect.
 resource "kubectl_manifest" "ingressroute" {
   yaml_body = yamlencode({
     apiVersion = "traefik.io/v1alpha1"
@@ -59,8 +66,9 @@ resource "kubectl_manifest" "ingressroute" {
     spec = {
       entryPoints = ["web"]
       routes = [{
-        match = "Host(`${var.from_domain}`) || HostRegexp(`^.+\\.${replace(var.from_domain, ".", "\\.")}$`)"
-        kind  = "Rule"
+        match    = "Host(`${var.from_domain}`) || HostRegexp(`^.+\\.${replace(var.from_domain, ".", "\\.")}$`)"
+        kind     = "Rule"
+        priority = 1
         services = [{
           name = "noop@internal"
           kind = "TraefikService"


### PR DESCRIPTION
## What

The zone-wide redirect IngressRoute now sets `priority: 1`, pinning it to the bottom of Traefik's route table.

## Why

Traefik's default route priority is the match-rule length. The redirect's OR'd apex+wildcard rule is long enough to outrank a plain `Host(...)` rule emitted for an explicit `routes:` entry on the same zone — so a carve-out subdomain on an otherwise redirect-only domain was 308-redirected instead of reaching its service. With the pin, any explicit host route wins and the redirect stays the fallback for everything else.

Verified live: carve-out host serves 200 from its service; all other subdomains still 308 to the canonical target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)