### PR TITLE
fix(stalwart): correct matches() argument order in spam-trust expr

### DIFF
--- a/modules/stalwart/CHANGELOG.md
+++ b/modules/stalwart/CHANGELOG.md
@@ -12,7 +12,7 @@ the project itself follows [Semantic Versioning](https://semver.org/).
   in-cluster senders.** New list variable (default `[]`, a no-op). When
   set, the DATA-stage `enableSpamFilter` expression keeps Stalwart's
   stock default (`is_empty(authenticated_as)`) and ANDs in a
-  `!matches(remote_ip, <regex>)` exclusion per pattern. Internal mail
+  `!matches(<regex>, remote_ip)` exclusion per pattern. Internal mail
   delivered straight to `:25` (e.g. Alertmanager → mail) comes from a
   pod IP, fails public SPF/DMARC, and was being spam-scored to Junk;
   trusting the cluster IP range lets it land in the inbox. Regex (not

--- a/modules/stalwart/main.tf
+++ b/modules/stalwart/main.tf
@@ -468,12 +468,13 @@ locals {
     # Trust in-cluster senders: exclude IPs matching operator-listed regex
     # patterns from the DATA-stage spam filter. Mail delivered straight to
     # :25 from a pod (e.g. Alertmanager) fails public SPF/DMARC and would
-    # otherwise be scored as spam and filed to Junk. `matches(remote_ip, …)`
-    # rather than a CIDR builtin — Stalwart 0.16.x has no CIDR expression
-    # function (`is_ip_in_cidr` only landed post-0.16.3). JMAP `update` is a
-    # per-property PATCH, so this coexists with the `script` update above.
-    # Keeps the stock default (`is_empty(authenticated_as)` = filter
-    # unauthenticated sessions) and ANDs in a `!matches` exclusion per pattern.
+    # otherwise be scored as spam and filed to Junk. `matches(regex, value)`
+    # (pattern FIRST per Stalwart's signature) rather than a CIDR builtin —
+    # 0.16.x has no CIDR expression function (`is_ip_in_cidr` only landed
+    # post-0.16.3). JMAP `update` is a per-property PATCH, so this coexists
+    # with the `script` update above. Keeps the stock default
+    # (`is_empty(authenticated_as)` = filter unauthenticated sessions) and
+    # ANDs in a `!matches` exclusion per pattern.
     length(var.internal_trusted_ip_patterns) > 0 ? [
       jsonencode({
         "@type" = "update"
@@ -481,7 +482,7 @@ locals {
         value = {
           enableSpamFilter = {
             match = {}
-            else  = "is_empty(authenticated_as)${join("", [for p in var.internal_trusted_ip_patterns : " && !matches(remote_ip, '${p}')"])}"
+            else  = "is_empty(authenticated_as)${join("", [for p in var.internal_trusted_ip_patterns : " && !matches('${p}', remote_ip)"])}"
           }
         }
       }),


### PR DESCRIPTION
Stalwart's `matches()` signature is `matches(regex, value)` — pattern first. The spam-trust `enableSpamFilter` expression passed `remote_ip` first, so the live applier rejected it (`Expected '"', found invalid character 'r'`; --continue-on-error kept the server up). Swap to `!matches('<pattern>', remote_ip)`. Verified the signature against the docs example `matches('^([^@]+)@(.+)$', rcpt)`.

`terraform validate` — Success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)