### PR TITLE
gitignore: actually add the lineoneagent-frontend-dev line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ config/domains/*.yaml
 # fresh clone trips the gitignore instead of polluting state.
 config/components/sipmesh-frontend.yaml
 config/components/platform-dash.yaml
+config/components/lineoneagent-frontend-dev.yaml
 
 # Platform-service toggles — the live file is per-operator
 config/platform.yaml


### PR DESCRIPTION
Follow-up to #170, which ran `git rm --cached` but never staged the matching `.gitignore` edit — so the ignore line was missing on main. This adds it. Keeps the tenant-coupled `config/components/lineoneagent-frontend-dev.yaml` untracked + ignored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)