### PR TITLE
feat(monitoring): make alert Source links reachable (vmalert + Prometheus)

### DIFF
--- a/config/components/prometheus.yaml
+++ b/config/components/prometheus.yaml
@@ -1,0 +1,17 @@
+# External component — routing only, no Deployment. Points at the
+# kube-prometheus-stack chart's Prometheus Service installed by the
+# terraform-k8s-addons module (same pattern as `grafana.yaml`/`alertmanager.yaml`).
+# Lets the "Source" link on a metric-alert email reach the Prometheus UI.
+#
+# Prometheus ships no built-in auth, so the `auth: zitadel` forward-auth
+# middleware gates it. Wire by adding a route to your domain yaml (e.g.
+# `prometheus: prometheus`); the prefix becomes `prometheus.<domain>`. For the
+# chart's generator links to match, also set `monitoring.prometheus_external_url`
+# to `https://prometheus.<domain>` in `config/platform.yaml` — main.tf feeds it
+# to the addons module's `monitoring_prometheus_extra_values`.
+kind: external
+service:
+  name: kube-prometheus-stack-prometheus
+  namespace: monitoring
+  port: 9090
+auth: zitadel

--- a/config/components/vmalert.yaml
+++ b/config/components/vmalert.yaml
@@ -1,0 +1,16 @@
+# External component — routing only, no Deployment. Points at the `vmalert`
+# Service emitted by `modules/logging` (the LogsQL alert evaluator). Lets the
+# "Source" link on a log-alert email reach vmalert's UI.
+#
+# vmalert ships no built-in auth, so the `auth: zitadel` forward-auth
+# middleware gates it. Wire by adding a route to your domain yaml (e.g.
+# `vmalert: vmalert`); the prefix becomes `vmalert.<domain>`. For the link
+# vmalert stamps on alerts to match, also set `monitoring.vmalert_external_url`
+# to `https://vmalert.<domain>` in `config/platform.yaml` (fed to the logging
+# module's `vmalert_external_url` => vmalert's `-external.url`).
+kind: external
+service:
+  name: vmalert
+  namespace: monitoring
+  port: 8880
+auth: zitadel

--- a/logging.tf
+++ b/logging.tf
@@ -38,4 +38,9 @@ module "logging" {
 
   # Generic baseline rules + the operator's app-specific additions.
   alert_rules = merge(local._default_alert_rules, local.platform.services.logging.alert_rules)
+
+  # Browser-reachable base for vmalert's alert Source/generator links (read
+  # from the `monitoring:` config block alongside the alertmanager/prometheus
+  # external URLs). Empty => vmalert keeps its in-cluster pod-address default.
+  vmalert_external_url = try(local.platform.monitoring.vmalert_external_url, "")
 }

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,7 @@ check "k3s_ssh_vars_set" {
 # Layer 2: Platform add-ons (Traefik, cert-manager, monitoring, namespaces).
 # -----------------------------------------------------------------------------
 module "addons" {
-  source = "git::https://github.com/rromenskyi/terraform-k8s-addons.git?ref=v2.4.1"
+  source = "git::https://github.com/rromenskyi/terraform-k8s-addons.git?ref=v2.4.2"
 
   kubeconfig_path      = module.k8s.kubeconfig_path
   cluster_name         = module.k8s.cluster_name
@@ -163,6 +163,16 @@ module "addons" {
   monitoring_alertmanager_extra_values = try(local.platform.monitoring.alertmanager_external_url, "") != "" ? {
     alertmanagerSpec = {
       externalUrl = local.platform.monitoring.alertmanager_external_url
+    }
+  } : {}
+
+  # Same treatment for Prometheus — pins prometheusSpec.externalUrl so a
+  # metric alert's "Source" link resolves to the browser-reachable host
+  # instead of the in-cluster Service. Needs the `prometheus` route +
+  # component. Empty config => {} => chart default (unchanged).
+  monitoring_prometheus_extra_values = try(local.platform.monitoring.prometheus_external_url, "") != "" ? {
+    prometheusSpec = {
+      externalUrl = local.platform.monitoring.prometheus_external_url
     }
   } : {}
 }

--- a/modules/logging/CHANGELOG.md
+++ b/modules/logging/CHANGELOG.md
@@ -8,6 +8,13 @@ the project itself follows [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 ### Added
+- **`vmalert_external_url` + a vmalert `Service`.** vmalert had no Service, so
+  the `Source`/generator links it stamps on alerts fell back to the raw pod
+  address (`vmalert-<hash>:8880`) — unreachable from a browser, the dead
+  "Source" button on alert emails. Now the module always emits
+  `kubernetes_service_v1.vmalert` (ClusterIP, port 8880) so a consumer can
+  route a hostname to the UI, and `vmalert_external_url` (default `""` = no-op)
+  sets vmalert's `-external.url` so the generated links use that host.
 - **Alerting — vmalert (LogsQL rules) → existing Alertmanager → email.** When
   `alert_email` is set, deploys a vmalert Deployment that evaluates a
   `type: vlogs` rule group (from `alert_rules`, two starter templates:

--- a/modules/logging/main.tf
+++ b/modules/logging/main.tf
@@ -430,6 +430,29 @@ resource "kubernetes_config_map_v1" "vmalert_rules" {
   }
 }
 
+# vmalert had no Service — its alert Source/generator links fell back to the
+# raw pod address (`vmalert-<hash>:8880`), which no browser can reach. This
+# gives the UI a stable in-cluster name so a consumer can route a hostname to
+# it (pair with `vmalert_external_url` so the generated links match).
+resource "kubernetes_service_v1" "vmalert" {
+  for_each = local.alerting
+
+  metadata {
+    name      = local.vmalert_name
+    namespace = var.namespace
+    labels    = merge(local.tags, { app = local.vmalert_name })
+  }
+
+  spec {
+    selector = { app = local.vmalert_name }
+    port {
+      name        = "http"
+      port        = 8880
+      target_port = 8880
+    }
+  }
+}
+
 resource "kubernetes_deployment_v1" "vmalert" {
   for_each = local.alerting
 
@@ -461,12 +484,17 @@ resource "kubernetes_deployment_v1" "vmalert" {
           name  = local.vmalert_name
           image = var.vmalert_image
 
-          args = [
+          args = concat([
             "-rule=/etc/vmalert/log-alerts.yaml",
             "-datasource.url=http://${local.vl_name}:9428",
             "-notifier.url=${var.alertmanager_url}",
             "-evaluationInterval=1m",
-          ]
+            ], var.vmalert_external_url != "" ? [
+            # Browser-reachable base for the Source/generator links vmalert
+            # stamps on alerts (the notification "Source" button). Omitted
+            # when unset, so vmalert keeps its in-cluster pod-address default.
+            "-external.url=${var.vmalert_external_url}",
+          ] : [])
 
           port {
             name           = "http"

--- a/modules/logging/variables.tf
+++ b/modules/logging/variables.tf
@@ -122,6 +122,12 @@ variable "alertmanager_url" {
   default     = "http://kube-prometheus-stack-alertmanager.monitoring.svc.cluster.local:9093"
 }
 
+variable "vmalert_external_url" {
+  description = "Browser-reachable base URL for vmalert (e.g. https://vmalert.example.com). Passed as `-external.url` so the `Source`/generator links vmalert stamps on alerts point at this host instead of the in-cluster pod address (a notification's \"Source\" button otherwise dead-ends). Empty (default) omits the flag — vmalert falls back to its pod address, unchanged. The module always emits a `kubernetes_service_v1.vmalert` (port 8880) so a consumer can route a hostname to it; this var only fixes the link vmalert generates."
+  type        = string
+  default     = ""
+}
+
 variable "alert_rules" {
   description = "Log alert rules the module renders into a vmalert `type: vlogs` rule group. Each: `query` is a LogsQL stats query ending in `stats count() as <name> | filter <name>:>N` (the time window lives in the query's `_time:` filter, the threshold in `| filter`); `for` is the sustain duration; `summary` is the notification text. The caller supplies these — the root wires a generic default set (panic/fatal/OOM) merged with the operator's `services.logging.alert_rules`."
   type = map(object({


### PR DESCRIPTION
Follow-up to the Alertmanager exposure (#183) — fixes the third dead link, **"Source"**, which points at the alerting rule (vmalert for log alerts, Prometheus for metric alerts) via in-cluster addresses.

- **modules/logging**: vmalert had **no Service** (hence the raw-pod-address `vmalert-<hash>:8880` link) — now emits `kubernetes_service_v1.vmalert` (:8880) + `vmalert_external_url` -> vmalert `-external.url`.
- **Bump addons v2.4.1 -> v2.4.2** and pass `monitoring_prometheus_extra_values` -> `prometheusSpec.externalUrl`.
- **Add `vmalert` + `prometheus` kind:external components** (`auth: zitadel`) so domain routes expose the UIs behind the forward-auth gate.

No-op until an operator sets the routes + `monitoring.{vmalert,prometheus}_external_url` in gitignored config.

`terraform validate` — Success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)