### PR TITLE
stalwart: ingest_forward matches a list of addresses (mail@ + reply@)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   app (`dev.lineoneagent.com`) than the rest of the zone. Tunnel DNS +
   ingress are wired automatically. No project namespace is created (it's
   a pure redirect, not a routed component).
+- **`mail.ingest_forward` takes a LIST of `addresses`.** One forward can
+  now fan several tagged addresses (e.g. `mail@` for bounce VERP +
+  `reply@` for reply-conversion) into the same in-cluster listener; the
+  consumer branches on the tagged local-part from `X-Original-To`.
+  Replaces the former single `address` field.
 - **VERP attribution on `mail.ingest_forward` — `X-Original-To` header.**
   The ingest-forward Sieve now stamps `X-Original-To: <original
   recipient>` on the forked copy so a consumer can attribute a bounce to

--- a/mail.tf
+++ b/mail.tf
@@ -88,12 +88,12 @@ locals {
   _mail_ingest_forwards = local.mail == null ? {} : {
     for name, cfg in local._domain_configs :
     cfg.slug => {
-      address          = cfg.mail.ingest_forward.address
+      addresses        = cfg.mail.ingest_forward.addresses
       synthetic_domain = cfg.mail.ingest_forward.synthetic_domain
       smtp_host        = cfg.mail.ingest_forward.smtp_host
       smtp_port        = try(cfg.mail.ingest_forward.smtp_port, 25)
     }
-    if try(cfg.mail.ingest_forward.address, "") != ""
+    if length(try(cfg.mail.ingest_forward.addresses, [])) > 0
   }
 }
 

--- a/modules/stalwart/CHANGELOG.md
+++ b/modules/stalwart/CHANGELOG.md
@@ -8,6 +8,14 @@ the project itself follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **`ingest_forwards` entries take a LIST of `addresses`.** One forward
+  now fans several tagged mailbox addresses into the SAME listener via a
+  single Sieve `anyof(envelope :is "to" ...)` rule — e.g. `mail@` (bounce
+  VERP `mail+<token>@`) + `reply@` (reply-conversion `reply+<id>@`) both
+  push to the campaign-ingest listener; the consumer branches on the
+  tagged local-part it reads from `X-Original-To`. Each address must
+  resolve to a deliverable mailbox/alias (the `:copy` keeps the original
+  locally). Replaces the former single `address` field.
 - **VERP attribution on ingest forwards — `X-Original-To` header.** Each
   forward's Sieve rule now stamps `X-Original-To` on the forked copy,
   recovered from the relay's `Received: ... for <addr>` clause. Stalwart

--- a/modules/stalwart/main.tf
+++ b/modules/stalwart/main.tf
@@ -384,8 +384,8 @@ locals {
 
     # ── SMTP-push ingest forwards (machine intake of mailbox mail) ─
     # Per `var.ingest_forwards` entry: a `redirect :copy` rule (every
-    # message whose SMTP envelope recipient is `address` → a synthetic
-    # ingest address) lives in ONE combined DATA-stage Sieve script
+    # message whose SMTP envelope recipient matches ANY of `addresses`
+    # → a synthetic ingest address) lives in ONE combined DATA-stage Sieve script
     # (`ingest-forwards`), and the synthetic domain is pinned to an
     # in-cluster SMTP listener via an MtaRoute Relay. `:copy` keeps the
     # original in the mailbox as archive; a down listener means standard
@@ -443,7 +443,7 @@ locals {
             # without a token still forwards cleanly.
             contents = "require [\"envelope\", \"copy\", \"editheader\", \"variables\"];\n${join("", [
               for key, f in var.ingest_forwards :
-              "if envelope :is \"to\" \"${f.address}\" {\n  if header :matches \"Received\" \"*for <*>*\" {\n    addheader \"X-Original-To\" \"$${2}\";\n  }\n  redirect :copy \"ingest@${f.synthetic_domain}\";\n}\n"
+              "if anyof(${join(", ", [for a in f.addresses : "envelope :is \"to\" \"${a}\""])}) {\n  if header :matches \"Received\" \"*for <*>*\" {\n    addheader \"X-Original-To\" \"$${2}\";\n  }\n  redirect :copy \"ingest@${f.synthetic_domain}\";\n}\n"
             ])}"
           }
         }

--- a/modules/stalwart/variables.tf
+++ b/modules/stalwart/variables.tf
@@ -87,9 +87,9 @@ variable "zitadel_provider_authenticated" {
 }
 
 variable "ingest_forwards" {
-  description = "SMTP-push forwards keyed by a stable slug. Each entry adds a `redirect :copy` rule (every message whose SMTP envelope recipient is `address` → a synthetic ingest address) into the combined DATA-stage Sieve script, and an MtaRoute pinning `synthetic_domain` to a plain-SMTP in-cluster listener at `smtp_host:smtp_port`. The copy never leaves the cluster and never hits MX/smarthost; the original is preserved in the mailbox; a down listener means standard SMTP queue+retry. Coexists with the spam filter (left enabled). Used for machine intake of mailbox traffic (e.g. campaign bounce/DSN ingest) without minting mailbox credentials. The applier triggers a settings reload when this is non-empty so the DATA-stage binding takes effect on the already-running server."
+  description = "SMTP-push forwards keyed by a stable slug. Each entry adds a `redirect :copy` rule (every message whose SMTP envelope recipient matches ANY of `addresses` → a synthetic ingest address) into the combined DATA-stage Sieve script, and an MtaRoute pinning `synthetic_domain` to a plain-SMTP in-cluster listener at `smtp_host:smtp_port`. `addresses` lets one forward fan several tagged mailbox addresses (e.g. `mail@` for bounce VERP + `reply@` for reply-conversion) into the SAME listener — the consumer branches on the tagged local-part it reads from `X-Original-To`. Each address must resolve to a deliverable mailbox/alias (the `:copy` keeps the original locally). The copy never leaves the cluster and never hits MX/smarthost; a down listener means standard SMTP queue+retry. Coexists with the spam filter (left enabled). The applier triggers a settings reload when this is non-empty so the DATA-stage binding takes effect on the already-running server."
   type = map(object({
-    address          = string
+    addresses        = list(string)
     synthetic_domain = string
     smtp_host        = string
     smtp_port        = number


### PR DESCRIPTION
## What

`mail.ingest_forward` now takes a list of `addresses` instead of a single `address`. The DATA-stage Sieve matches `anyof(envelope :is "to" ...)` over them and forks all to the one campaign-ingest listener. For l1promo: `mail@` (bounce VERP) + `reply@` (reply-conversion).

## Why

lineoneagent-backend shipped reply-conversion (their PR #223): campaign mail carries a second Reply-To `reply+<id>@l1promo.com`; a copy of the reply must reach the existing bounce-ingest listener so the backend attributes the conversion. Backend branches on the `mail+` vs `reply+` prefix it reads from `X-Original-To`.

## Notes

- Stalwart strips subaddressing before the Sieve, so `reply+<id>@` normalizes to `reply@` — matched explicitly alongside `mail@`. `reply@` is an alias on the `mail@` system account so the `:copy` original archives there (no bounce).
- Reuses the existing listener / MtaRoute / synthetic domain — no new port, secret, or relay change.
- `X-Original-To` recovery (relay `Received: for <...>`) is unchanged.

## Verified e2e

- `reply+TESTID@l1promo.com` (To: header a different sender) → forked to the listener (250); SMTP-sink capture shows `X-Original-To: reply+TESTID@l1promo.com`; original archived in the `mail@` mailbox.
- bounce `mail+` path unaffected; spam filter still on; applier `0 failed` + reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)