### PR TITLE
chore(chat): bump Open WebUI v0.9.5 -> v0.9.6

### DIFF
--- a/config/components/chat.yaml
+++ b/config/components/chat.yaml
@@ -1,4 +1,4 @@
-image: ghcr.io/open-webui/open-webui:v0.9.5
+image: ghcr.io/open-webui/open-webui:v0.9.6
 port: 8080
 replicas: 1
 


### PR DESCRIPTION
Patch bump of the Open WebUI chat image to the latest release (v0.9.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)