### PR TITLE
logging: VictoriaLogs + Vector + Grafana datasource (services.logging)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`modules/logging` — cluster log aggregation (VictoriaLogs + Vector).**
+  New `services.logging` toggle stands up VictoriaLogs (single-binary store +
+  LogsQL query API, data on a Longhorn PV, time-based `retention_period`) and a
+  Vector DaemonSet that tails every node's `/var/log/pods` and ships to it.
+  Replaces node-local kubelet log rotation (~50 MiB/container, lost on pod
+  delete) with time-retained, searchable logs in the existing Grafana — the
+  module emits a sidecar-discovered Grafana datasource and the root installs
+  the VictoriaLogs Grafana plugin (`monitoring_grafana_extra_values`, gated on
+  the toggle) for full LogsQL + the Explore UI. Lands in `monitoring`. Alerting
+  (vmalert → Alertmanager) is a separate follow-up.
 - **`redirect_hosts:` — per-host 301 redirects on a domain.** A domain
   yaml can now carry `redirect_hosts: { <prefix>: <target-fqdn> }`
   alongside (or instead of) the zone-wide `redirect_to:`. Each entry

--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -168,6 +168,19 @@ services:
   kured:
     enabled: false
 
+  # Cluster log aggregation — VictoriaLogs (store + LogsQL query) + a
+  # Vector DaemonSet collector + a Grafana datasource. Replaces node-local
+  # kubelet log rotation (~50 MiB/container, lost on pod delete) with a
+  # time-retained, searchable store in the existing Grafana. Lands in the
+  # `monitoring` namespace next to kube-prometheus-stack.
+  logging:
+    enabled: false
+    # namespace: monitoring        # co-locate with Grafana (datasource sidecar)
+    retention_period: 30d          # TIME-based retention (not the kubelet size cap)
+    storage_class: longhorn        # "" = node-local local-path (lost on node loss)
+    storage_size: 50Gi
+    # node_selector: {}            # empty = scheduler picks (fine with Longhorn PV)
+
   # Longhorn — distributed block storage. Provides a `longhorn`
   # StorageClass that PVCs can use instead of the per-node
   # hostPath default. Volumes get replicated across cluster

--- a/locals.tf
+++ b/locals.tf
@@ -61,6 +61,17 @@ locals {
       kured = {
         enabled = false
       }
+      # Cluster log aggregation — VictoriaLogs store + Vector collector +
+      # Grafana datasource (see modules/logging). Time-retained, searchable
+      # logs in the existing Grafana, replacing node-local kubelet rotation.
+      logging = {
+        enabled          = false
+        namespace        = "monitoring"
+        retention_period = "30d"
+        storage_class    = "longhorn"
+        storage_size     = "50Gi"
+        node_selector    = {}
+      }
       # Optional Cloudflare DNS-01 ACME solver — adds a second solver to
       # the Let's Encrypt ClusterIssuers gated by `dns_zones`. HTTP-01
       # stays the default for hosts outside those zones. Required for
@@ -300,6 +311,7 @@ locals {
       vault            = merge(local._platform_defaults.services.vault, try(local._platform_services.vault, {}))
       argocd           = merge(local._platform_defaults.services.argocd, try(local._platform_services.argocd, {}))
       kured            = merge(local._platform_defaults.services.kured, try(local._platform_services.kured, {}))
+      logging          = merge(local._platform_defaults.services.logging, try(local._platform_services.logging, {}))
       dns01_cloudflare = merge(local._platform_defaults.services.dns01_cloudflare, try(local._platform_services.dns01_cloudflare, {}))
       longhorn         = merge(local._platform_defaults.services.longhorn, try(local._platform_services.longhorn, {}))
       metallb          = merge(local._platform_defaults.services.metallb, try(local._platform_services.metallb, {}))

--- a/logging.tf
+++ b/logging.tf
@@ -1,0 +1,19 @@
+# Cluster log aggregation — VictoriaLogs (store/query) + Vector (collector) +
+# a Grafana datasource. Lands in the `monitoring` namespace next to the
+# kube-prometheus-stack so the Grafana datasource sidecar discovers the
+# emitted ConfigMap. The VictoriaLogs Grafana plugin is installed through the
+# addons module (`monitoring_grafana_extra_values`, in main.tf) gated on this
+# service being enabled. Toggle via `services.logging` in config/platform.yaml.
+module "logging" {
+  source     = "./modules/logging"
+  depends_on = [module.addons]
+
+  context   = module.platform_label.context
+  enabled   = local.platform.services.logging.enabled
+  namespace = local.platform.services.logging.namespace
+
+  retention_period = local.platform.services.logging.retention_period
+  storage_class    = local.platform.services.logging.storage_class
+  storage_size     = local.platform.services.logging.storage_size
+  node_selector    = local.platform.services.logging.node_selector
+}

--- a/main.tf
+++ b/main.tf
@@ -145,6 +145,14 @@ module "addons" {
   traefik_deployment_kind = local.platform.services.addons.traefik_deployment_kind
   traefik_tolerations     = local.platform.services.addons.traefik_tolerations
   traefik_node_selector   = local.platform.services.addons.traefik_node_selector
+
+  # Install the VictoriaLogs Grafana plugin when the logging stack is on,
+  # so the datasource the `logging` module emits (sidecar-discovered) renders
+  # with full LogsQL + the Explore field/time UI. Gated so a disabled logging
+  # stack adds nothing to the Grafana pod. The plugin downloads at pod start.
+  monitoring_grafana_extra_values = local.platform.services.logging.enabled ? {
+    plugins = ["victoriametrics-logs-datasource"]
+  } : {}
 }
 
 # =============================================================================

--- a/modules/logging/CHANGELOG.md
+++ b/modules/logging/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+All notable changes to this module are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
+the project itself follows [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+- Initial module: cluster log aggregation with **VictoriaLogs** (single-binary
+  store + LogsQL query API on :9428, data on a Longhorn PV, time-based
+  `-retentionPeriod`) and a **Vector** DaemonSet collector (tails every node's
+  `/var/log/pods` via the `kubernetes_logs` source, ships to VictoriaLogs over
+  the Elasticsearch-compatible ingest endpoint). Registers a **Grafana
+  datasource** via the kube-prometheus-stack datasource sidecar (ConfigMap
+  labelled `grafana_datasource=1`) using the native VictoriaLogs plugin for
+  full LogsQL + the Explore UI. Vector tolerates all taints (collects from
+  every node); VictoriaLogs runs as a single hardened non-root pod. Alerting
+  (vmalert + Alertmanager receiver) is layered separately. CHANGELOG / README /
+  variables / outputs per AGENT.md module conventions.

--- a/modules/logging/README.md
+++ b/modules/logging/README.md
@@ -1,0 +1,46 @@
+# modules/logging
+
+Cluster log aggregation: **VictoriaLogs** (store + query) + **Vector**
+(per-node collector) + a **Grafana** datasource. Replaces node-local kubelet
+log rotation (≈50 MiB/container, lost on pod delete) with a time-retained,
+searchable store.
+
+```
+every node:  /var/log/pods/*  →  Vector DaemonSet (kubernetes_logs)
+                                       │  HTTP ingest :9428
+                                       ▼
+                             VictoriaLogs (1 pod, -retentionPeriod, Longhorn PV)
+                                       ▲
+                             Grafana (kube-prometheus-stack) ── LogsQL datasource
+```
+
+## Design
+
+- **Namespace `monitoring`** — co-located with Grafana/Prometheus/Alertmanager
+  so the Grafana datasource sidecar discovers the emitted ConfigMap
+  (`grafana_datasource=1`) with no cross-namespace wiring.
+- **Storage = Longhorn** by default — VictoriaLogs has no object-storage
+  tiering, so the replicated PV is the durability story (survives node loss,
+  pod reschedules anywhere). Set `storage_class = ""` for node-local
+  `local-path` (faster, pinned, lost on node loss).
+- **Retention is time-based** (`retention_period`, default `30d`) — the win
+  over the kubelet's size cap: real history across the whole cluster,
+  surviving pod deletes and rollouts.
+- **Vector runs on every node** (`vector_tolerations` defaults to tolerate
+  all) — log collection must cover the whole cluster, including tainted nodes.
+- **Grafana plugin** — the datasource uses `victoriametrics-logs-datasource`
+  (full LogsQL + Explore field/time UI). The plugin is installed via the
+  addons module's `monitoring_grafana_extra_values.plugins`, wired at the root
+  (gated on this service being enabled). Without the plugin, a Loki-compatible
+  datasource type is the fallback (reduced query surface).
+
+## Inputs / outputs
+
+See `variables.tf` / `outputs.tf`. Toggle via `services.logging` in
+`config/platform.yaml`.
+
+## Not in this module
+
+Alerting (vmalert evaluating LogsQL rules → Alertmanager → email) is a
+separate, layered concern wired at the root once a notification channel is
+chosen.

--- a/modules/logging/main.tf
+++ b/modules/logging/main.tf
@@ -1,0 +1,376 @@
+terraform {
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+  }
+}
+
+# =============================================================================
+# Cluster log aggregation — VictoriaLogs (store/query) + Vector (collector)
+# =============================================================================
+#
+# Replaces "logs only live on the node until the kubelet rotates them away
+# (50 MiB/container, gone on pod delete)" with a real, time-retained,
+# searchable log store:
+#
+#   every node:  /var/log/pods/*  →  Vector DaemonSet (kubernetes_logs,
+#                                     auto-enriched with pod/ns/labels)
+#                                          │ HTTP ingest :9428
+#                                          ▼
+#                                VictoriaLogs (1 pod, -retentionPeriod,
+#                                     data on a Longhorn PV)
+#                                          ▲
+#                                Grafana (kube-prometheus-stack) ── LogsQL
+#                                     datasource (sidecar-discovered ConfigMap)
+#
+# Everything lands in the `monitoring` namespace so the Grafana datasource
+# sidecar picks up the ConfigMap with no cross-namespace plumbing. VictoriaLogs
+# is a single static binary (low RAM); Vector runs on every node (tolerates all
+# taints). Alerting (vmalert + Alertmanager email receiver) is layered on top
+# separately — this module is the store + collector + datasource.
+
+locals {
+  instances = var.enabled ? toset(["enabled"]) : toset([])
+  tags      = module.label.tags
+
+  vl_name     = "victorialogs"
+  vector_name = "vector"
+
+  # kubernetes_logs emits `.message` / `.timestamp` / `.kubernetes.*`;
+  # map those onto VictoriaLogs' message/time/stream fields at ingest.
+  vector_config = yamlencode({
+    data_dir = "/vector-data-dir"
+    api      = { enabled = false }
+    sources = {
+      k8s = { type = "kubernetes_logs" }
+    }
+    sinks = {
+      vlogs = {
+        type        = "elasticsearch"
+        inputs      = ["k8s"]
+        endpoints   = ["http://${local.vl_name}:9428/insert/elasticsearch/"]
+        mode        = "bulk"
+        api_version = "v8"
+        compression = "gzip"
+        healthcheck = { enabled = false }
+        query = {
+          _msg_field     = "message"
+          _time_field    = "timestamp"
+          _stream_fields = "kubernetes.pod_namespace,kubernetes.pod_name,kubernetes.container_name"
+        }
+      }
+    }
+  })
+}
+
+module "label" {
+  source = "git::https://github.com/rromenskyi/terraform-null-label.git?ref=v0.1.0"
+
+  context   = var.context
+  namespace = var.namespace
+  name      = "logging"
+  tags = {
+    "app.kubernetes.io/part-of" = "observability"
+  }
+}
+
+# ── VictoriaLogs — store + query API ─────────────────────────────────────────
+
+resource "kubernetes_service_v1" "victorialogs" {
+  for_each = local.instances
+
+  metadata {
+    name      = local.vl_name
+    namespace = var.namespace
+    labels    = merge(local.tags, { app = local.vl_name })
+  }
+
+  spec {
+    selector = { app = local.vl_name }
+    port {
+      name        = "http"
+      port        = 9428
+      target_port = 9428
+    }
+  }
+}
+
+resource "kubernetes_stateful_set_v1" "victorialogs" {
+  for_each = local.instances
+
+  metadata {
+    name      = local.vl_name
+    namespace = var.namespace
+    labels    = merge(local.tags, { app = local.vl_name })
+  }
+
+  spec {
+    replicas     = 1
+    service_name = local.vl_name
+    selector {
+      match_labels = { app = local.vl_name }
+    }
+
+    template {
+      metadata {
+        labels = merge(local.tags, { app = local.vl_name })
+      }
+
+      spec {
+        security_context {
+          run_as_user     = 1000
+          run_as_group    = 1000
+          run_as_non_root = true
+          fs_group        = 1000
+        }
+
+        node_selector = var.node_selector
+
+        container {
+          name  = local.vl_name
+          image = var.victorialogs_image
+
+          args = [
+            "-storageDataPath=/vlogs",
+            "-retentionPeriod=${var.retention_period}",
+            "-httpListenAddr=:9428",
+          ]
+
+          port {
+            name           = "http"
+            container_port = 9428
+          }
+
+          volume_mount {
+            name       = "data"
+            mount_path = "/vlogs"
+          }
+
+          resources {
+            requests = var.victorialogs_resources.requests
+            limits   = var.victorialogs_resources.limits
+          }
+
+          readiness_probe {
+            http_get {
+              path = "/health"
+              port = 9428
+            }
+            initial_delay_seconds = 5
+            period_seconds        = 15
+          }
+
+          security_context {
+            allow_privilege_escalation = false
+            capabilities { drop = ["ALL"] }
+          }
+        }
+      }
+    }
+
+    volume_claim_template {
+      metadata {
+        name = "data"
+      }
+      spec {
+        access_modes       = ["ReadWriteOnce"]
+        storage_class_name = var.storage_class != "" ? var.storage_class : null
+        resources {
+          requests = { storage = var.storage_size }
+        }
+      }
+    }
+  }
+}
+
+# ── Vector — per-node log collector (DaemonSet) ──────────────────────────────
+
+resource "kubernetes_service_account_v1" "vector" {
+  for_each = local.instances
+
+  metadata {
+    name      = local.vector_name
+    namespace = var.namespace
+    labels    = merge(local.tags, { app = local.vector_name })
+  }
+}
+
+resource "kubernetes_cluster_role_v1" "vector" {
+  for_each = local.instances
+
+  metadata {
+    name   = "${var.namespace}-vector-log-reader"
+    labels = local.tags
+  }
+
+  rule {
+    api_groups = [""]
+    resources  = ["namespaces", "pods", "nodes"]
+    verbs      = ["get", "list", "watch"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding_v1" "vector" {
+  for_each = local.instances
+
+  metadata {
+    name   = "${var.namespace}-vector-log-reader"
+    labels = local.tags
+  }
+
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = kubernetes_cluster_role_v1.vector["enabled"].metadata[0].name
+  }
+
+  subject {
+    kind      = "ServiceAccount"
+    name      = kubernetes_service_account_v1.vector["enabled"].metadata[0].name
+    namespace = var.namespace
+  }
+}
+
+resource "kubernetes_config_map_v1" "vector" {
+  for_each = local.instances
+
+  metadata {
+    name      = "${local.vector_name}-config"
+    namespace = var.namespace
+    labels    = merge(local.tags, { app = local.vector_name })
+  }
+
+  data = {
+    "vector.yaml" = local.vector_config
+  }
+}
+
+resource "kubernetes_daemon_set_v1" "vector" {
+  for_each = local.instances
+
+  metadata {
+    name      = local.vector_name
+    namespace = var.namespace
+    labels    = merge(local.tags, { app = local.vector_name })
+  }
+
+  spec {
+    selector {
+      match_labels = { app = local.vector_name }
+    }
+
+    template {
+      metadata {
+        labels      = merge(local.tags, { app = local.vector_name })
+        annotations = { "checksum/config" = sha256(local.vector_config) }
+      }
+
+      spec {
+        service_account_name = kubernetes_service_account_v1.vector["enabled"].metadata[0].name
+
+        # Reads /var/log/pods/* which are root-owned (mode 0600) — the
+        # collector must run as root to tail every pod's logs.
+        security_context {
+          run_as_user = 0
+        }
+
+        dynamic "toleration" {
+          for_each = var.vector_tolerations
+          content {
+            key      = try(toleration.value.key, null)
+            operator = try(toleration.value.operator, null)
+            value    = try(toleration.value.value, null)
+            effect   = try(toleration.value.effect, null)
+          }
+        }
+
+        container {
+          name  = local.vector_name
+          image = var.vector_image
+          args  = ["--config", "/etc/vector/vector.yaml"]
+
+          env {
+            name = "VECTOR_SELF_NODE_NAME"
+            value_from {
+              field_ref { field_path = "spec.nodeName" }
+            }
+          }
+
+          volume_mount {
+            name       = "config"
+            mount_path = "/etc/vector"
+            read_only  = true
+          }
+          volume_mount {
+            name       = "var-log"
+            mount_path = "/var/log"
+            read_only  = true
+          }
+          volume_mount {
+            name       = "data-dir"
+            mount_path = "/vector-data-dir"
+          }
+
+          resources {
+            requests = var.vector_resources.requests
+            limits   = var.vector_resources.limits
+          }
+        }
+
+        volume {
+          name = "config"
+          config_map {
+            name = kubernetes_config_map_v1.vector["enabled"].metadata[0].name
+          }
+        }
+        volume {
+          name = "var-log"
+          host_path {
+            path = "/var/log"
+          }
+        }
+        volume {
+          name = "data-dir"
+          host_path {
+            path = "/var/lib/vector"
+            type = "DirectoryOrCreate"
+          }
+        }
+      }
+    }
+  }
+}
+
+# ── Grafana datasource — sidecar discovery ───────────────────────────────────
+# The kube-prometheus-stack Grafana runs a datasource sidecar that watches
+# this namespace for ConfigMaps labelled `grafana_datasource=1` and loads
+# them. Registers VictoriaLogs via its native Grafana plugin
+# (`victoriametrics-logs-datasource`, installed through the addons
+# `monitoring_grafana_extra_values.plugins`), giving full LogsQL + the
+# Explore field/time UI.
+
+resource "kubernetes_config_map_v1" "grafana_datasource" {
+  for_each = local.instances
+
+  metadata {
+    name      = "victorialogs-datasource"
+    namespace = var.namespace
+    labels    = merge(local.tags, { grafana_datasource = "1" })
+  }
+
+  data = {
+    "victorialogs.yaml" = yamlencode({
+      apiVersion = 1
+      datasources = [{
+        name      = "VictoriaLogs"
+        type      = "victoriametrics-logs-datasource"
+        access    = "proxy"
+        url       = "http://${local.vl_name}:9428"
+        isDefault = false
+        editable  = true
+      }]
+    })
+  }
+}

--- a/modules/logging/outputs.tf
+++ b/modules/logging/outputs.tf
@@ -1,0 +1,14 @@
+output "enabled" {
+  description = "Whether the logging stack is deployed."
+  value       = var.enabled
+}
+
+output "victorialogs_url" {
+  description = "In-cluster VictoriaLogs HTTP endpoint (ingest + LogsQL query API). Null when disabled. Consumed by a future vmalert datasource + as the Grafana datasource URL."
+  value       = var.enabled ? "http://${local.vl_name}.${var.namespace}.svc.cluster.local:9428" : null
+}
+
+output "namespace" {
+  description = "Namespace the stack runs in."
+  value       = var.namespace
+}

--- a/modules/logging/variables.tf
+++ b/modules/logging/variables.tf
@@ -1,0 +1,85 @@
+variable "context" {
+  description = "Serialized null-label context from the platform root (`module.platform_label.context`). Chains this module's labels off the platform-wide tag set."
+  type        = any
+  default     = null
+}
+
+variable "enabled" {
+  description = "Master toggle. When false every resource collapses to zero via the `instances` toset, so disabling the service after the fact tears the whole stack (VictoriaLogs + Vector + datasource) down cleanly."
+  type        = bool
+  default     = false
+}
+
+variable "namespace" {
+  description = "Namespace for VictoriaLogs + Vector. Defaults to `monitoring` so the stack sits next to Grafana/Prometheus/Alertmanager and the Grafana datasource sidecar (which watches this namespace) picks up the emitted datasource ConfigMap with no cross-namespace plumbing."
+  type        = string
+  default     = "monitoring"
+}
+
+variable "victorialogs_image" {
+  description = "VictoriaLogs container image. Single static binary; HTTP ingest + query API on :9428, data on a local path."
+  type        = string
+  default     = "victoriametrics/victoria-logs:v1.51.0"
+}
+
+variable "vector_image" {
+  description = "Vector collector image (the DaemonSet agent that tails every node's container logs and ships them to VictoriaLogs)."
+  type        = string
+  default     = "timberio/vector:0.43.1-distroless-static"
+}
+
+variable "retention_period" {
+  description = "VictoriaLogs `-retentionPeriod`. TIME-based retention (unlike the kubelet's 50 MiB/container size cap) — logs older than this are dropped regardless of volume. Accepts VictoriaMetrics duration form (`30d`, `90d`, `1y`)."
+  type        = string
+  default     = "30d"
+}
+
+variable "storage_class" {
+  description = "StorageClass for the VictoriaLogs data PVC. Default `longhorn` (replicated network block storage) so the log store survives a node loss and the pod reschedules anywhere — VictoriaLogs has no S3/object-storage tiering, so the PV is the durability story. Set to `\"\"` for the node-local `local-path` default (faster, but pinned to one node + lost on node loss)."
+  type        = string
+  default     = "longhorn"
+}
+
+variable "storage_size" {
+  description = "VictoriaLogs data PVC size. VictoriaLogs compresses ~10x, so a small cluster's 30d of logs fits comfortably in tens of GiB; size for peak-volume headroom."
+  type        = string
+  default     = "50Gi"
+}
+
+variable "node_selector" {
+  description = "Node placement for the VictoriaLogs StatefulSet pod. Empty (default) lets the scheduler pick — fine with a Longhorn PV (it follows the pod). Pin only if using node-local storage."
+  type        = map(string)
+  default     = {}
+}
+
+variable "victorialogs_resources" {
+  description = "Resource requests/limits for the VictoriaLogs pod. VictoriaLogs is light for a small cluster; raise limits if ingest volume grows."
+  type = object({
+    requests = map(string)
+    limits   = map(string)
+  })
+  default = {
+    requests = { cpu = "100m", memory = "256Mi" }
+    limits   = { cpu = "2", memory = "1Gi" }
+  }
+}
+
+variable "vector_tolerations" {
+  description = "Tolerations for the Vector DaemonSet so it runs on EVERY node (including tainted ones) — log collection must cover the whole cluster. Default tolerates everything (operate-everywhere collector); narrow it to exclude specific nodes."
+  type        = list(any)
+  default = [
+    { operator = "Exists" },
+  ]
+}
+
+variable "vector_resources" {
+  description = "Resource requests/limits per Vector DaemonSet pod (one per node)."
+  type = object({
+    requests = map(string)
+    limits   = map(string)
+  })
+  default = {
+    requests = { cpu = "50m", memory = "128Mi" }
+    limits   = { cpu = "500m", memory = "256Mi" }
+  }
+}


### PR DESCRIPTION
## What

New `modules/logging` + `services.logging` toggle: cluster log aggregation with **VictoriaLogs** (store + LogsQL) + a **Vector** DaemonSet collector + a **Grafana** datasource. Replaces node-local kubelet log rotation (~50 MiB/container, gone on pod delete) with time-retained, searchable logs in the existing Grafana.

```
every node: /var/log/pods/* → Vector (DaemonSet) → VictoriaLogs (:9428, Longhorn PV, 30d)
                                                          ↑ Grafana LogsQL datasource
```

## Design

- **monitoring namespace** — co-located with kube-prometheus-stack so the Grafana datasource sidecar discovers the emitted ConfigMap (`grafana_datasource=1`).
- **Longhorn PV** — VictoriaLogs has no object-storage tiering; the replicated PV is durability (survives node loss).
- **Time-based retention** (`retention_period`, 30d) — the win over the kubelet size cap.
- **Vector on all nodes** (tolerates every taint).
- **Native VictoriaLogs Grafana plugin** installed via the addons `monitoring_grafana_extra_values` (gated on the toggle) for full LogsQL + Explore.

## Verified live

- 1358 lines / 5m ingested across namespaces, queryable via LogsQL (`stats by namespace`).
- Vector healthy to the VL endpoint on 4/5 nodes (5th is the down `matrix` node).
- Grafana wrote the datasource provisioning file + installed the plugin.

## Follow-up

Alerting (vmalert evaluating LogsQL rules → Alertmanager → email) is a separate layered PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)