### PR TITLE
logging: alerting — vmalert LogsQL rules → Alertmanager → email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   delete) with time-retained, searchable logs in the existing Grafana — the
   module emits a sidecar-discovered Grafana datasource and the root installs
   the VictoriaLogs Grafana plugin (`monitoring_grafana_extra_values`, gated on
-  the toggle) for full LogsQL + the Explore UI. Lands in `monitoring`. Alerting
-  (vmalert → Alertmanager) is a separate follow-up.
+  the toggle) for full LogsQL + the Explore UI. Lands in `monitoring`.
+- **`services.logging.alert_email` — log alerts to email.** Set a (local)
+  mailbox to also deploy **vmalert** evaluating LogsQL alert rules against
+  VictoriaLogs → the existing Alertmanager → an `AlertmanagerConfig` email
+  receiver, delivering through the in-cluster Stalwart SMTP (local mailbox, no
+  relay-trust change or credentials). Ships two tunable starter rules
+  (critical-pattern + error-burst). Empty = no alerting (store + collector
+  only). Verified e2e end to delivered email.
 - **`redirect_hosts:` — per-host 301 redirects on a domain.** A domain
   yaml can now carry `redirect_hosts: { <prefix>: <target-fqdn> }`
   alongside (or instead of) the zone-wide `redirect_to:`. Each entry

--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -180,6 +180,9 @@ services:
     storage_class: longhorn        # "" = node-local local-path (lost on node loss)
     storage_size: 50Gi
     # node_selector: {}            # empty = scheduler picks (fine with Longhorn PV)
+    # alert_email: ""              # set a LOCAL mailbox to wire vmalert LogsQL
+    #                              # alerts → Alertmanager → email (empty = no
+    #                              # alerting, store + collector only)
 
   # Longhorn — distributed block storage. Provides a `longhorn`
   # StorageClass that PVCs can use instead of the per-node

--- a/locals.tf
+++ b/locals.tf
@@ -71,6 +71,10 @@ locals {
         storage_class    = "longhorn"
         storage_size     = "50Gi"
         node_selector    = {}
+        # Empty = store + collector only (no alerting). Set to a LOCAL mailbox
+        # (e.g. an @ipsupport.us address Stalwart delivers without auth) to
+        # wire vmalert LogsQL alerts → Alertmanager → email.
+        alert_email = ""
       }
       # Optional Cloudflare DNS-01 ACME solver — adds a second solver to
       # the Let's Encrypt ClusterIssuers gated by `dns_zones`. HTTP-01

--- a/logging.tf
+++ b/logging.tf
@@ -16,4 +16,9 @@ module "logging" {
   storage_class    = local.platform.services.logging.storage_class
   storage_size     = local.platform.services.logging.storage_size
   node_selector    = local.platform.services.logging.node_selector
+
+  # Alerting — empty alert_email leaves the store + collector running with no
+  # vmalert / Alertmanager receiver. Set it to wire LogsQL rule alerts to email
+  # via the existing Alertmanager + the in-cluster Stalwart SMTP (local mailbox).
+  alert_email = local.platform.services.logging.alert_email
 }

--- a/modules/logging/CHANGELOG.md
+++ b/modules/logging/CHANGELOG.md
@@ -8,6 +8,20 @@ the project itself follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **Alerting — vmalert (LogsQL rules) → existing Alertmanager → email.** When
+  `alert_email` is set, deploys a vmalert Deployment that evaluates a
+  `type: vlogs` rule group (from `alert_rules`, two starter templates:
+  critical-pattern + error-burst) against VictoriaLogs and fires to the
+  kube-prometheus-stack Alertmanager. An `AlertmanagerConfig` adds an email
+  receiver routed to the operator's mailbox through the in-cluster Stalwart
+  SMTP listener (local delivery — no relay-trust change or credentials).
+  Notes: alerts carry an `alert_source=log` label and the route matches it, so
+  the receiver gets ONLY log alerts (not the built-in metric alerts that also
+  carry `namespace=monitoring`); the email `hello` (EHLO) is a real FQDN
+  (`alertmanager.ipsupport.us`) because Stalwart rejects the pod hostname with
+  `550 Invalid EHLO domain`; `requireTLS=false` for the in-cluster hop. Empty
+  `alert_email` deploys none of this (store + collector only). Verified e2e: a
+  panic log line → vmalert fires → email delivered to the mailbox.
 - Initial module: cluster log aggregation with **VictoriaLogs** (single-binary
   store + LogsQL query API on :9428, data on a Longhorn PV, time-based
   `-retentionPeriod`) and a **Vector** DaemonSet collector (tails every node's

--- a/modules/logging/main.tf
+++ b/modules/logging/main.tf
@@ -4,6 +4,10 @@ terraform {
       source  = "hashicorp/kubernetes"
       version = "~> 2.0"
     }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = "~> 1.14"
+    }
   }
 }
 
@@ -33,10 +37,41 @@ terraform {
 
 locals {
   instances = var.enabled ? toset(["enabled"]) : toset([])
-  tags      = module.label.tags
+  # Alerting (vmalert + Alertmanager receiver) only when an alert email is set.
+  alerting = var.enabled && var.alert_email != "" ? toset(["enabled"]) : toset([])
+  tags     = module.label.tags
 
-  vl_name     = "victorialogs"
-  vector_name = "vector"
+  vl_name      = "victorialogs"
+  vector_name  = "vector"
+  vmalert_name = "vmalert"
+
+  # vmalert rule file: one `type: vlogs` group whose rules evaluate the
+  # operator's LogsQL `stats count() | filter` queries against VictoriaLogs.
+  # Each alert carries `namespace = <this ns>` so the AlertmanagerConfig's
+  # OnNamespace matcher routes it to the email receiver.
+  vmalert_rules = yamlencode({
+    groups = [{
+      name     = "log-alerts"
+      type     = "vlogs"
+      interval = "1m"
+      rules = [
+        for k, r in var.alert_rules : {
+          alert = k
+          expr  = r.query
+          for   = r.for
+          labels = {
+            severity  = r.severity
+            namespace = var.namespace
+            # Distinguishes log alerts from the built-in kube-prometheus-stack
+            # metric alerts (which also carry namespace=monitoring) so the
+            # email route matches ONLY these.
+            alert_source = "log"
+          }
+          annotations = { summary = r.summary }
+        }
+      ]
+    }]
+  })
 
   # kubernetes_logs emits `.message` / `.timestamp` / `.kubernetes.*`;
   # map those onto VictoriaLogs' message/time/stream fields at ingest.
@@ -373,4 +408,145 @@ resource "kubernetes_config_map_v1" "grafana_datasource" {
       }]
     })
   }
+}
+
+# ── Alerting — vmalert (LogsQL rules) → existing Alertmanager → email ─────────
+# Only when `alert_email` is set. vmalert evaluates the `type: vlogs` rule
+# group against VictoriaLogs' stats endpoint and fires to the kube-prometheus-
+# stack Alertmanager; an AlertmanagerConfig adds the email receiver. The store
+# + collector run with no alerting when this is empty.
+
+resource "kubernetes_config_map_v1" "vmalert_rules" {
+  for_each = local.alerting
+
+  metadata {
+    name      = "${local.vmalert_name}-rules"
+    namespace = var.namespace
+    labels    = merge(local.tags, { app = local.vmalert_name })
+  }
+
+  data = {
+    "log-alerts.yaml" = local.vmalert_rules
+  }
+}
+
+resource "kubernetes_deployment_v1" "vmalert" {
+  for_each = local.alerting
+
+  metadata {
+    name      = local.vmalert_name
+    namespace = var.namespace
+    labels    = merge(local.tags, { app = local.vmalert_name })
+  }
+
+  spec {
+    replicas = 1
+    selector {
+      match_labels = { app = local.vmalert_name }
+    }
+
+    template {
+      metadata {
+        labels      = merge(local.tags, { app = local.vmalert_name })
+        annotations = { "checksum/rules" = sha256(local.vmalert_rules) }
+      }
+
+      spec {
+        security_context {
+          run_as_user     = 1000
+          run_as_non_root = true
+        }
+
+        container {
+          name  = local.vmalert_name
+          image = var.vmalert_image
+
+          args = [
+            "-rule=/etc/vmalert/log-alerts.yaml",
+            "-datasource.url=http://${local.vl_name}:9428",
+            "-notifier.url=${var.alertmanager_url}",
+            "-evaluationInterval=1m",
+          ]
+
+          port {
+            name           = "http"
+            container_port = 8880
+          }
+
+          volume_mount {
+            name       = "rules"
+            mount_path = "/etc/vmalert"
+            read_only  = true
+          }
+
+          resources {
+            requests = { cpu = "20m", memory = "64Mi" }
+            limits   = { cpu = "200m", memory = "192Mi" }
+          }
+
+          security_context {
+            allow_privilege_escalation = false
+            capabilities { drop = ["ALL"] }
+          }
+        }
+
+        volume {
+          name = "rules"
+          config_map {
+            name = kubernetes_config_map_v1.vmalert_rules["enabled"].metadata[0].name
+          }
+        }
+      }
+    }
+  }
+}
+
+# Email receiver on the existing kube-prometheus-stack Alertmanager. The
+# Alertmanager CR selects AlertmanagerConfigs cluster-wide (selector `{}`); the
+# default `OnNamespace` matcher strategy scopes this to alerts labelled
+# `namespace=<this ns>` — which the vmalert rules above all carry. Sends through
+# the in-cluster Stalwart inbound listener (plaintext, in-cluster hop) to the
+# operator's local mailbox; no relay-trust change or SMTP credentials.
+resource "kubectl_manifest" "alertmanager_email" {
+  for_each = local.alerting
+
+  yaml_body = yamlencode({
+    apiVersion = "monitoring.coreos.com/v1alpha1"
+    kind       = "AlertmanagerConfig"
+    metadata = {
+      name      = "log-alerts-email"
+      namespace = var.namespace
+      labels    = local.tags
+    }
+    spec = {
+      route = {
+        receiver       = "email"
+        groupBy        = ["alertname"]
+        groupWait      = "30s"
+        groupInterval  = "5m"
+        repeatInterval = "3h"
+        # Only our log alerts (the OnNamespace strategy already injects a
+        # `namespace=<ns>` matcher; this narrows to log alerts so the
+        # built-in metric alerts in this namespace don't hit the receiver).
+        matchers = [{
+          name      = "alert_source"
+          value     = "log"
+          matchType = "="
+        }]
+      }
+      receivers = [{
+        name = "email"
+        emailConfigs = [{
+          to   = var.alert_email
+          from = var.smtp_from
+          # EHLO hostname — must be a valid FQDN or Stalwart rejects the
+          # session with "550 Invalid EHLO domain" (the pod hostname isn't).
+          hello        = var.smtp_hello
+          smarthost    = var.smtp_smarthost
+          requireTLS   = false
+          sendResolved = true
+        }]
+      }]
+    }
+  })
 }

--- a/modules/logging/variables.tf
+++ b/modules/logging/variables.tf
@@ -83,3 +83,64 @@ variable "vector_resources" {
     limits   = { cpu = "500m", memory = "256Mi" }
   }
 }
+
+# ── Alerting (vmalert → Alertmanager → email) ────────────────────────────────
+
+variable "alert_email" {
+  description = "Destination address for log alerts. Empty (default) deploys NO alerting (no vmalert, no Alertmanager receiver) — the store + collector run alone. Set it to wire vmalert (evaluates the LogsQL rules against VictoriaLogs) + an AlertmanagerConfig email receiver on the existing kube-prometheus-stack Alertmanager."
+  type        = string
+  default     = ""
+}
+
+variable "smtp_smarthost" {
+  description = "SMTP host:port Alertmanager sends through. Default is the in-cluster Stalwart inbound listener, which accepts unauthenticated submission for LOCAL recipients (e.g. an `@ipsupport.us` mailbox) — no relay-trust change or credentials needed. External recipients would require auth/relay changes (out of scope)."
+  type        = string
+  default     = "stalwart-smtp.mail.svc.cluster.local:25"
+}
+
+variable "smtp_from" {
+  description = "Envelope/From address for alert emails."
+  type        = string
+  default     = "alerts@ipsupport.us"
+}
+
+variable "smtp_hello" {
+  description = "EHLO hostname Alertmanager presents to the SMTP server. Must be a valid FQDN — the default pod hostname is not, and Stalwart rejects the session with `550 Invalid EHLO domain`."
+  type        = string
+  default     = "alertmanager.ipsupport.us"
+}
+
+variable "vmalert_image" {
+  description = "vmalert container image (VictoriaMetrics' alerting evaluator). Runs the LogsQL rule groups against VictoriaLogs and fires to Alertmanager."
+  type        = string
+  default     = "victoriametrics/vmalert:v1.106.0"
+}
+
+variable "alertmanager_url" {
+  description = "In-cluster Alertmanager endpoint vmalert fires alerts to (the existing kube-prometheus-stack Alertmanager)."
+  type        = string
+  default     = "http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093"
+}
+
+variable "alert_rules" {
+  description = "Log alert rules, each a small object the module renders into a vmalert `type: vlogs` rule group. `query` is LogsQL returning a single count via `stats count() as <name>` (the module thresholds with `| filter`); `for` is the sustain duration; `summary` is the notification text. Defaults ship two starter templates (critical-pattern + error burst) the operator can tune/extend."
+  type = map(object({
+    query    = string
+    for      = optional(string, "5m")
+    severity = optional(string, "warning")
+    summary  = string
+  }))
+  default = {
+    critical-log-pattern = {
+      query   = "_time:10m (panic OR fatal OR segfault OR \"OOMKilled\" OR \"out of memory\") | stats count() as hits | filter hits:>0"
+      for     = "1m"
+      summary = "{{ $value }} critical log line(s) (panic/fatal/OOM) in the last 10m"
+    }
+    error-burst = {
+      query    = "_time:5m error | stats count() as errors | filter errors:>500"
+      for      = "5m"
+      severity = "warning"
+      summary  = "Cluster-wide error-log burst: {{ $value }} 'error' lines in 5m (tune the >500 threshold)"
+    }
+  }
+}


### PR DESCRIPTION
## What

When `services.logging.alert_email` is set, the logging module also deploys **vmalert** (evaluates a `type: vlogs` LogsQL rule group against VictoriaLogs) + an **AlertmanagerConfig** email receiver on the existing kube-prometheus-stack Alertmanager. Alerts deliver through the in-cluster **Stalwart** SMTP listener to a local mailbox — no relay-trust change, no SMTP credentials.

Two tunable starter rules: `critical-log-pattern` (panic/fatal/segfault/OOM) and `error-burst` (cluster-wide error-log storm). Empty `alert_email` deploys none of it (store + collector only).

## Routing/SMTP details (learned in verification)

- Alerts carry `alert_source=log` and the route matches it → the receiver gets **only** log alerts (the OnNamespace strategy already injects a `namespace=monitoring` matcher, which the built-in metric alerts also satisfy — so the extra label scopes it).
- email `hello=alertmanager.ipsupport.us` (a real FQDN) — Stalwart rejects the pod hostname with `550 Invalid EHLO domain`.
- `requireTLS=false` for the in-cluster hop to the local recipient.

## Verified e2e

panic log line → Vector → VictoriaLogs → vmalert fires `critical-log-pattern` → Alertmanager → Stalwart → **delivered** to roman220@ipsupport.us (`Delivery completed, from alerts@ipsupport.us, to roman220@ipsupport.us`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)