### PR TITLE
logging: alert_rules caller-supplied + merged with a generic baseline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mailbox to also deploy **vmalert** evaluating LogsQL alert rules against
   VictoriaLogs → the existing Alertmanager → an `AlertmanagerConfig` email
   receiver, delivering through the in-cluster Stalwart SMTP (local mailbox, no
-  relay-trust change or credentials). Ships two tunable starter rules
-  (critical-pattern + error-burst). Empty = no alerting (store + collector
-  only). Verified e2e end to delivered email.
+  relay-trust change or credentials). Alert rules are config: the root wires a
+  generic baseline (panic/fatal/OOM) merged with the operator's
+  `services.logging.alert_rules` (each a LogsQL `stats count() | filter`
+  query + threshold) — so the operator config lists only app-specific
+  additions. Empty `alert_email` = no alerting (store + collector only).
+  Verified e2e end to delivered email.
 - **`redirect_hosts:` — per-host 301 redirects on a domain.** A domain
   yaml can now carry `redirect_hosts: { <prefix>: <target-fqdn> }`
   alongside (or instead of) the zone-wide `redirect_to:`. Each entry

--- a/config/platform.yaml.example
+++ b/config/platform.yaml.example
@@ -183,6 +183,12 @@ services:
     # alert_email: ""              # set a LOCAL mailbox to wire vmalert LogsQL
     #                              # alerts → Alertmanager → email (empty = no
     #                              # alerting, store + collector only)
+    # alert_rules:                 # app-specific rules, MERGED on top of the
+    #   my-rule:                   # generic default set (panic/fatal/OOM). The
+    #     query: '_time:5m kubernetes.pod_namespace:"phost-x" "some error" | stats count() as n | filter n:>3'
+    #     for: 1m                  # window lives in the query's _time:; the
+    #     severity: warning        # threshold in | filter. Scope to a namespace
+    #     summary: "{{ $value }} hits in 5m"   # to avoid alerting on dev/test.
 
   # Longhorn — distributed block storage. Provides a `longhorn`
   # StorageClass that PVCs can use instead of the per-node

--- a/locals.tf
+++ b/locals.tf
@@ -75,6 +75,10 @@ locals {
         # (e.g. an @ipsupport.us address Stalwart delivers without auth) to
         # wire vmalert LogsQL alerts → Alertmanager → email.
         alert_email = ""
+        # Operator-defined alert rules, MERGED on top of the generic default
+        # set (`local._default_alert_rules`) by logging.tf — so the yaml only
+        # lists ADDITIONS (e.g. app-specific substrings), not the defaults.
+        alert_rules = {}
       }
       # Optional Cloudflare DNS-01 ACME solver — adds a second solver to
       # the Let's Encrypt ClusterIssuers gated by `dns_zones`. HTTP-01

--- a/logging.tf
+++ b/logging.tf
@@ -1,3 +1,17 @@
+locals {
+  # Generic, app-agnostic alert rules every cluster wants. Operators ADD
+  # app-specific rules via `services.logging.alert_rules` (merged on top), so
+  # the operator config only lists additions — not this baseline. The window
+  # lives in the query's `_time:` filter, the threshold in `| filter`.
+  _default_alert_rules = {
+    critical-log-pattern = {
+      query   = "_time:10m (panic OR fatal OR segfault OR \"OOMKilled\" OR \"out of memory\") | stats count() as hits | filter hits:>0"
+      for     = "1m"
+      summary = "{{ $value }} critical log line(s) (panic/fatal/OOM) cluster-wide in 10m"
+    }
+  }
+}
+
 # Cluster log aggregation — VictoriaLogs (store/query) + Vector (collector) +
 # a Grafana datasource. Lands in the `monitoring` namespace next to the
 # kube-prometheus-stack so the Grafana datasource sidecar discovers the
@@ -21,4 +35,7 @@ module "logging" {
   # vmalert / Alertmanager receiver. Set it to wire LogsQL rule alerts to email
   # via the existing Alertmanager + the in-cluster Stalwart SMTP (local mailbox).
   alert_email = local.platform.services.logging.alert_email
+
+  # Generic baseline rules + the operator's app-specific additions.
+  alert_rules = merge(local._default_alert_rules, local.platform.services.logging.alert_rules)
 }

--- a/modules/logging/CHANGELOG.md
+++ b/modules/logging/CHANGELOG.md
@@ -15,6 +15,11 @@ the project itself follows [Semantic Versioning](https://semver.org/).
   kube-prometheus-stack Alertmanager. An `AlertmanagerConfig` adds an email
   receiver routed to the operator's mailbox through the in-cluster Stalwart
   SMTP listener (local delivery — no relay-trust change or credentials).
+  `alert_rules` is caller-supplied (default empty); the root wires a generic
+  baseline (panic/fatal/OOM) merged with the operator's app-specific rules, so
+  operator config lists only additions. Each rule's LogsQL ends in
+  `stats count() as <name> | filter <name>:>N` (window in `_time:`, threshold
+  in `filter`).
   Notes: alerts carry an `alert_source=log` label and the route matches it, so
   the receiver gets ONLY log alerts (not the built-in metric alerts that also
   carry `namespace=monitoring`); the email `hello` (EHLO) is a real FQDN

--- a/modules/logging/variables.tf
+++ b/modules/logging/variables.tf
@@ -123,24 +123,12 @@ variable "alertmanager_url" {
 }
 
 variable "alert_rules" {
-  description = "Log alert rules, each a small object the module renders into a vmalert `type: vlogs` rule group. `query` is LogsQL returning a single count via `stats count() as <name>` (the module thresholds with `| filter`); `for` is the sustain duration; `summary` is the notification text. Defaults ship two starter templates (critical-pattern + error burst) the operator can tune/extend."
+  description = "Log alert rules the module renders into a vmalert `type: vlogs` rule group. Each: `query` is a LogsQL stats query ending in `stats count() as <name> | filter <name>:>N` (the time window lives in the query's `_time:` filter, the threshold in `| filter`); `for` is the sustain duration; `summary` is the notification text. The caller supplies these — the root wires a generic default set (panic/fatal/OOM) merged with the operator's `services.logging.alert_rules`."
   type = map(object({
     query    = string
     for      = optional(string, "5m")
     severity = optional(string, "warning")
     summary  = string
   }))
-  default = {
-    critical-log-pattern = {
-      query   = "_time:10m (panic OR fatal OR segfault OR \"OOMKilled\" OR \"out of memory\") | stats count() as hits | filter hits:>0"
-      for     = "1m"
-      summary = "{{ $value }} critical log line(s) (panic/fatal/OOM) in the last 10m"
-    }
-    error-burst = {
-      query    = "_time:5m error | stats count() as errors | filter errors:>500"
-      for      = "5m"
-      severity = "warning"
-      summary  = "Cluster-wide error-log burst: {{ $value }} 'error' lines in 5m (tune the >500 threshold)"
-    }
-  }
+  default = {}
 }


### PR DESCRIPTION
## What

The logging module no longer hardcodes starter alert rules (`var.alert_rules` defaults to `{}`). The root wires a generic baseline (`critical-log-pattern` — panic/fatal/OOM) and merges the operator's `services.logging.alert_rules` on top, so the gitignored operator config lists only **app-specific additions**, not the baseline — and no tenant namespaces leak into the module.

## Why

Lets per-app log alerts (e.g. sipmesh's SIP/RTP failure substrings) live in the operator config while the engine stays generic. The live operator config now carries the sipmesh rule set from their handoff (verbatim engine substrings, prod-scoped, no blanket error rule per the engine team).

## Verified

All 7 live rules (1 baseline + 6 sipmesh) load `health=ok` in vmalert against VictoriaLogs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)