### PR TITLE
fix(stalwart): use matches() not is_ip_in_cidr for spam-trust (0.16.3)

### DIFF
--- a/mail.tf
+++ b/mail.tf
@@ -134,10 +134,11 @@ module "stalwart" {
   spf_authorized_ip = try(local.mail.spf_authorized_ip, "")
   dmarc_policy      = try(local.mail.dmarc_policy, "quarantine")
 
-  # CIDRs whose inbound :25 traffic skips the spam filter (in-cluster
-  # senders like Alertmanager fail public SPF from a pod IP). From the
-  # primary domain's `mail.trusted_networks` yaml; empty = stock filter.
-  internal_trusted_cidrs = try(local.mail.trusted_networks, [])
+  # remote_ip regex patterns whose inbound :25 traffic skips the spam
+  # filter (in-cluster senders like Alertmanager fail public SPF from a
+  # pod IP). From the primary domain's `mail.trusted_ip_patterns` yaml;
+  # empty = stock filter.
+  internal_trusted_ip_patterns = try(local.mail.trusted_ip_patterns, [])
 
   # SMTP inbound forwarder bind IP — typically the WireGuard interface
   # address on the home node so the public relay's outbound tunnel can

--- a/modules/stalwart/CHANGELOG.md
+++ b/modules/stalwart/CHANGELOG.md
@@ -8,16 +8,17 @@ the project itself follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
-- **`internal_trusted_cidrs` — skip the spam filter for trusted
+- **`internal_trusted_ip_patterns` — skip the spam filter for trusted
   in-cluster senders.** New list variable (default `[]`, a no-op). When
   set, the DATA-stage `enableSpamFilter` expression keeps Stalwart's
   stock default (`is_empty(authenticated_as)`) and ANDs in a
-  `!is_ip_in_cidr(remote_ip, <cidr>)` exclusion per range. Internal
-  mail delivered straight to `:25` (e.g. Alertmanager → mail) comes
-  from a pod IP, fails public SPF/DMARC, and was being spam-scored to
-  Junk; trusting the cluster CIDR lets it land in the inbox. Emitted as
-  a separate `MtaStageData` PATCH so it coexists with the ingest-forward
-  `script` binding.
+  `!matches(remote_ip, <regex>)` exclusion per pattern. Internal mail
+  delivered straight to `:25` (e.g. Alertmanager → mail) comes from a
+  pod IP, fails public SPF/DMARC, and was being spam-scored to Junk;
+  trusting the cluster IP range lets it land in the inbox. Regex (not
+  CIDR) because Stalwart 0.16.x has no CIDR expression function. Emitted
+  as a separate `MtaStageData` PATCH so it coexists with the
+  ingest-forward `script` binding.
 - **`wait-zitadel` init container — survive node reboots without a
   manual restart.** When OIDC is enabled, an init container now blocks
   the main Stalwart container until the configured `zitadel_issuer_url`

--- a/modules/stalwart/main.tf
+++ b/modules/stalwart/main.tf
@@ -465,21 +465,23 @@ locals {
       }),
     ] : [],
 
-    # Trust in-cluster senders: exclude operator-listed CIDRs from the
-    # DATA-stage spam filter. Mail delivered straight to :25 from a pod
-    # (e.g. Alertmanager) fails public SPF/DMARC and would otherwise be
-    # scored as spam and filed to Junk. JMAP `update` is a per-property
-    # PATCH, so this coexists with the `script` update above. Keeps the
-    # stock default (`is_empty(authenticated_as)` = filter unauthenticated
-    # sessions) and ANDs in a `!is_ip_in_cidr` exclusion per trusted range.
-    length(var.internal_trusted_cidrs) > 0 ? [
+    # Trust in-cluster senders: exclude IPs matching operator-listed regex
+    # patterns from the DATA-stage spam filter. Mail delivered straight to
+    # :25 from a pod (e.g. Alertmanager) fails public SPF/DMARC and would
+    # otherwise be scored as spam and filed to Junk. `matches(remote_ip, …)`
+    # rather than a CIDR builtin — Stalwart 0.16.x has no CIDR expression
+    # function (`is_ip_in_cidr` only landed post-0.16.3). JMAP `update` is a
+    # per-property PATCH, so this coexists with the `script` update above.
+    # Keeps the stock default (`is_empty(authenticated_as)` = filter
+    # unauthenticated sessions) and ANDs in a `!matches` exclusion per pattern.
+    length(var.internal_trusted_ip_patterns) > 0 ? [
       jsonencode({
         "@type" = "update"
         object  = "MtaStageData"
         value = {
           enableSpamFilter = {
             match = {}
-            else  = "is_empty(authenticated_as)${join("", [for c in var.internal_trusted_cidrs : " && !is_ip_in_cidr(remote_ip, '${c}')"])}"
+            else  = "is_empty(authenticated_as)${join("", [for p in var.internal_trusted_ip_patterns : " && !matches(remote_ip, '${p}')"])}"
           }
         }
       }),

--- a/modules/stalwart/variables.tf
+++ b/modules/stalwart/variables.tf
@@ -158,8 +158,8 @@ variable "dmarc_policy" {
   default     = "quarantine"
 }
 
-variable "internal_trusted_cidrs" {
-  description = "CIDR ranges whose inbound SMTP connections are trusted and bypass the DATA-stage spam filter. Intended for in-cluster senders that deliver straight to Stalwart's :25 (e.g. Alertmanager → mail) — their mail comes from a pod IP, fails public SPF/DMARC, and would otherwise be scored as spam and filed to Junk. Empty list (default) leaves Stalwart's stock `enableSpamFilter` (filter every unauthenticated session) untouched, so this is a no-op unless an operator opts in."
+variable "internal_trusted_ip_patterns" {
+  description = "Regex patterns matched against the connecting IP (`remote_ip`); matching inbound SMTP connections are trusted and bypass the DATA-stage spam filter. Intended for in-cluster senders that deliver straight to Stalwart's :25 (e.g. Alertmanager → mail) — their mail comes from a pod IP, fails public SPF/DMARC, and would otherwise be scored as spam and filed to Junk. Regex (not CIDR) because Stalwart 0.16.x has no CIDR expression function; e.g. `^100\\.(6[4-9]|7[0-9])\\.` matches the k3s 100.64.0.0/12 range. Empty list (default) leaves Stalwart's stock `enableSpamFilter` (filter every unauthenticated session) untouched, so this is a no-op unless an operator opts in."
   type        = list(string)
   default     = []
 }


### PR DESCRIPTION
## Problem

PR for `internal_trusted_cidrs` used `is_ip_in_cidr(remote_ip, <cidr>)` in
the DATA-stage `enableSpamFilter` expression. That builtin only landed
**after** Stalwart 0.16.3 (the deployed version), so the applier rejected
it:

```
✗ update MtaStageData: enableSpamFilter: invalid value
  "Error parsing 'else' expression: Invalid variable or constant "is_ip_in_cidr""
```

`--continue-on-error` kept the server up, but the spam-trust never took
effect.

## Fix

Rename `internal_trusted_cidrs` → **`internal_trusted_ip_patterns`** and
build the exclusion from **`!matches(remote_ip, <regex>)`** — `matches()`
is a core expression function present in 0.16.x. Operators now pass regex
patterns (e.g. `^100\.(6[4-9]|7[0-9])\.` for the k3s 100.64.0.0/12 range)
instead of CIDRs.

No-op when the list is empty (default), so tracked TF stays generic.

## Verification

- `terraform fmt` — no diff
- `terraform validate` — Success
- Live applier validation of the new expression confirmed post-merge on apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)