### PR TITLE
redirect-domain: per-host redirects (redirect_hosts)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`redirect_hosts:` — per-host 301 redirects on a domain.** A domain
+  yaml can now carry `redirect_hosts: { <prefix>: <target-fqdn> }`
+  alongside (or instead of) the zone-wide `redirect_to:`. Each entry
+  redirects exactly `<prefix>.<domain>` (path + query preserved) to its
+  own target, winning over the zone redirect via an explicit high Traefik
+  priority. Use for campaign link hosts that must stay on the link domain
+  for alignment (e.g. `dev-links.l1promo.com`) but land on a different
+  app (`dev.lineoneagent.com`) than the rest of the zone. Tunnel DNS +
+  ingress are wired automatically. No project namespace is created (it's
+  a pure redirect, not a routed component).
 - **VERP attribution on `mail.ingest_forward` — `X-Original-To` header.**
   The ingest-forward Sieve now stamps `X-Original-To: <original
   recipient>` on the forked copy so a consumer can attribute a bounce to

--- a/cloudflare.tf
+++ b/cloudflare.tf
@@ -195,6 +195,19 @@ resource "cloudflare_zero_trust_tunnel_cloudflared_config" "main" {
           }
         }
       ],
+      # Per-host redirects (`redirect_hosts:` in domain yamls). Same
+      # cleartext-to-Traefik backend; the per-host IngressRoute serves a
+      # 301 to a different target than the zone redirect.
+      [
+        for hostname, cfg in local.redirect_host_tunnel_hostnames : {
+          hostname = hostname
+          service  = cfg.service
+          origin_request = {
+            origin_server_name = hostname
+            http2_origin       = false
+          }
+        }
+      ],
       # Catch-all (required by Cloudflare — must be the last entry,
       # match-anything by omitting `hostname`).
       [{
@@ -212,6 +225,7 @@ resource "cloudflare_dns_record" "tunnel" {
       local.all_hostnames,
       local.tunnel_argocd_hostnames,
       local.redirect_tunnel_hostnames,
+      local.redirect_host_tunnel_hostnames,
     ) :
     hostname => cfg
     if cfg.zone_id != null

--- a/modules/redirect-domain/CHANGELOG.md
+++ b/modules/redirect-domain/CHANGELOG.md
@@ -7,6 +7,19 @@ the project itself follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- **`priority` and `include_subdomains` inputs — single-host redirects.**
+  `include_subdomains` (default true) keeps the whole-zone behaviour
+  (apex + `*.from_domain`); set false to match only the exact
+  `from_domain`, for redirecting one host that sits on an otherwise
+  redirect-only zone. `priority` (default 2, unchanged for zone
+  redirects) lets a single-host redirect pass a higher value so it wins
+  over an overlapping zone redirect — Traefik's default rule-length
+  priority proved unreliable when a long zone-redirect rule competes
+  with a default-priority host route (observed live: a carve-out lost
+  to the zone redirect despite a longer rule). Backward compatible:
+  existing callers get the previous apex+wildcard, priority-2 shape.
+
 ### Fixed
 - **Catch-all redirect no longer shadows explicit per-host routes on the
   same zone.** The IngressRoute now carries `priority: 2`, pinning it to

--- a/modules/redirect-domain/main.tf
+++ b/modules/redirect-domain/main.tf
@@ -41,23 +41,23 @@ resource "kubectl_manifest" "middleware" {
   })
 }
 
-# Matches both the apex (`Host(...)`) and any subdomain
-# (`HostRegexp(...)`). Single rule with both predicates OR'd so one
-# IngressRoute covers the entire zone. No backend — Traefik's
-# `services` field is required by the CRD, so we point at the built-in
-# `noop@internal` service that's a no-op (never reached because the
+# Matches the apex (`Host(...)`) and — when `include_subdomains` —
+# every subdomain (`HostRegexp(...)`), OR'd into one rule so a single
+# IngressRoute covers the whole zone. With `include_subdomains = false`
+# it matches only the exact `from_domain` (single-host redirect). No
+# backend — Traefik's `services` field is required by the CRD, so we
+# point at the built-in `noop@internal` no-op (never reached: the
 # middleware returns 301 before service dispatch).
 #
-# `priority: 2` pins this catch-all near the bottom of Traefik's
-# route table. Traefik's default priority is the rule length, and this
-# OR'd match is long enough to outrank a plain `Host(...)` rule —
-# without the pin, an explicit `routes:` carve-out on a subdomain of a
-# redirected zone (e.g. a link-tracking host on an otherwise
-# redirect-only domain) would be shadowed by the redirect. NOT 1: the
-# platform-wide `traefik-fallback` catch-all (the "Service is starting
-# up" page) sits at priority 1, and on an equal-priority tie Traefik's
-# winner is effectively arbitrary — at 1 the fallback page can (and
-# did) swallow every host of a redirected zone.
+# `priority` (default 2) places the rule in Traefik's route table.
+# Default 2 sits just above the platform-wide `traefik-fallback` (the
+# "Service is starting up" page, priority 1) and below a default-
+# priority service route — so a whole-zone redirect yields to explicit
+# carve-outs. NOT 1: on an equal-priority tie Traefik's winner is
+# arbitrary, and at 1 the fallback page swallowed redirected zones. A
+# single-host redirect that must WIN over an overlapping zone redirect
+# passes a higher value (Traefik's default rule-length priority is
+# unreliable when a long zone-redirect rule competes — observed live).
 resource "kubectl_manifest" "ingressroute" {
   yaml_body = yamlencode({
     apiVersion = "traefik.io/v1alpha1"
@@ -70,9 +70,11 @@ resource "kubectl_manifest" "ingressroute" {
     spec = {
       entryPoints = ["web"]
       routes = [{
-        match    = "Host(`${var.from_domain}`) || HostRegexp(`^.+\\.${replace(var.from_domain, ".", "\\.")}$`)"
+        match = var.include_subdomains ? (
+          "Host(`${var.from_domain}`) || HostRegexp(`^.+\\.${replace(var.from_domain, ".", "\\.")}$`)"
+        ) : "Host(`${var.from_domain}`)"
         kind     = "Rule"
-        priority = 2
+        priority = var.priority
         services = [{
           name = "noop@internal"
           kind = "TraefikService"

--- a/modules/redirect-domain/variables.tf
+++ b/modules/redirect-domain/variables.tf
@@ -29,3 +29,15 @@ variable "labels" {
   type        = map(string)
   default     = {}
 }
+
+variable "include_subdomains" {
+  description = "Whether the IngressRoute also matches every subdomain of `from_domain` (the `HostRegexp` predicate). True (default) for a whole-zone redirect (apex + `*.from_domain`). Set false for a single-host redirect (e.g. a campaign link host) so only the exact `from_domain` is matched and unrelated subdomains fall through to whatever else claims them."
+  type        = bool
+  default     = true
+}
+
+variable "priority" {
+  description = "Traefik route priority for the redirect IngressRoute. Default 2 sits just above the platform-wide `traefik-fallback` (priority 1) but below a default-priority service route, so a whole-zone redirect yields to explicit carve-outs. A single-host redirect that must WIN over an overlapping zone redirect should pass a higher value (e.g. 100) — relying on Traefik's default rule-length priority is unreliable when a long zone-redirect rule competes."
+  type        = number
+  default     = 2
+}

--- a/redirect_domains.tf
+++ b/redirect_domains.tf
@@ -43,6 +43,35 @@ locals {
       }
     }
   ]...)
+
+  # Per-HOST 301 redirects, driven from a `redirect_hosts:` map in a
+  # domain yaml: `{ <prefix>: <target-fqdn> }`. Unlike `redirect_to`
+  # (whole zone → one target), this redirects ONE host to its own
+  # target, overriding the zone redirect for that host. Use for
+  # campaign link hosts that live on an otherwise redirect-only zone
+  # but must land on a different app (e.g. `dev-links.l1promo.com` →
+  # `dev.lineoneagent.com` while the rest of l1promo.com → the prod
+  # site). Keyed by FQDN for a stable for_each.
+  _redirect_hosts = merge([
+    for name, cfg in local._domain_configs : {
+      for prefix, target in try(cfg.redirect_hosts, {}) :
+      "${prefix}.${cfg.name}" => {
+        zone_id   = cfg.cloudflare_zone_id
+        from_host = "${prefix}.${cfg.name}"
+        to_domain = target
+      }
+    }
+  ]...)
+
+  # Tunnel/DNS wiring for the per-host redirects — just the host itself
+  # (no wildcard; a single-host redirect owns exactly one name).
+  redirect_host_tunnel_hostnames = {
+    for fqdn, r in local._redirect_hosts :
+    fqdn => {
+      zone_id = r.zone_id
+      service = "http://traefik.ingress-controller.svc.cluster.local:80"
+    }
+  }
 }
 
 # One in-cluster Traefik IngressRoute + RedirectRegex Middleware per
@@ -54,6 +83,22 @@ module "redirect_domain" {
   from_domain = each.value.from_domain
   to_domain   = each.value.to_domain
   labels      = module.platform_label.tags
+}
+
+# One in-cluster redirect per `redirect_hosts:` entry. Matches the exact
+# host only (`include_subdomains = false`) at an explicit high priority
+# so it wins over any overlapping zone redirect on the same domain
+# (Traefik's default rule-length priority proved unreliable for this —
+# a long zone-redirect rule outranked a default-priority carve-out).
+module "redirect_host" {
+  source   = "./modules/redirect-domain"
+  for_each = local._redirect_hosts
+
+  from_domain        = each.value.from_host
+  to_domain          = each.value.to_domain
+  include_subdomains = false
+  priority           = 100
+  labels             = module.platform_label.tags
 }
 
 output "redirect_domains" {


### PR DESCRIPTION
## What

New `redirect_hosts: { <prefix>: <target-fqdn> }` domain-yaml field — redirect ONE host (path + query preserved) to its own target, overriding the zone-wide `redirect_to` for that host. The `redirect-domain` module gains `include_subdomains` (default true) and `priority` (default 2) inputs.

## Why

Campaign dev link hosts (`dev-links.l1promo.com`, `d.l1pr.co`) must stay on the link domain in mail for alignment, but should land on the dev app (`dev.lineoneagent.com`), not the prod site the zone redirect points at.

Explicit high priority (100) is required: Traefik's default rule-length priority proved unreliable — a default-priority carve-out lost to the priority-2 zone redirect for a longer hostname while a shorter one won. An explicit priority makes the per-host redirect deterministically win.

## Verified live

- `dev-links.l1promo.com/c/ABC` → 308 → `dev.lineoneagent.com/c/ABC` (path preserved)
- `d.l1pr.co/x/TOK` → 308 → `dev.lineoneagent.com/x/TOK`
- other `*.l1promo.com` + apex → still the zone redirect (lineoneagent.com)
- the two route-only project namespaces this replaces are removed (no workloads)

🤖 Generated with [Claude Code](https://claude.com/claude-code)