### PR TITLE
stalwart: SMTP-push ingest forwards for machine mailbox intake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`mail.ingest_forward` — SMTP-push intake of a mailbox's inbound mail.**
+  A domain yaml's `mail:` block can declare `ingest_forward: { address,
+  synthetic_domain, smtp_host, smtp_port }`; the stalwart module forks
+  every message whose SMTP envelope recipient is `address` (DATA-stage
+  Sieve `redirect :copy`) onto the synthetic domain, which an MtaRoute
+  pins to an in-cluster SMTP listener. Machine consumers (campaign
+  bounce/DSN ingest) get realtime push with SMTP queue+retry and zero
+  mailbox credentials; the mailbox keeps the original as archive; the
+  spam filter stays on. See `modules/stalwart` CHANGELOG for the
+  mechanism (and the start-time-cache `ReloadSettings` gotcha).
 - **Optional `mail.dmarc_rua` knob for additional mail domains.** A domain yaml
   with `mail.submission_only: true` can now also set `mail.dmarc_rua: <address>`;
   the emitted `_dmarc` TXT then carries `rua=mailto:<address>` so aggregate

--- a/mail.tf
+++ b/mail.tf
@@ -80,6 +80,21 @@ locals {
     }
     if try(cfg.mail.submission_only, false)
   }
+
+  # SMTP-push ingest forwards declared by domain yamls
+  # (`mail.ingest_forward`). Machine intake of a mailbox's inbound
+  # traffic (campaign bounce/DSN ingest) without minting mailbox
+  # credentials — see `modules/stalwart` `ingest_forwards`.
+  _mail_ingest_forwards = local.mail == null ? {} : {
+    for name, cfg in local._domain_configs :
+    cfg.slug => {
+      address          = cfg.mail.ingest_forward.address
+      synthetic_domain = cfg.mail.ingest_forward.synthetic_domain
+      smtp_host        = cfg.mail.ingest_forward.smtp_host
+      smtp_port        = try(cfg.mail.ingest_forward.smtp_port, 25)
+    }
+    if try(cfg.mail.ingest_forward.address, "") != ""
+  }
 }
 
 module "stalwart" {
@@ -110,6 +125,9 @@ module "stalwart" {
       dmarc_policy  = cfg.dmarc_policy
     }
   }
+
+  # SMTP-push ingest forwards (machine intake of mailbox traffic).
+  ingest_forwards = local._mail_ingest_forwards
 
   # DNS / DKIM knobs from yaml.
   dkim_selector     = try(local.mail.dkim_selector, "stalwart")

--- a/modules/stalwart/CHANGELOG.md
+++ b/modules/stalwart/CHANGELOG.md
@@ -7,6 +7,34 @@ the project itself follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **`ingest_forwards` — SMTP-push machine intake for mailbox traffic.**
+  Map of slug → { address, synthetic_domain, smtp_host, smtp_port }.
+  Each entry adds a `redirect :copy` rule (every message whose SMTP
+  envelope recipient is `address` → `ingest@<synthetic_domain>`) into
+  ONE combined DATA-stage Sieve script (`ingest-forwards`), plus its
+  own MtaRoute Relay pinning the synthetic domain to a plain-SMTP
+  in-cluster listener. The script is bound via `MtaStageData.script`
+  (an Expression object — `{match, else}`, the `else` names the
+  script) and **coexists with the spam filter** (left enabled; both
+  run at the DATA stage — verified e2e). The Sieve matches the SMTP
+  envelope recipient (`envelope :is "to"`), not the `To:` header, so
+  bounces/DSNs (whose header carries the original sender) are caught.
+  Built for campaign bounce/DSN ingest by a backend service: realtime
+  push at delivery, zero mailbox credentials (the auth directory is
+  external/OIDC — internal account passwords aren't even possible),
+  original kept in the mailbox, SMTP queue+retry when the listener is
+  down. **Critical applier change:** the running server caches
+  `MtaStageData` at startup, so the applier now triggers a
+  `ReloadSettings` action after the apply when forwards exist — without
+  it the DATA-stage binding stays inert (same start-time-cache class
+  the OIDC Directory idempotency works around; cost us a full debug
+  cycle). The applier's stale-object pre-step is generalised from the
+  single `smarthost` route to every `ingest-*` MtaRoute + the
+  `ingest-forwards` script. The single combined `MtaOutboundStrategy`
+  update now composes the per-domain ingest branches ahead of the
+  smarthost/mx fallback (and is emitted even with no smart host).
+
 ### Fixed
 - **Applier no longer fails 3 ops on every Stalwart start (clean convergence).**
   The Domain idempotency now covers *every* domain in the plan (primary +

--- a/modules/stalwart/main.tf
+++ b/modules/stalwart/main.tf
@@ -349,13 +349,13 @@ locals {
     ] : [],
 
     # ── Outbound smart host (when configured) ─────────────────────
-    # MtaRoute Relay variant + MtaOutboundStrategy.route override.
-    # The pre-existing built-in routes `local` and `mx` are NOT
-    # touched — we add a third route named `smarthost` and rewire the
-    # default else-branch from `'mx'` to `'smarthost'` so non-local
-    # mail goes through the relay. The applier sidecar deletes any
-    # stale MtaRoute named `smarthost` before this create runs (see
-    # the applier command), so plan re-applies are idempotent.
+    # MtaRoute Relay variant. The pre-existing built-in routes `local`
+    # and `mx` are NOT touched — we add a route named `smarthost`; the
+    # single combined MtaOutboundStrategy update further below flips the
+    # default else-branch from `'mx'` to `'smarthost'` so non-local mail
+    # goes through the relay. The applier sidecar deletes any stale
+    # MtaRoute named `smarthost` before this create runs (see the
+    # applier command), so plan re-applies are idempotent.
     local.smarthost_enabled ? [
       jsonencode({
         "@type" = "create"
@@ -380,17 +380,100 @@ locals {
           }
         }
       }),
-      # Route every non-local recipient through the smart host. The
-      # `match` keeps the upstream `is_local_domain → 'local'` branch
-      # so accounts on this Stalwart still deliver locally; the
-      # `else` flips from `'mx'` to `'smarthost'`.
+    ] : [],
+
+    # ── SMTP-push ingest forwards (machine intake of mailbox mail) ─
+    # Per `var.ingest_forwards` entry: a `redirect :copy` rule (every
+    # message whose SMTP envelope recipient is `address` → a synthetic
+    # ingest address) lives in ONE combined DATA-stage Sieve script
+    # (`ingest-forwards`), and the synthetic domain is pinned to an
+    # in-cluster SMTP listener via an MtaRoute Relay. `:copy` keeps the
+    # original in the mailbox as archive; a down listener means standard
+    # SMTP queue+retry. The Sieve uses `envelope :is "to"` (the SMTP
+    # RCPT TO) not the `To:` header — bounces/DSNs carry the original
+    # sender in the header, only the envelope names our mailbox. Proven
+    # to coexist with the spam filter (it stays enabled; both run at the
+    # DATA stage). The script lives in ONE object because the DATA stage
+    # runs a single script (`MtaStageData.script`); per-forward scripts
+    # would never fire. CRITICAL: the running server caches MtaStageData
+    # at startup, so the applier MUST `ReloadSettings` after this apply
+    # for the binding to take effect (see the applier command) — same
+    # start-time-cache class as the OIDC Directory id.
+    [
+      for key, f in var.ingest_forwards :
+      jsonencode({
+        "@type" = "create"
+        object  = "MtaRoute"
+        value = {
+          "ingest-${key}" = {
+            "@type"           = "Relay"
+            name              = "ingest-${key}"
+            description       = "SMTP-push ingest: ${f.synthetic_domain} delivers to an in-cluster listener."
+            address           = f.smtp_host
+            port              = f.smtp_port
+            protocol          = "smtp"
+            implicitTls       = false
+            allowInvalidCerts = false
+            authSecret        = { "@type" = "None" }
+          }
+        }
+      })
+    ],
+
+    # Combined DATA-stage Sieve script (one `redirect :copy` per
+    # forward) + bind it into the DATA stage. Only when ≥1 forward.
+    length(var.ingest_forwards) > 0 ? [
+      jsonencode({
+        "@type" = "create"
+        object  = "SieveSystemScript"
+        value = {
+          "sieve-ingest-forwards" = {
+            name     = "ingest-forwards"
+            isActive = true
+            contents = "require [\"envelope\", \"copy\"];\n${join("", [
+              for key, f in var.ingest_forwards :
+              "if envelope :is \"to\" \"${f.address}\" {\n  redirect :copy \"ingest@${f.synthetic_domain}\";\n}\n"
+            ])}"
+          }
+        }
+      }),
+      # Bind the script into the SMTP DATA stage. `script` is an
+      # Expression object (`{match, else}`), not a bare string — the
+      # unconditional `else` names the script (default is the
+      # expression `false` = run nothing). `enableSpamFilter` is left
+      # untouched; both run at the DATA stage.
+      jsonencode({
+        "@type" = "update"
+        object  = "MtaStageData"
+        value = {
+          script = {
+            match = {}
+            else  = "'ingest-forwards'"
+          }
+        }
+      }),
+    ] : [],
+
+    # Single combined outbound routing strategy. Keeps the upstream
+    # `is_local_domain → 'local'` branch, pins each synthetic ingest
+    # domain to its route, and falls back to the smart host (or plain
+    # MX when no smart host is configured).
+    (local.smarthost_enabled || length(var.ingest_forwards) > 0) ? [
       jsonencode({
         "@type" = "update"
         object  = "MtaOutboundStrategy"
         value = {
           route = {
-            match = { "0" = { if = "is_local_domain(rcpt_domain)", then = "'local'" } }
-            else  = "'smarthost'"
+            match = merge(
+              { "0" = { if = "is_local_domain(rcpt_domain)", then = "'local'" } },
+              { for i, key in keys(var.ingest_forwards) :
+                tostring(i + 1) => {
+                  if   = "rcpt_domain == '${var.ingest_forwards[key].synthetic_domain}'"
+                  then = "'ingest-${key}'"
+                }
+              }
+            )
+            else = local.smarthost_enabled ? "'smarthost'" : "'mx'"
           }
         }
       }),
@@ -1198,6 +1281,14 @@ resource "kubernetes_deployment_v1" "stalwart" {
             name  = "PRIMARY_DOMAIN"
             value = var.primary_domain
           }
+          env {
+            name  = "INGEST_ROUTE_NAMES"
+            value = join(" ", [for k, _ in var.ingest_forwards : "ingest-${k}"])
+          }
+          env {
+            name  = "INGEST_RELOAD"
+            value = length(var.ingest_forwards) > 0 ? "1" : ""
+          }
 
           command = ["bash", "-eu", "-c", <<-EOT
             for i in $(seq 1 180); do
@@ -1207,16 +1298,28 @@ resource "kubernetes_deployment_v1" "stalwart" {
               sleep 2
             done
 
-            # Delete any stale `smarthost` MtaRoute before the plan
-            # tries to create one. MtaRoute has no destroy-by-filter
-            # in `apply` ndjson, so a re-apply with an existing route
-            # would primary-key-violate — handled here by id lookup.
-            echo "[applier] removing stale MtaRoute named 'smarthost' (if present)"
-            SH_ID=$(/shared/bin/stalwart-cli query MtaRoute 2>/dev/null \
-              | awk '$2=="smarthost" {print $1; exit}') || true
-            if [ -n "$${SH_ID:-}" ]; then
-              /shared/bin/stalwart-cli delete MtaRoute --ids "$SH_ID" \
-                || echo "[applier] smarthost delete returned non-zero — proceeding anyway"
+            # Delete stale create-only objects before the plan tries to
+            # recreate them (no destroy-by-filter in `apply` ndjson, so a
+            # re-apply with an existing object would primary-key-violate)
+            # — handled here by name → id lookup. Covers the `smarthost`
+            # MtaRoute, every `ingest-*` ingest-forward MtaRoute (names in
+            # INGEST_ROUTE_NAMES), and the combined `ingest-forwards`
+            # DATA-stage Sieve script.
+            for rname in smarthost $${INGEST_ROUTE_NAMES:-}; do
+              RID=$(/shared/bin/stalwart-cli query MtaRoute 2>/dev/null \
+                | awk -v n="$rname" '$2==n {print $1; exit}') || true
+              if [ -n "$${RID:-}" ]; then
+                echo "[applier] removing stale MtaRoute '$rname' (id $RID)"
+                /shared/bin/stalwart-cli delete MtaRoute --ids "$RID" \
+                  || echo "[applier] $rname delete returned non-zero — proceeding anyway"
+              fi
+            done
+            SID=$(/shared/bin/stalwart-cli query SieveSystemScript 2>/dev/null \
+              | awk '$2=="ingest-forwards" {print $1; exit}') || true
+            if [ -n "$${SID:-}" ]; then
+              echo "[applier] removing stale SieveSystemScript 'ingest-forwards' (id $SID)"
+              /shared/bin/stalwart-cli delete SieveSystemScript --ids "$SID" \
+                || echo "[applier] ingest-forwards delete returned non-zero — proceeding anyway"
             fi
 
             # Domain idempotency. The plan declares
@@ -1307,6 +1410,20 @@ resource "kubernetes_deployment_v1" "stalwart" {
               echo "[applier] plan applied OK"
             else
               echo "[applier] apply finished with errors — see above; main server stays up"
+            fi
+
+            # Settings-class objects (MtaStageData.script) are cached by
+            # the running server at startup; the applier mutates them in
+            # the DB AFTER the server is up, so the DATA-stage ingest
+            # script binding stays inert until a reload. Trigger one when
+            # ingest forwards are configured (same start-time-cache class
+            # the OIDC Directory idempotency works around). Data objects
+            # (Domains, MtaRoutes, accounts) take effect without it, so
+            # the reload is skipped when there are no forwards.
+            if [ -n "$${INGEST_RELOAD:-}" ]; then
+              echo "[applier] reloading settings (ingest DATA-stage script binding)"
+              /shared/bin/stalwart-cli create Action --json '{"@type":"ReloadSettings"}' \
+                || echo "[applier] ReloadSettings returned non-zero — proceeding anyway"
             fi
 
             sleep infinity

--- a/modules/stalwart/variables.tf
+++ b/modules/stalwart/variables.tf
@@ -86,6 +86,17 @@ variable "zitadel_provider_authenticated" {
   default     = false
 }
 
+variable "ingest_forwards" {
+  description = "SMTP-push forwards keyed by a stable slug. Each entry adds a `redirect :copy` rule (every message whose SMTP envelope recipient is `address` → a synthetic ingest address) into the combined DATA-stage Sieve script, and an MtaRoute pinning `synthetic_domain` to a plain-SMTP in-cluster listener at `smtp_host:smtp_port`. The copy never leaves the cluster and never hits MX/smarthost; the original is preserved in the mailbox; a down listener means standard SMTP queue+retry. Coexists with the spam filter (left enabled). Used for machine intake of mailbox traffic (e.g. campaign bounce/DSN ingest) without minting mailbox credentials. The applier triggers a settings reload when this is non-empty so the DATA-stage binding takes effect on the already-running server."
+  type = map(object({
+    address          = string
+    synthetic_domain = string
+    smtp_host        = string
+    smtp_port        = number
+  }))
+  default = {}
+}
+
 variable "smarthost_address" {
   description = "Hostname or IP of the outbound SMTP relay. Empty string keeps the default `mx` route (direct MX delivery); set to a relay address (typically the WireGuard IP of a public Postfix relay VPS, or its public hostname) to push every non-local message through it. Residential ISPs and Cloudflare Tunnel both block outbound :25 — without a smart host the queue spools forever and bounces. The relay must be configured to accept mail from this Stalwart's outgoing IP (typically by static IP / WG peer ACL) and to handle SPF/DKIM signing on the public side."
   type        = string


### PR DESCRIPTION
## What

New `mail.ingest_forward` (domain yaml) / `ingest_forwards` (stalwart module) knob: forks every message whose **SMTP envelope recipient** is a given address onto a synthetic domain pinned to an in-cluster SMTP listener. Realtime push intake for machine consumers (campaign bounce/DSN ingest) with **zero mailbox credentials**, the original kept in the mailbox as archive, spam filter untouched.

## Why

The auth directory is external/OIDC, so a headless mailbox can't have a JMAP/IMAP password minted (internal account passwords are forbidden in external-directory mode). SMTP-push sidesteps credentials entirely: Stalwart relays a copy to the consumer at delivery time; a down consumer just means standard SMTP queue+retry.

## Mechanism (proven e2e on dev)

- One combined **DATA-stage Sieve script** (`ingest-forwards`) with a `redirect :copy` rule per forward. Uses `envelope :is "to"` (the SMTP RCPT), **not** the `To:` header — bounces/DSNs carry the original sender in the header, only the envelope names our mailbox.
- `MtaStageData.script` binds it; **coexists with the spam filter** (both run at DATA; verified spam classification still happens and non-matching recipients are untouched — the script runs globally and no-ops).
- A per-forward **MtaRoute Relay** + a single composed **MtaOutboundStrategy** route the synthetic domain to the listener.

## The gotcha this cost

The running server caches `MtaStageData` at startup; the applier mutates it after the server is up, so the binding stayed **inert** until a reload (same start-time-cache class as the OIDC Directory idempotency this module already works around). Fix: the applier now triggers a `ReloadSettings` action after the apply when forwards exist.

## Verified

- e2e: external mail to `mail@l1promo.com` → forked to the backend listener (code 250, backend logs receipt) **and** archived in the mailbox.
- regression: mail to a different recipient delivers normally, no fork; spam filter still classifies.
- applier converges `0 failed` + logs the reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)