### PR TITLE
feat(stalwart): skip spam filter for trusted in-cluster CIDRs

### DIFF
--- a/mail.tf
+++ b/mail.tf
@@ -134,6 +134,11 @@ module "stalwart" {
   spf_authorized_ip = try(local.mail.spf_authorized_ip, "")
   dmarc_policy      = try(local.mail.dmarc_policy, "quarantine")
 
+  # CIDRs whose inbound :25 traffic skips the spam filter (in-cluster
+  # senders like Alertmanager fail public SPF from a pod IP). From the
+  # primary domain's `mail.trusted_networks` yaml; empty = stock filter.
+  internal_trusted_cidrs = try(local.mail.trusted_networks, [])
+
   # SMTP inbound forwarder bind IP — typically the WireGuard interface
   # address on the home node so the public relay's outbound tunnel can
   # reach it without exposing :25 on the LAN.

--- a/modules/stalwart/CHANGELOG.md
+++ b/modules/stalwart/CHANGELOG.md
@@ -8,6 +8,16 @@ the project itself follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **`internal_trusted_cidrs` — skip the spam filter for trusted
+  in-cluster senders.** New list variable (default `[]`, a no-op). When
+  set, the DATA-stage `enableSpamFilter` expression keeps Stalwart's
+  stock default (`is_empty(authenticated_as)`) and ANDs in a
+  `!is_ip_in_cidr(remote_ip, <cidr>)` exclusion per range. Internal
+  mail delivered straight to `:25` (e.g. Alertmanager → mail) comes
+  from a pod IP, fails public SPF/DMARC, and was being spam-scored to
+  Junk; trusting the cluster CIDR lets it land in the inbox. Emitted as
+  a separate `MtaStageData` PATCH so it coexists with the ingest-forward
+  `script` binding.
 - **`wait-zitadel` init container — survive node reboots without a
   manual restart.** When OIDC is enabled, an init container now blocks
   the main Stalwart container until the configured `zitadel_issuer_url`

--- a/modules/stalwart/main.tf
+++ b/modules/stalwart/main.tf
@@ -465,6 +465,26 @@ locals {
       }),
     ] : [],
 
+    # Trust in-cluster senders: exclude operator-listed CIDRs from the
+    # DATA-stage spam filter. Mail delivered straight to :25 from a pod
+    # (e.g. Alertmanager) fails public SPF/DMARC and would otherwise be
+    # scored as spam and filed to Junk. JMAP `update` is a per-property
+    # PATCH, so this coexists with the `script` update above. Keeps the
+    # stock default (`is_empty(authenticated_as)` = filter unauthenticated
+    # sessions) and ANDs in a `!is_ip_in_cidr` exclusion per trusted range.
+    length(var.internal_trusted_cidrs) > 0 ? [
+      jsonencode({
+        "@type" = "update"
+        object  = "MtaStageData"
+        value = {
+          enableSpamFilter = {
+            match = {}
+            else  = "is_empty(authenticated_as)${join("", [for c in var.internal_trusted_cidrs : " && !is_ip_in_cidr(remote_ip, '${c}')"])}"
+          }
+        }
+      }),
+    ] : [],
+
     # Single combined outbound routing strategy. Keeps the upstream
     # `is_local_domain → 'local'` branch, pins each synthetic ingest
     # domain to its route, and falls back to the smart host (or plain

--- a/modules/stalwart/variables.tf
+++ b/modules/stalwart/variables.tf
@@ -158,6 +158,12 @@ variable "dmarc_policy" {
   default     = "quarantine"
 }
 
+variable "internal_trusted_cidrs" {
+  description = "CIDR ranges whose inbound SMTP connections are trusted and bypass the DATA-stage spam filter. Intended for in-cluster senders that deliver straight to Stalwart's :25 (e.g. Alertmanager → mail) — their mail comes from a pod IP, fails public SPF/DMARC, and would otherwise be scored as spam and filed to Junk. Empty list (default) leaves Stalwart's stock `enableSpamFilter` (filter every unauthenticated session) untouched, so this is a no-op unless an operator opts in."
+  type        = list(string)
+  default     = []
+}
+
 variable "dkim_selector" {
   description = "DKIM selector — the DNS label `<selector>._domainkey.<domain>` where the public key is published. Stable; rotating means generating a new key under a new selector and dual-signing through the cutover."
   type        = string


### PR DESCRIPTION
## Problem

Internal monitoring mail (Alertmanager → Stalwart `:25`, delivered
in-cluster) lands in **Junk**. It's sent as a domain-local From but
originates from a **pod IP**, so Stalwart's stock spam filter scores it:

- `VIOLATED_DIRECT_SPF` + `SPF_FAIL` (pod IP not in the public SPF) — the
  bulk of the score,
- `DMARC_NA`, `HELO_IPREV_MISMATCH`, `MIME_MA_MISSING_TEXT` …

→ total well over the spam threshold. The alert still arrives, but in the
Junk folder where it's easily missed.

## Fix

New module variable **`internal_trusted_cidrs`** (`list(string)`, default
`[]` → no-op). When set, the DATA-stage `enableSpamFilter` expression
keeps Stalwart's stock default and ANDs in a per-range exclusion:

```
is_empty(authenticated_as) && !is_ip_in_cidr(remote_ip, '<cidr>')
```

so connections from trusted in-cluster ranges bypass the spam filter
entirely (no `X-Spam-Status`, no Junk). This is the maintainer's
recommended approach for "Stalwart behind a trusted upstream" (disable
the filter for the trusted source rather than fight SPF).

Emitted as a **separate `MtaStageData` update** — JMAP `/set update` is a
per-property PATCH, so it coexists with the existing ingest-forward
`script` binding on the same singleton.

Wiring: `mail.tf` passes `internal_trusted_cidrs` from the primary
domain's `mail.trusted_networks` (gitignored operator config), so tracked
TF stays generic — the variable is empty/no-op for any deployment that
doesn't opt in.

## Verification

- `terraform fmt` — no diff
- `terraform validate` — Success

🤖 Generated with [Claude Code](https://claude.com/claude-code)