### PR TITLE
monitoring: config-driven Prometheus rules + metric-alert email routing

### DIFF
--- a/alertmanager_metric_email.tf
+++ b/alertmanager_metric_email.tf
@@ -1,0 +1,57 @@
+# Email routing for metric alerts (label `alert_source=metric`).
+#
+# kube-prometheus-stack's Alertmanager selects AlertmanagerConfigs cluster-wide
+# but its default `OnNamespace` matcher strategy injects a `namespace=<config's
+# own namespace>` matcher into each. Metric alerts carry the namespace of the
+# series they fire on (e.g. an engine in a project namespace), NOT `monitoring`
+# — so the log-alert AlertmanagerConfig (in the logging namespace) can't catch
+# them. This emits one AlertmanagerConfig per namespace the operator lists, each
+# routing that namespace's `alert_source=metric` alerts to email.
+#
+# Everything operator/tenant-specific (recipient, From, EHLO, the namespace
+# list) comes from the gitignored config under `monitoring.metric_alert_email`
+# — tracked TF stays generic. smarthost defaults to the in-cluster Stalwart
+# inbound listener (unauthenticated LOCAL delivery), same path the log alerts
+# already use. Absent config (no address or no namespaces) => no resources.
+locals {
+  _metric_alert     = try(local.platform.monitoring.metric_alert_email, {})
+  _metric_alert_nss = try(local._metric_alert.namespaces, [])
+  _metric_alert_to  = try(local._metric_alert.address, "")
+  _metric_alert_on  = local._metric_alert_to != "" && length(local._metric_alert_nss) > 0
+}
+
+resource "kubectl_manifest" "metric_alert_email" {
+  for_each   = local._metric_alert_on ? toset(local._metric_alert_nss) : toset([])
+  depends_on = [module.addons]
+
+  yaml_body = yamlencode({
+    apiVersion = "monitoring.coreos.com/v1alpha1"
+    kind       = "AlertmanagerConfig"
+    metadata = {
+      name      = "metric-alerts-email"
+      namespace = each.value
+      labels    = { "app.kubernetes.io/managed-by" = "terraform" }
+    }
+    spec = {
+      route = {
+        receiver       = "email"
+        groupBy        = ["alertname", "namespace"]
+        groupWait      = "30s"
+        groupInterval  = "5m"
+        repeatInterval = "3h"
+        matchers       = [{ name = "alert_source", value = "metric", matchType = "=" }]
+      }
+      receivers = [{
+        name = "email"
+        emailConfigs = [{
+          to           = local._metric_alert_to
+          from         = try(local._metric_alert.from, "alerts@example.com")
+          hello        = try(local._metric_alert.hello, "alertmanager.example.com")
+          smarthost    = try(local._metric_alert.smarthost, "stalwart-smtp.mail.svc.cluster.local:25")
+          requireTLS   = false
+          sendResolved = true
+        }]
+      }]
+    }
+  })
+}

--- a/locals.tf
+++ b/locals.tf
@@ -306,8 +306,11 @@ locals {
       }
     }
   }
-  _platform_file     = "${path.module}/config/platform.yaml"
-  _platform_raw      = fileexists(local._platform_file) ? yamldecode(file(local._platform_file)) : {}
+  _platform_file = "${path.module}/config/platform.yaml"
+  # Decode the YAML string (file content, or "{}" when absent) — conditioning on
+  # the string keeps the ternary's branch types consistent regardless of which
+  # top-level keys the config declares, while still surfacing invalid-YAML errors.
+  _platform_raw      = yamldecode(fileexists(local._platform_file) ? file(local._platform_file) : "{}")
   _platform_services = try(local._platform_raw.services, {})
   platform = {
     services = {
@@ -336,6 +339,10 @@ locals {
       security_scan    = merge(local._platform_defaults.services.security_scan, try(local._platform_services.security_scan, {}))
       traefik_public   = merge(local._platform_defaults.services.traefik_public, try(local._platform_services.traefik_public, {}))
     }
+    # Operator-supplied monitoring extras (gitignored config). Generic engine
+    # in prometheus_rules.tf renders whatever is under `monitoring.prometheus_rules`
+    # into a PrometheusRule — app/tenant-specific exprs stay out of tracked TF.
+    monitoring = try(local._platform_raw.monitoring, {})
   }
 
   # Load raw domain configs from YAML files

--- a/prometheus_rules.tf
+++ b/prometheus_rules.tf
@@ -1,0 +1,50 @@
+# Operator-defined Prometheus alert rules.
+#
+# kube-prometheus-stack (module.addons) owns Prometheus + Alertmanager. Its
+# Prometheus CR selects PrometheusRules by the label `release:
+# kube-prometheus-stack`, cluster-wide. This renders ONE PrometheusRule from
+# the operator's gitignored config so app/tenant-specific PromQL never lands in
+# tracked TF (same split as `services.logging.alert_rules` for log alerts).
+#
+# Config shape (config/platform.yaml, gitignored):
+#   monitoring:
+#     prometheus_rules:
+#       <group-name>:
+#         - alert: <Name>
+#           expr: <PromQL>
+#           for: 2m                 # optional
+#           labels: { severity: critical }      # optional
+#           annotations: { summary: "...", description: "..." }  # optional
+#
+# Empty/absent config => no resource (count 0), so this is a no-op for any
+# cluster that doesn't declare rules. Lands in the `monitoring` namespace so it
+# matches the Prometheus rule selector regardless of its namespaceSelector.
+locals {
+  _prometheus_rule_groups = try(local.platform.monitoring.prometheus_rules, {})
+}
+
+resource "kubectl_manifest" "operator_prometheus_rules" {
+  count      = length(local._prometheus_rule_groups) > 0 ? 1 : 0
+  depends_on = [module.addons]
+
+  yaml_body = yamlencode({
+    apiVersion = "monitoring.coreos.com/v1"
+    kind       = "PrometheusRule"
+    metadata = {
+      name      = "platform-operator-rules"
+      namespace = "monitoring"
+      labels = {
+        release                        = "kube-prometheus-stack"
+        "app.kubernetes.io/managed-by" = "terraform"
+      }
+    }
+    spec = {
+      groups = [
+        for name, rules in local._prometheus_rule_groups : {
+          name  = name
+          rules = rules
+        }
+      ]
+    }
+  })
+}


### PR DESCRIPTION
Two generic, config-driven monitoring mechanisms (operator's app/tenant-specific values stay in gitignored `config/platform.yaml` under `monitoring.*`; tracked TF is generic):

- **`prometheus_rules.tf`** — renders operator-defined alert rule groups into a single `PrometheusRule` (label `release=kube-prometheus-stack` so the stack's Prometheus selects it). Empty/absent config ⇒ no resource.
- **`alertmanager_metric_email.tf`** — emits a per-namespace `AlertmanagerConfig` routing `alert_source=metric` alerts to email. The Alertmanager `OnNamespace` matcher strategy scopes each config to its own namespace, and metric alerts carry the namespace of the series they fire on (not the monitoring ns), so one config per originating namespace is required. Reuses the same in-cluster Stalwart submission path as the existing log-alert routing.
- **`locals.tf`** — decode `_platform_raw` by conditioning on the file string (`file() : "{}"`) instead of the decoded object, so adding a new top-level config key (here `monitoring`) doesn't break the ternary's branch-type-consistency check, while invalid-YAML errors still surface.

Verified on the live cluster: the rendered PrometheusRule loads (3 rules, `health=ok`), and the AlertmanagerConfig merges into the generated Alertmanager config with the expected `alert_source=metric` + namespace matchers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)