### PR TITLE
stalwart: VERP attribution on ingest forwards (X-Original-To)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **VERP attribution on `mail.ingest_forward` — `X-Original-To` header.**
+  The ingest-forward Sieve now stamps `X-Original-To: <original
+  recipient>` on the forked copy so a consumer can attribute a bounce to
+  the exact campaign/recipient via a VERP `mail+<token>@` envelope.
+  Recovered from the relay's `Received: ... for <addr>` clause because
+  Stalwart strips subaddressing before the DATA-stage Sieve. See
+  `modules/stalwart` CHANGELOG.
 - **`mail.ingest_forward` — SMTP-push intake of a mailbox's inbound mail.**
   A domain yaml's `mail:` block can declare `ingest_forward: { address,
   synthetic_domain, smtp_host, smtp_port }`; the stalwart module forks

--- a/config/components/lineoneagent-frontend-dev.yaml
+++ b/config/components/lineoneagent-frontend-dev.yaml
@@ -1,0 +1,11 @@
+# External component — routing only, no Deployment. Points at the
+# ArgoCD-managed lineoneagent-frontend dev Service (the chart in
+# phost-lineoneagent-com-dev owns the workload). Used to route
+# carve-out hostnames on other zones (campaign link-tracking host)
+# into the same frontend.
+kind: external
+
+service:
+  name:      lineoneagent-frontend-dev-web
+  namespace: phost-lineoneagent-com-dev
+  port:      3000

--- a/modules/stalwart/CHANGELOG.md
+++ b/modules/stalwart/CHANGELOG.md
@@ -8,6 +8,17 @@ the project itself follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **VERP attribution on ingest forwards — `X-Original-To` header.** Each
+  forward's Sieve rule now stamps `X-Original-To` on the forked copy,
+  recovered from the relay's `Received: ... for <addr>` clause. Stalwart
+  strips subaddressing (`mail+<token>@`) *before* the DATA-stage Sieve
+  runs — `:detail`/`:all` return the bare address, so the VERP token is
+  not recoverable from the envelope (verified). The relay (Postfix)
+  records the true envelope recipient in its `Received` `for` clause
+  *before* Stalwart, so the script extracts it there into
+  `X-Original-To` for the consumer (works even when `To:` is the
+  original sender, as in real DSNs). No-ops cleanly when no `for` clause
+  exists. Adds the `editheader` + `variables` Sieve requires.
 - **`ingest_forwards` — SMTP-push machine intake for mailbox traffic.**
   Map of slug → { address, synthetic_domain, smtp_host, smtp_port }.
   Each entry adds a `redirect :copy` rule (every message whose SMTP

--- a/modules/stalwart/main.tf
+++ b/modules/stalwart/main.tf
@@ -430,9 +430,20 @@ locals {
           "sieve-ingest-forwards" = {
             name     = "ingest-forwards"
             isActive = true
-            contents = "require [\"envelope\", \"copy\"];\n${join("", [
+            # VERP attribution: Stalwart strips subaddressing
+            # (`mail+<token>@`) BEFORE the DATA-stage Sieve, so the
+            # token is gone from the envelope (`:detail`/`:all` return
+            # the bare address — verified). The relay (Postfix) records
+            # the real envelope recipient in its `Received: ... for
+            # <mail+<token>@dom>` clause, added before Stalwart, so we
+            # recover it from there into `X-Original-To` for the
+            # listener. `${2}` is the Sieve match var (TF-escaped
+            # `$${2}`); the `header :matches` test no-ops (no header
+            # added) when no `for` clause is present, so plain mail
+            # without a token still forwards cleanly.
+            contents = "require [\"envelope\", \"copy\", \"editheader\", \"variables\"];\n${join("", [
               for key, f in var.ingest_forwards :
-              "if envelope :is \"to\" \"${f.address}\" {\n  redirect :copy \"ingest@${f.synthetic_domain}\";\n}\n"
+              "if envelope :is \"to\" \"${f.address}\" {\n  if header :matches \"Received\" \"*for <*>*\" {\n    addheader \"X-Original-To\" \"$${2}\";\n  }\n  redirect :copy \"ingest@${f.synthetic_domain}\";\n}\n"
             ])}"
           }
         }


### PR DESCRIPTION
## What

Each ingest-forward Sieve rule now stamps `X-Original-To: <original recipient>` on the forked copy, so a consumer can attribute a bounce to the exact campaign/recipient via a VERP `mail+<token>@` envelope-from. Requested by lineoneagent-backend (fallback for the minority of bounces that strip the original headers).

## The catch (and the fix)

Stalwart **strips subaddressing** (`mail+<token>@`) *before* the DATA-stage Sieve runs — `envelope :detail` / `:all` return the bare `mail@l1promo.com`, so the VERP token is **not recoverable from the envelope** (verified: `:detail` yields nothing, `:all` yields the stripped address).

The relay (Postfix) records the true envelope recipient in its `Received: ... for <mail+<token>@dom>` clause, added **before** Stalwart. The script recovers it from there (`header :matches "Received" "*for <*>*"` → `addheader "X-Original-To" "${2}"`). This works even when the `To:` header is the original sender (real DSNs).

## Verified e2e

- Bounce-shaped message: envelope `mail+TESTTOKEN@l1promo.com`, `To:` header `original-sender@example.net` → SMTP-sink capture shows `X-Original-To: mail+TESTTOKEN@l1promo.com` on the forked copy.
- The module-generated script is byte-identical to the proven one (TF `$${2}` escape renders the Sieve `${2}` correctly).
- Forks to the real backend listener (code 250); regression: non-l1promo mail unforked, spam filter still on; applier converges `0 failed` + reload.

No-ops cleanly when no `for` clause exists. Adds the `editheader` + `variables` Sieve requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)