### PR TITLE
feat(monitoring): expose Alertmanager UI + pin its externalUrl

### DIFF
--- a/config/components/alertmanager.yaml
+++ b/config/components/alertmanager.yaml
@@ -1,0 +1,18 @@
+# External component — routing only, no Deployment. Points at the
+# kube-prometheus-stack chart's Alertmanager Service installed by the
+# terraform-k8s-addons module (same pattern as `grafana.yaml`).
+#
+# Alertmanager ships no built-in auth, so the `auth: zitadel` forward-auth
+# middleware gates it — never expose the UI open. Wire by adding a route to
+# your domain yaml (e.g. `alertmanager: alertmanager` in the routes map);
+# the prefix becomes `alertmanager.<domain>`. For the chart's notification
+# links (the email "View in Alertmanager" button, generator URLs) to point
+# here, also set `monitoring.alertmanager_external_url` to the matching
+# `https://alertmanager.<domain>` in `config/platform.yaml` — main.tf feeds
+# it to the addons module's `monitoring_alertmanager_extra_values`.
+kind: external
+service:
+  name: kube-prometheus-stack-alertmanager
+  namespace: monitoring
+  port: 9093
+auth: zitadel

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ check "k3s_ssh_vars_set" {
 # Layer 2: Platform add-ons (Traefik, cert-manager, monitoring, namespaces).
 # -----------------------------------------------------------------------------
 module "addons" {
-  source = "git::https://github.com/rromenskyi/terraform-k8s-addons.git?ref=v2.4.0"
+  source = "git::https://github.com/rromenskyi/terraform-k8s-addons.git?ref=v2.4.1"
 
   kubeconfig_path      = module.k8s.kubeconfig_path
   cluster_name         = module.k8s.cluster_name
@@ -152,6 +152,18 @@ module "addons" {
   # stack adds nothing to the Grafana pod. The plugin downloads at pod start.
   monitoring_grafana_extra_values = local.platform.services.logging.enabled ? {
     plugins = ["victoriametrics-logs-datasource"]
+  } : {}
+
+  # Pin Alertmanager's externalUrl (from the gitignored monitoring config)
+  # so notification links — the email "View in Alertmanager" button and
+  # generator URLs — resolve to the browser-reachable host instead of the
+  # in-cluster Service name. Requires the matching `alertmanager` route +
+  # `config/components/alertmanager.yaml`. Empty config => {} => chart
+  # default (unchanged), so this is a no-op until an operator opts in.
+  monitoring_alertmanager_extra_values = try(local.platform.monitoring.alertmanager_external_url, "") != "" ? {
+    alertmanagerSpec = {
+      externalUrl = local.platform.monitoring.alertmanager_external_url
+    }
   } : {}
 }
 


### PR DESCRIPTION
## Problem

Alertmanager notification emails carry dead links — "View in Alertmanager",
the footer, and generator/Source URLs all point at the in-cluster Service
name (`http://kube-prometheus-stack-alertmanager.monitoring:9093`), which a
browser can't resolve. Root cause: Alertmanager's `externalUrl` is the chart
default, and the UI isn't exposed.

## Change

- **Bump `terraform-k8s-addons` v2.4.0 → v2.4.1** (adds the
  `monitoring_alertmanager_extra_values` passthrough).
- **Feed `alertmanagerSpec.externalUrl`** from `monitoring.alertmanager_external_url`
  (gitignored operator config) so Alertmanager generates browser-reachable
  links. Absent config => `{}` => chart default, so this is a **no-op until
  an operator opts in**.
- **Add `config/components/alertmanager.yaml`** (`kind: external`, `auth: zitadel`)
  mirroring `grafana.yaml`/`argocd.yaml`, so a domain route (`alertmanager: alertmanager`)
  exposes the UI behind the forward-auth gate (Alertmanager has no own auth).

The route + `alertmanager_external_url` value live in gitignored config, so
tracked TF stays generic.

## Verification

- `terraform init -upgrade` pulls addons v2.4.1
- `terraform validate` — Success

🤖 Generated with [Claude Code](https://claude.com/claude-code)