### PR TITLE
argocd: fold notifications config into the Helm release for durability

### DIFF
--- a/argocd.tf
+++ b/argocd.tf
@@ -101,6 +101,14 @@ module "argocd" {
 
   node_selector = local.platform.services.argocd.node_selector
   tolerations   = local.platform.services.argocd.tolerations
+
+  # Notifications ("deploy succeeded → Telegram") folded into the chart
+  # values for durability — see modules/argocd/main.tf. The yaml is
+  # helm-values-shaped (notifiers / templates / triggers); the bot token
+  # comes from TF_VAR_telegram_token (.env, gitignored), never from the
+  # file. Collapses to {} when argocd is disabled.
+  notifications_config = local.platform.services.argocd.enabled ? yamldecode(file("${path.module}/config/argocd-notifications.yaml")).notifications : {}
+  telegram_token       = var.telegram_token
 }
 
 output "argocd_url" {

--- a/config/argocd-notifications.yaml
+++ b/config/argocd-notifications.yaml
@@ -1,0 +1,55 @@
+# Argo CD Notifications — "deploy succeeded" → Telegram.
+#
+# Read by Terraform: `argocd.tf` decodes this file's `notifications:` block and
+# passes it to `module.argocd`, which folds it into the `argo-cd` Helm release
+# values. The chart then renders `argocd-notifications-cm` (notifiers ->
+# service.*, templates -> template.*, triggers -> trigger.*). This is the
+# durable replacement for the previous live `kubectl patch` flow — a
+# `helm upgrade` no longer wipes the config.
+#
+# Mirror of lineoneagent-infra/k8s/argocd/notifications-values.yaml. Two keys
+# are intentionally NOT set here and are supplied by the module instead:
+#   - `argocdUrl` — forced from `var.hostname` to stay single-sourced with
+#     `configs.cm.url`.
+#   - `secret` — the module attaches `telegram-token` from TF_VAR_telegram_token
+#     (.env, gitignored). The bot token is referenced as `$telegram-token` and
+#     never lives in this file.
+# Recipients (chat ids) are set per-Application via a subscribe annotation in
+# each app's deploy/argocd/apps manifest (app-of-apps managed).
+
+notifications:
+  notifiers:
+    service.telegram: |
+      token: $telegram-token
+
+  templates:
+    # For the lineoneagent frontend/backend dev apps the deploy lines show the
+    # REAL source commit — short sha + subject, and the author name on its own
+    # line — not the digest-bump commit ArgoCD synced to. Mechanism: the
+    # `bump-dev-digest` CI job in ipsupport-llc/lineoneagent-frontend and
+    # ipsupport-llc/lineoneagent-backend (.github/workflows/ci.yml) writes
+    # `built-from=<github.sha>` into the bump-commit body; here we parse it and
+    # resolve subject + author via a second GetCommitMetadata (author trimmed
+    # to the name before `<email>`). Guarded on the app name so other tenants
+    # keep the plain `revision:` line and incur no extra repo lookup. Falls back
+    # to `revision:` when the token is absent.
+    template.app-deployed: |
+      message: |
+        Deployed: {{.app.metadata.name}}
+        {{ if has .app.metadata.name (list "lineoneagent-frontend-dev" "lineoneagent-backend-dev") }}{{ $bump := call .repo.GetCommitMetadata .app.status.sync.revision }}{{ $sha := regexFind "built-from=[0-9a-f]{7,40}" $bump.Message | trimPrefix "built-from=" }}{{ if $sha }}{{ $real := call .repo.GetCommitMetadata $sha }}{{ printf "%s — %s\n%s" (trunc 7 $sha) (first (splitList "\n" $real.Message)) (trim (regexFind "^[^<]+" $real.Author)) }}{{ else }}revision: {{ .app.status.sync.revision }}{{ end }}{{ else }}revision: {{ .app.status.sync.revision }}{{ end }}
+        {{.context.argocdUrl}}/applications/{{.app.metadata.name}}
+
+  triggers:
+    # For the lineoneagent frontend/backend dev apps, only notify when the
+    # synced revision is a digest-bump commit (carries `built-from=`). A dev
+    # deploy advances ArgoCD through TWO main revisions — the code/merge commit
+    # (phantom no-op sync on the old image) then the bump commit (the real
+    # rollout) — which otherwise fires two notifications. The guard suppresses
+    # the phantom one. `or` short-circuits for other tenants, so they keep the
+    # original behaviour with no extra repo lookup.
+    trigger.on-deployed: |
+      - description: Application is synced and healthy. Triggered once per commit.
+        oncePer: app.status.sync.revision
+        when: app.status.operationState.phase in ['Succeeded'] and app.status.health.status == 'Healthy' and (app.metadata.name not in ['lineoneagent-frontend-dev','lineoneagent-backend-dev'] or repo.GetCommitMetadata(app.status.sync.revision).Message matches 'built-from=')
+        send:
+          - app-deployed

--- a/modules/argocd/main.tf
+++ b/modules/argocd/main.tf
@@ -40,7 +40,7 @@ locals {
   # Chart values. `commonLabels` propagates to every chart-rendered
   # resource. Server-config is built conditionally so empty OIDC
   # inputs don't render a half-shaped `oidc.config` block.
-  values = yamlencode({
+  base_values = {
     global = {
       nodeSelector = var.node_selector
       tolerations = [
@@ -109,7 +109,27 @@ locals {
         enabled = false
       }
     }
-  })
+  }
+
+  # Argo CD notifications, folded into the chart values so the chart
+  # renders `argocd-notifications-cm` + `argocd-notifications-secret`
+  # itself. Without this a `helm upgrade` overwrites the live (kubectl-
+  # patched) CM and wipes the telegram token, since both objects are
+  # already Helm-managed. `argocdUrl` is forced from `var.hostname` to
+  # stay single-sourced with `configs.cm.url`. An empty
+  # `notifications_config` collapses the block, so callers that don't
+  # opt in render byte-identical values and see no change.
+  notifications_values = length(var.notifications_config) == 0 ? {} : {
+    notifications = merge(var.notifications_config, {
+      argocdUrl = "https://${var.hostname}"
+      secret = {
+        create = true
+        items  = var.telegram_token != "" ? { "telegram-token" = var.telegram_token } : {}
+      }
+    })
+  }
+
+  values = yamlencode(merge(local.base_values, local.notifications_values))
 }
 
 # ── Resources ─────────────────────────────────────────────────────────────

--- a/modules/argocd/variables.tf
+++ b/modules/argocd/variables.tf
@@ -63,3 +63,16 @@ variable "tolerations" {
   }))
   default = []
 }
+
+variable "notifications_config" {
+  description = "Decoded `notifications:` block (notifiers / templates / triggers) for the argo-cd chart's notifications subsystem, fed by the caller from `config/argocd-notifications.yaml`. The module forces `argocdUrl` from `hostname` and attaches the secret items itself, so those keys can be omitted here. An empty map leaves notifications untouched — the rendered values stay byte-identical and the chart behaves as before."
+  type        = any
+  default     = {}
+}
+
+variable "telegram_token" {
+  description = "Telegram bot token written into `argocd-notifications-secret` (data key `telegram-token`, referenced as `$telegram-token` by the `service.telegram` notifier). Sensitive — it lands in a Helm-managed Secret and in Terraform state. Empty leaves the secret items empty so the notifier stays inert until a token is supplied."
+  type        = string
+  default     = ""
+  sensitive   = true
+}

--- a/variables.tf
+++ b/variables.tf
@@ -155,3 +155,16 @@ variable "zitadel_login_client_pat" {
 # can re-add a sensitive `smarthost_password` variable here and pipe
 # it through `mail.tf`. The home-cluster relay accepts by WG peer-ACL,
 # so no AUTH is needed and the var is unused.
+
+variable "telegram_token" {
+  description = <<-EOT
+    Telegram bot token for the Argo CD "deploy succeeded" notifier. Piped
+    into `module.argocd` → `argocd-notifications-secret` (key
+    `telegram-token`). Sourced from `TF_VAR_telegram_token` in `.env`
+    (gitignored) so the token never enters the repo. Empty leaves the
+    notifications secret without a token and the notifier stays inert.
+  EOT
+  type        = string
+  default     = ""
+  sensitive   = true
+}


### PR DESCRIPTION
## Why

The ArgoCD "deploy succeeded → Telegram" notifications config lived only as an example in `lineoneagent-infra/k8s/argocd/notifications-values.yaml` and was applied to the live `argocd-notifications-cm` / `argocd-notifications-secret` **by hand** (`kubectl patch`). Both objects are Helm-managed (release `argocd`, chart `argo-cd-9.5.11`), so the next `helm upgrade` — i.e. a `terraform apply` of `module.argocd` — would re-render them from the chart values (which had **no** notifications block) and **wipe** the live config and the bot token.

This folds the config into the chart values so the release owns it durably.

## Changes

- **`config/argocd-notifications.yaml`** (new): helm-values-shaped `notifiers` / `templates` / `triggers`, a mirror of the infra source of truth. `argocdUrl` and the `secret` are supplied by the module, not this file; the bot token is referenced as `$telegram-token` and never stored here.
- **`modules/argocd`**: new `notifications_config` + sensitive `telegram_token` inputs, merged into the chart values. `argocdUrl` is forced from `hostname` to stay single-sourced with `configs.cm.url`; the secret items attach the token. An empty config collapses the block, so any other caller renders byte-identical values (no-op).
- **`argocd.tf` / `variables.tf`**: decode the yaml and pass it through; `telegram_token` comes from `TF_VAR_telegram_token` (`.env`, gitignored — token never enters the repo).

## Safety / verification

- `terraform validate` + `terraform fmt -check`: clean.
- Diffed the rendered `service.telegram` / `template.app-deployed` / `trigger.on-deployed` / `context.argocdUrl` against the **live** ConfigMap → **byte-for-byte identical**. `hostname` is `argocd.ipsupport.us`, matching live `context.argocdUrl`.
- Module is called exactly once (`argocd.tf:91`); no `replace`/recreate triggers → expected plan is a single `helm_release.argocd` **update in place**.

## Deploy steps (on roman220, after merge)

1. Add `TF_VAR_telegram_token=<current token>` to `/home/roman220/platform/.env` (value dumped from the live `argocd-notifications-secret`; `.env` is gitignored).
2. **Dry-run gate:** `sudo ./tf plan` — proceed only if the sole change is `module.argocd.helm_release.argocd` *update in place*.
3. `sudo ./tf apply`, then verify CM keys, secret token, and controller logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)