### PR TITLE
redirect-domain: priority 2 — tie with traefik-fallback broke whole zones

### DIFF
--- a/modules/redirect-domain/CHANGELOG.md
+++ b/modules/redirect-domain/CHANGELOG.md
@@ -9,13 +9,16 @@ the project itself follows [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 - **Catch-all redirect no longer shadows explicit per-host routes on the
-  same zone.** The IngressRoute now carries `priority: 1`, pinning it to
+  same zone.** The IngressRoute now carries `priority: 2`, pinning it to
   the bottom of Traefik's route table. Traefik's default priority is the
   match-rule length, and the apex+wildcard OR'd rule is long enough to
   outrank a plain `Host(...)` rule emitted for a `routes:` entry — a
   carve-out subdomain on an otherwise redirect-only domain (e.g. a
   link-tracking host) was 308-redirected instead of reaching its
-  service.
+  service. Priority is 2, not 1: the platform-wide `traefik-fallback`
+  router sits at 1, and an equal-priority tie is broken arbitrarily —
+  at 1 the fallback "Service is starting up" page swallowed entire
+  redirected zones.
 
 ### Added
 - Initial module: zone-wide permanent HTTP redirect to a canonical

--- a/modules/redirect-domain/main.tf
+++ b/modules/redirect-domain/main.tf
@@ -48,12 +48,16 @@ resource "kubectl_manifest" "middleware" {
 # `noop@internal` service that's a no-op (never reached because the
 # middleware returns 301 before service dispatch).
 #
-# `priority: 1` pins this catch-all to the bottom of Traefik's route
-# table. Traefik's default priority is the rule length, and this OR'd
-# match is long enough to outrank a plain `Host(...)` rule — without
-# the pin, an explicit `routes:` carve-out on a subdomain of a
+# `priority: 2` pins this catch-all near the bottom of Traefik's
+# route table. Traefik's default priority is the rule length, and this
+# OR'd match is long enough to outrank a plain `Host(...)` rule —
+# without the pin, an explicit `routes:` carve-out on a subdomain of a
 # redirected zone (e.g. a link-tracking host on an otherwise
-# redirect-only domain) would be shadowed by the redirect.
+# redirect-only domain) would be shadowed by the redirect. NOT 1: the
+# platform-wide `traefik-fallback` catch-all (the "Service is starting
+# up" page) sits at priority 1, and on an equal-priority tie Traefik's
+# winner is effectively arbitrary — at 1 the fallback page can (and
+# did) swallow every host of a redirected zone.
 resource "kubectl_manifest" "ingressroute" {
   yaml_body = yamlencode({
     apiVersion = "traefik.io/v1alpha1"
@@ -68,7 +72,7 @@ resource "kubectl_manifest" "ingressroute" {
       routes = [{
         match    = "Host(`${var.from_domain}`) || HostRegexp(`^.+\\.${replace(var.from_domain, ".", "\\.")}$`)"
         kind     = "Rule"
-        priority = 1
+        priority = 2
         services = [{
           name = "noop@internal"
           kind = "TraefikService"


### PR DESCRIPTION
Follow-up to #166. `priority: 1` ties with the platform-wide `traefik-fallback` router (also priority 1); equal-priority ordering in Traefik is effectively arbitrary, and the fallback "Service is starting up" page swallowed every host of redirected zones. `priority: 2` keeps the catch-all redirect above the fallback, still below any explicit `Host()` route.

Verified live: redirected zones 301 again on apex/wildcard; explicit carve-out host serves its service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)