### PR TITLE
fix(stalwart): wait for Zitadel issuer before starting on reboot

### DIFF
--- a/modules/stalwart/CHANGELOG.md
+++ b/modules/stalwart/CHANGELOG.md
@@ -8,6 +8,17 @@ the project itself follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **`wait-zitadel` init container — survive node reboots without a
+  manual restart.** When OIDC is enabled, an init container now blocks
+  the main Stalwart container until the configured `zitadel_issuer_url`
+  discovery endpoint (`/.well-known/openid-configuration`) is reachable.
+  On a node reboot Stalwart otherwise comes up before Zitadel
+  (`id.<domain>`) is back, fails to fetch OIDC keys, then rejects every
+  token and serves no TLS until someone restarts it. The wait is bounded
+  (~5m, 100 × 3s) and then starts anyway, so a genuinely-down Zitadel
+  never blocks SMTP mail delivery — it only falls back to the prior
+  start-anyway behaviour. Gated on `local.oidc_enabled` (no-op when OIDC
+  is off).
 - **`ingest_forwards` entries take a LIST of `addresses`.** One forward
   now fans several tagged mailbox addresses into the SAME listener via a
   single Sieve `anyof(envelope :is "to" ...)` rule — e.g. `mail@` (bounce

--- a/modules/stalwart/main.tf
+++ b/modules/stalwart/main.tf
@@ -1135,6 +1135,11 @@ resource "kubernetes_deployment_v1" "stalwart" {
         #    overwrite — small file, only datastore stanza), patches the
         #    upstream WebUI bundle with our Zitadel client_id and places
         #    the result on /shared, downloads stalwart-cli onto /shared.
+        # 2) wait-zitadel (OIDC only): block the main container until the
+        #    configured issuer is reachable, so a node reboot can't start
+        #    Stalwart before Zitadel is back and leave it rejecting every
+        #    OIDC token + serving no TLS until manually restarted. Bounded
+        #    wait then starts anyway, so a down Zitadel never blocks SMTP.
         init_container {
           name  = "bootstrap"
           image = "alpine:3.22"
@@ -1228,6 +1233,47 @@ resource "kubernetes_deployment_v1" "stalwart" {
           volume_mount {
             name       = "seed"
             mount_path = "/seed"
+          }
+        }
+
+        # Gated on OIDC: only meaningful when Stalwart validates Zitadel
+        # tokens. alpine image matches the bootstrap init above (already
+        # pulled); `apk add curl` brings ca-certificates for the HTTPS
+        # issuer probe. Bounded ~5m (100 × 3s) then exits 0 regardless.
+        dynamic "init_container" {
+          for_each = local.oidc_set
+          content {
+            name  = "wait-zitadel"
+            image = "alpine:3.22"
+
+            security_context {
+              run_as_user = 0
+            }
+
+            resources {
+              requests = { cpu = "10m", memory = "16Mi" }
+              limits   = { cpu = "100m", memory = "64Mi" }
+            }
+
+            env {
+              name  = "ZITADEL_ISSUER"
+              value = var.zitadel_issuer_url
+            }
+
+            command = ["sh", "-eu", "-c", <<-EOT
+              apk add --no-cache curl >/dev/null
+              URL="$ZITADEL_ISSUER/.well-known/openid-configuration"
+              echo "[wait-zitadel] waiting up to ~5m for $URL"
+              for i in $(seq 1 100); do
+                if curl -sf -m 5 -o /dev/null "$URL"; then
+                  echo "[wait-zitadel] Zitadel OIDC reachable — starting Stalwart"
+                  exit 0
+                fi
+                sleep 3
+              done
+              echo "[wait-zitadel] still unreachable after ~5m — starting Stalwart anyway"
+            EOT
+            ]
           }
         }
 


### PR DESCRIPTION
## Problem

After a node reboot, Stalwart comes up **before** the Zitadel IdP
(`id.<domain>`) is reachable again — the same startup-order race that
crash-loops `forward-auth`. Stalwart then can't fetch the OIDC keys, so:

- IMAPS auth fails with `Failed to decode token` (webmail clients can't
  log in),
- TLS listeners come up with `No TLS certificates available`.

Stalwart does **not** self-heal — it needs a manual
`kubectl -n mail rollout restart deploy/stalwart` every reboot. Mail
*delivery* (SMTP) keeps working; only login is affected.

## Fix

Add an OIDC-gated `wait-zitadel` init container that blocks the main
container until the configured `zitadel_issuer_url` discovery endpoint
(`/.well-known/openid-configuration`) returns 200 — so Stalwart only
starts once its own OIDC fetch is guaranteed to succeed.

**Bounded by design:** waits ~5m (100 × 3s) then starts anyway. A
genuinely-down IdP therefore never blocks Stalwart boot / SMTP delivery
— it just falls back to today's start-anyway behaviour (and the manual
restart remains the fallback). Gated on `local.oidc_enabled`, so it is a
no-op when OIDC is disabled.

Mirrors the existing wait-loop pattern in `modules/vault`. Image is
`alpine:3.22` (already pulled by the bootstrap init above); `apk add
curl` brings `ca-certificates` for the HTTPS probe.

## Verification

- `terraform fmt` — no diff
- `terraform validate` — Success

🤖 Generated with [Claude Code](https://claude.com/claude-code)